### PR TITLE
feat: accept new OpenAI key formats

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend package for RevenuePilot."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# Ensure the repository root is on sys.path so tests can import the backend package
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)


### PR DESCRIPTION
## Summary
- replace live OpenAI validation with pattern check so new project-scoped keys are accepted
- add backend package initialiser and test configuration for reliable imports

## Testing
- `pytest` *(fails: Transcription should not be empty; Phone numbers should be redacted)*

------
https://chatgpt.com/codex/tasks/task_e_6890fe0de9dc83248a1ff854f48cc22c