### PR TITLE
Accept project-based OpenAI keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ deploy RevenuePilot, consider the following steps:
    `OPENAI_API_KEY` before starting the backend.  For example:
 
    ```bash
-   export OPENAI_API_KEY=sk-your-key-here
+   export OPENAI_API_KEY=sk-your-key-here  # project keys like sk-proj-... also work
    uvicorn backend.main:app --reload --port 8000
    ```
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -351,12 +351,13 @@ async def set_api_key(model: ApiKeyModel):
         return JSONResponse({"status": "error", "message": "Key cannot be empty"}, status_code=400)
 
     # Basic format validation: accept keys starting with ``sk-`` and at
-    # least 20 additional characters consisting of letters, numbers or
-    # hyphens.  This covers classic and project‑scoped keys without
-    # relying on the OpenAI SDK's pattern enforcement.
+    # least 20 additional non‑whitespace characters.  This intentionally
+    # permits new project‑scoped keys such as ``sk-proj-`` which may
+    # include hyphens or colons in their suffix without relying on the
+    # OpenAI SDK's pattern enforcement.
     import re
 
-    if not re.fullmatch(r"sk-[A-Za-z0-9-]{20,}", key):
+    if not re.fullmatch(r"sk-\S{20,}", key):
         return JSONResponse(
             {"status": "error", "message": "Key not in expected format"},
             status_code=400,

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -45,7 +45,7 @@ function Settings({ settings, updateSettings }) {
           type="password"
           value={apiKeyInput}
           onChange={(e) => setApiKeyInput(e.target.value)}
-          placeholder="sk-..."
+          placeholder="sk-... (e.g., sk-proj-...)"
           style={{ flexGrow: 1, padding: '0.5rem', border: '1px solid var(--disabled)', borderRadius: '4px' }}
         />
         <button onClick={handleSaveKey} style={{ marginLeft: '0.5rem' }}>Save Key</button>


### PR DESCRIPTION
## Summary
- relax API key validation to accept project-scoped keys like `sk-proj-...`
- update settings placeholder and README to mention `sk-proj-` keys

## Testing
- `pytest` *(fails: Transcription should not be empty, Phone numbers should be redacted)*

------
https://chatgpt.com/codex/tasks/task_e_689112f5d6508324a37844e1cc2c4664