### PR TITLE
Bundle backend with Electron app and document packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,20 @@ app into an Electron shell for desktop deployment.
 4. **Run the Electron shell**.  The project includes scripts to launch
    and package a desktop version:
 
-   ```bash
-   npm run electron:dev   # build the frontend and start Electron
-   npm run electron:build # generate a distributable with electron-builder
-   ```
+ ```bash
+  npm run electron:dev   # build the frontend and start Electron
+  npm run electron:build # generate a distributable with electron-builder
+  ```
 
-   Vite outputs files to `electron/dist`, which `electron/main.js`
-   loads when creating the Electron `BrowserWindow`.
+  Vite outputs files to `electron/dist`, which `electron/main.js`
+  loads when creating the Electron `BrowserWindow`.
+
+  The packaged application now bundles the FastAPI backend and a Python
+  runtime.  Ensure `backend/venv` contains all Python dependencies before
+  running `electron-builder`; this virtual environment will be shipped with
+  the app and used by `electron/main.js` to launch the backend subprocess.
+  If you prefer to ship a standalone Python build instead, place the
+  executable under `python/` so it is included in the distributable.
 
 ## Structure
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,12 @@
   "build": {
     "appId": "com.revenuepilot.app",
     "productName": "RevenuePilot",
-    "files": ["dist/**/*", "electron/**/*"],
+    "files": [
+      "dist/**/*",
+      "electron/**/*",
+      "backend/**/*",
+      "python/**/*"
+    ],
     "directories": {
       "buildResources": "assets"
     },


### PR DESCRIPTION
## Summary
- package backend and optional Python runtime with the Electron build
- spawn backend subprocess from Electron, preferring packaged virtualenv
- document backend bundling and Python requirements for packaging

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `pytest` *(fails: Transcription should not be empty; Phone numbers should be redacted)*

------
https://chatgpt.com/codex/tasks/task_e_689224c82d708324a115faac8821fb01