### PR TITLE
fix: remove python directory from build files

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
       "dist/**/*",
       "electron/**/*",
       "backend/**/*",
-      "backend/venv/**/*",
-      "python/**/*"
+      "backend/venv/**/*"
     ],
     "directories": {
       "buildResources": "assets"


### PR DESCRIPTION
## Summary
- remove `python/**/*` from build files

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689243ad5e688324a90fa73847908ca3