### PR TITLE
chore: enable mac packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "electron:dev": "npm run build && electron electron/main.js",
-    "electron:build": "npm run build && npm run fetch-icons && npm run backend:prebuild && electron-builder -wl",
+    "electron:build": "npm run build && npm run fetch-icons && npm run backend:prebuild && electron-builder -mwl",
     "fetch-icons": "node scripts/fetch-icons.js",
     "backend:prebuild": "node scripts/backend-prebuild.js"
   },


### PR DESCRIPTION
## Summary
- include macOS build target in electron:build script

## Testing
- `npm run electron:build` *(fails: Cannot find module 'dmg-license')*


------
https://chatgpt.com/codex/tasks/task_e_6892575cf6e08324adb7764b58891c45