### PR TITLE
feat: add update server and build env checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,15 +83,31 @@ app into an Electron shell for desktop deployment.
    `electron:build` downloads icon assets and bundles the backend.  Set the
    following environment variables before running it:
 
-   * `OPENAI_API_KEY` – API key consumed by the backend.
-   * `VITE_API_URL` – URL for the backend API, usually `http://localhost:8000`.
-   * `ICON_PNG_URL`, `ICON_ICO_URL`, `ICON_ICNS_URL` – URLs for 256×256 PNG,
-     Windows `.ico`, and macOS `.icns` icons.
-   * Optional `CSC_LINK` and `CSC_KEY_PASSWORD` – signing certificate for
-     Windows builds.
-   * Optional `UPDATE_SERVER_URL` – feed URL for auto‑updates.
+  * `OPENAI_API_KEY` – API key consumed by the backend.
+  * `VITE_API_URL` – URL for the backend API, usually `http://localhost:8000`.
+  * `ICON_PNG_URL`, `ICON_ICO_URL`, `ICON_ICNS_URL` – URLs for 256×256 PNG,
+    Windows `.ico`, and macOS `.icns` icons.
+  * `UPDATE_SERVER_URL` – feed URL for auto‑updates.  During development you
+    can run `npm run update-server` to host the `dist/` directory and set
+    `UPDATE_SERVER_URL=http://localhost:8080`.
+  * Optional `CSC_LINK` and `CSC_KEY_PASSWORD` – signing certificate for
+    Windows builds.
 
-   After packaging, run the output located in `dist/`:
+  The build script aborts if `UPDATE_SERVER_URL` is missing and warns when
+  signing variables are not supplied.
+
+### Update server
+
+Run a minimal HTTP server to host built artifacts for auto‑update testing:
+
+```bash
+npm run update-server
+```
+
+This serves the `dist/` directory on port 8080.  Point
+`UPDATE_SERVER_URL` at this URL when building.
+
+After packaging, run the output located in `dist/`:
 
    * **macOS** – open the generated `.dmg`/`.zip` or run `open dist/mac/RevenuePilot.app`.
    * **Windows** – execute `dist/RevenuePilot Setup.exe`.

--- a/electron/main.js
+++ b/electron/main.js
@@ -45,6 +45,8 @@ app.whenReady().then(() => {
 
   if (process.env.UPDATE_SERVER_URL) {
     autoUpdater.setFeedURL({ url: process.env.UPDATE_SERVER_URL });
+  } else {
+    console.warn('UPDATE_SERVER_URL not set; auto-updates disabled.');
   }
   autoUpdater.checkForUpdatesAndNotify();
 

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
     "build": "vite build",
     "preview": "vite preview",
     "electron:dev": "npm run build && electron electron/main.js",
-    "electron:build": "npm run build && npm run fetch-icons && npm run backend:prebuild && electron-builder -wl",
+    "electron:build": "npm run build && npm run fetch-icons && npm run backend:prebuild && node scripts/check-build-env.js && electron-builder -wl",
     "fetch-icons": "node scripts/fetch-icons.js",
-    "backend:prebuild": "node scripts/backend-prebuild.js"
+    "backend:prebuild": "node scripts/backend-prebuild.js",
+    "update-server": "node scripts/update-server.js"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/scripts/check-build-env.js
+++ b/scripts/check-build-env.js
@@ -1,0 +1,18 @@
+const required = ['UPDATE_SERVER_URL'];
+const signing = ['CSC_LINK', 'CSC_KEY_PASSWORD'];
+
+let missing = false;
+for (const name of required) {
+  if (!process.env[name]) {
+    console.error(`Missing required environment variable: ${name}`);
+    missing = true;
+  }
+}
+if (missing) {
+  process.exit(1);
+}
+for (const name of signing) {
+  if (!process.env[name]) {
+    console.warn(`Signing variable ${name} not set; build may be unsigned.`);
+  }
+}

--- a/scripts/update-server.js
+++ b/scripts/update-server.js
@@ -1,0 +1,23 @@
+const http = require('http');
+const path = require('path');
+const fs = require('fs');
+
+const port = process.env.UPDATE_SERVER_PORT || 8080;
+const baseDir = process.env.UPDATE_DIR || path.join(__dirname, '..', 'dist');
+
+const server = http.createServer((req, res) => {
+  const filePath = path.join(baseDir, req.url);
+  fs.stat(filePath, (err, stats) => {
+    if (err || !stats.isFile()) {
+      res.statusCode = 404;
+      res.end('Not found');
+      return;
+    }
+    fs.createReadStream(filePath).pipe(res);
+  });
+});
+
+server.listen(port, () => {
+  console.log(`Update server running at http://localhost:${port}`);
+  console.log(`Serving updates from ${baseDir}`);
+});


### PR DESCRIPTION
## Summary
- add env check before packaging to ensure UPDATE_SERVER_URL and warn about signing variables
- provide simple static update server and document its usage
- log when auto-update URL is missing to disable updates

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892577be4bc832497115891ce1c318b