### PR TITLE
Inject backend URL for local API

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -37,6 +37,15 @@ function createWindow() {
     ? path.join(process.resourcesPath, 'dist', 'index.html')
     : path.join(__dirname, 'dist', 'index.html');
   win.loadFile(indexPath);
+
+  // Inject the backend URL so the frontend can locate the API server.
+  // This avoids having to bake the URL at build time and allows local
+  // development against the Python backend running on port 8000.
+  win.webContents.on('dom-ready', () => {
+    win.webContents.executeJavaScript(
+      "window.__BACKEND_URL__ = 'http://localhost:8000';"
+    );
+  });
 }
 
 app.whenReady().then(() => {


### PR DESCRIPTION
## Summary
- inject `window.__BACKEND_URL__` pointing to the local backend in Electron's main process so the renderer can reach it

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68925b0845f08324a211ac8490907625