### PR TITLE
Add build environment setup script and .env template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Copy this file to .env or run `npm run setup-env`
+# and provide the required values.
+
+OPENAI_API_KEY=
+VITE_API_URL=http://localhost:8000
+ICON_PNG_URL=
+ICON_ICO_URL=
+ICON_ICNS_URL=
+UPDATE_SERVER_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ Thumbs.db
 # Environment / secrets
 .env
 .env.*
+!.env.example
 # Database & analytics artifacts
 backend/analytics.db
 analytics.db

--- a/README.md
+++ b/README.md
@@ -74,15 +74,22 @@ app into an Electron shell for desktop deployment.
    This command builds the frontend and starts Electron along with the Python
    backend so you can develop against the desktop shell.
 
-   To create installers for macOS, Windows and Linux run:
+  To create installers for macOS, Windows and Linux you first need to collect
+  build-time environment variables.  Run the setup script and follow the
+  prompts to create a `.env` file:
 
-   ```bash
-   npm run electron:build
-   ```
+  ```bash
+  npm run setup-env
+  ```
 
+  After `.env` has been written you can build the installers:
 
-   `electron:build` downloads icon assets and bundles the backend.  Set the
-   following environment variables before running it:
+  ```bash
+  npm run electron:build
+  ```
+
+  `electron:build` downloads icon assets and bundles the backend.  The `.env`
+  file is read by the build scripts and should define:
 
 
   * `OPENAI_API_KEY` – API key consumed by the backend.

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,3 +1,5 @@
+require('dotenv').config();
+
 const { app, BrowserWindow } = require('electron');
 const { autoUpdater } = require('electron-updater');
 const { spawn } = require('child_process');

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "revenuepilot-app",
       "version": "0.1.0",
       "dependencies": {
+        "dotenv": "^16.6.1",
         "electron-updater": "^6.3.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -3353,7 +3354,6 @@
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -13,13 +13,15 @@
 
     "fetch-icons": "node scripts/fetch-icons.js",
     "backend:prebuild": "node scripts/backend-prebuild.js",
-    "update-server": "node scripts/update-server.js"
+    "update-server": "node scripts/update-server.js",
+    "setup-env": "node scripts/setup-env.js"
   },
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-quill": "^2.0.0",
-    "electron-updater": "^6.3.0"
+    "electron-updater": "^6.3.0",
+    "dotenv": "^16.6.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",

--- a/scripts/check-build-env.js
+++ b/scripts/check-build-env.js
@@ -1,3 +1,5 @@
+require('dotenv').config();
+
 const required = ['UPDATE_SERVER_URL'];
 const signing = ['CSC_LINK', 'CSC_KEY_PASSWORD'];
 

--- a/scripts/fetch-icons.js
+++ b/scripts/fetch-icons.js
@@ -1,3 +1,5 @@
+require('dotenv').config();
+
 const fs = require('fs');
 const path = require('path');
 const { execFile } = require('child_process');

--- a/scripts/setup-env.js
+++ b/scripts/setup-env.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+const dotenv = require('dotenv');
+
+const envPath = path.join(__dirname, '..', '.env');
+const existing = fs.existsSync(envPath) ? dotenv.parse(fs.readFileSync(envPath)) : {};
+
+const vars = [
+  { name: 'OPENAI_API_KEY', prompt: 'OpenAI API key' },
+  { name: 'VITE_API_URL', prompt: 'Backend API URL' },
+  { name: 'ICON_PNG_URL', prompt: 'PNG icon URL' },
+  { name: 'ICON_ICO_URL', prompt: 'ICO icon URL' },
+  { name: 'ICON_ICNS_URL', prompt: 'ICNS icon URL' },
+  { name: 'UPDATE_SERVER_URL', prompt: 'Update server URL' },
+];
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+const answers = {};
+
+function ask(index) {
+  if (index === vars.length) {
+    const lines = vars.map(v => `${v.name}=${answers[v.name] || ''}`).join('\n');
+    fs.writeFileSync(envPath, lines + '\n');
+    console.log(`Wrote ${envPath}`);
+    rl.close();
+    return;
+  }
+  const v = vars[index];
+  const def = process.env[v.name] || existing[v.name] || '';
+  rl.question(`${v.prompt}${def ? ` [${def}]` : ''}: `, (input) => {
+    answers[v.name] = input || def;
+    ask(index + 1);
+  });
+}
+
+ask(0);

--- a/scripts/update-server.js
+++ b/scripts/update-server.js
@@ -1,3 +1,5 @@
+require('dotenv').config();
+
 const http = require('http');
 const path = require('path');
 const fs = require('fs');


### PR DESCRIPTION
## Summary
- add `setup-env` script and `.env.example` for build-time configuration
- load `.env` via dotenv in build scripts and electron main
- document environment setup before `npm run electron:build`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68925b11aec08324a4c1cfc2307dca38