### PR TITLE
Use local uvicorn in dev start scripts

### DIFF
--- a/start.ps1
+++ b/start.ps1
@@ -9,7 +9,8 @@ $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
 Set-Location $scriptDir
 
 Write-Host "Starting backend (FastAPI) on port 8000..."
-$backend = Start-Process uvicorn -ArgumentList 'backend.main:app --reload --port 8000' -PassThru
+$uvicornPath = Join-Path $scriptDir 'backend\venv\Scripts\uvicorn.exe'
+$backend = Start-Process $uvicornPath -ArgumentList 'backend.main:app --reload --port 8000' -PassThru
 
 try {
     Write-Host "Backend started with PID $($backend.Id)"
@@ -24,3 +25,4 @@ finally {
     Write-Host "Stopping backend..."
     Stop-Process -Id $backend.Id
 }
+

--- a/start.sh
+++ b/start.sh
@@ -12,7 +12,7 @@ cd "$DIR"
 echo "Starting backend (FastAPI) on port 8000..."
 
 # Start backend in background.  --reload enables live code reloading.
-uvicorn backend.main:app --reload --port 8000 &
+backend/venv/bin/uvicorn backend.main:app --reload --port 8000 &
 BACKEND_PID=$!
 
 # Ensure the backend is terminated when this script exits


### PR DESCRIPTION
## Summary
- Run backend using project venv's uvicorn in Unix start script
- Run backend using project venv's uvicorn in Windows start script

## Testing
- `bash install.sh`
- `which uvicorn` (no global uvicorn in PATH)
- `timeout 5 bash start.sh`
- `pytest`
- `pwsh -File install.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68925fc99b6c8324adf79196adaaaab2