### PR TITLE
feat: allow configuring backend URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@
 
 OPENAI_API_KEY=
 VITE_API_URL=http://localhost:8000
+BACKEND_URL=http://localhost:8000
 ICON_PNG_URL=
 ICON_ICO_URL=
 ICON_ICNS_URL=

--- a/README.md
+++ b/README.md
@@ -92,18 +92,23 @@ app into an Electron shell for desktop deployment.
   file is read by the build scripts and should define:
 
 
-  * `OPENAI_API_KEY` – API key consumed by the backend.
-  * `VITE_API_URL` – URL for the backend API, usually `http://localhost:8000`.
-  * `ICON_PNG_URL`, `ICON_ICO_URL`, `ICON_ICNS_URL` – URLs for 256×256 PNG,
+* `OPENAI_API_KEY` – API key consumed by the backend.
+* `VITE_API_URL` – URL for the backend API, usually `http://localhost:8000`.
+* `BACKEND_URL` – backend URL injected into the packaged Electron app.
+* `ICON_PNG_URL`, `ICON_ICO_URL`, `ICON_ICNS_URL` – URLs for 256×256 PNG,
 
     Windows `.ico`, and macOS `.icns` icons.
-  * `UPDATE_SERVER_URL` – feed URL for auto‑updates.  For production releases
+* `UPDATE_SERVER_URL` – feed URL for auto‑updates.  For production releases
     you must set this to point at your update server.  During development you
     can run `npm run update-server` to host the `dist/` directory and set
     `UPDATE_SERVER_URL=http://localhost:8080`.  Local packaging works without
     it but auto‑updates will be disabled.
-  * Optional `CSC_LINK` and `CSC_KEY_PASSWORD` – signing certificate for
+* Optional `CSC_LINK` and `CSC_KEY_PASSWORD` – signing certificate for
     Windows builds.
+
+The `BACKEND_URL` entry controls the API endpoint used by the packaged Electron
+app.  Adjust this before running `electron:build` if your backend is hosted
+somewhere other than `http://localhost:8000`.
 
   The build script warns if `UPDATE_SERVER_URL` is missing, so local builds
   may not receive updates.  It also warns when signing variables are not

--- a/electron/main.js
+++ b/electron/main.js
@@ -8,6 +8,10 @@ const path = require('path');
 const http = require('http');
 
 let backendProcess;
+const backendUrl =
+  process.env.BACKEND_URL ||
+  process.env.VITE_API_URL ||
+  'http://localhost:8000';
 
 function waitForServer(url, timeout = 10000) {
   return new Promise((resolve, reject) => {
@@ -74,11 +78,11 @@ function createWindow() {
   win.loadFile(indexPath);
 
   // Inject the backend URL so the frontend can locate the API server.
-  // This avoids having to bake the URL at build time and allows local
-  // development against the Python backend running on port 8000.
+  // The value is read from BACKEND_URL or VITE_API_URL and falls back to
+  // http://localhost:8000 for local development.
   win.webContents.on('dom-ready', () => {
     win.webContents.executeJavaScript(
-      "window.__BACKEND_URL__ = 'http://localhost:8000';"
+      `window.__BACKEND_URL__ = ${JSON.stringify(backendUrl)};`
     );
   });
 }


### PR DESCRIPTION
## Summary
- read backend URL from BACKEND_URL or VITE_API_URL
- inject backend URL into renderer so frontend can reach API server
- document BACKEND_URL in `.env.example` and README

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68925fdaee1883249b63ab62c8ccd537