### PR TITLE
Package Python backend in Electron build

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview",
     "electron:dev": "npm run build && npm run backend:prebuild && electron electron/main.js",
 
-    "electron:build": "npm run build && npm run fetch-icons && npm run backend:prebuild && node scripts/check-build-env.js && electron-builder -mwl",
+    "electron:build": "npm run build && npm run fetch-icons && npm run backend:prebuild && node -r dotenv/config scripts/check-build-env.js && node -r dotenv/config ./node_modules/.bin/electron-builder -mwl",
 
     "fetch-icons": "node scripts/fetch-icons.js",
     "backend:prebuild": "node scripts/backend-prebuild.js",
@@ -39,11 +39,12 @@
         "filter": ["**/*"]
       },
       "electron/main.js",
-      "package.json",
+      "package.json"
+    ],
+    "extraResources": [
       {
         "from": "backend",
-        "to": "backend",
-        "filter": ["**/*"]
+        "to": "backend"
       }
     ],
     "directories": {


### PR DESCRIPTION
## Summary
- ensure Python backend and virtual environment are bundled using `extraResources`
- load `.env` configuration when building Electron to expose signing and update variables

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest`
- `ICON_PNG_URL= ICON_ICO_URL= ICON_ICNS_URL= npm run electron:build` *(fails: Cannot find module 'dmg-license')*

------
https://chatgpt.com/codex/tasks/task_e_68926a8704e4832494543aa2c7947ae9