### PR TITLE
Add JWT login and enhance dashboard metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "react-dom": "^18.2.0",
     "react-quill": "^2.0.0",
     "electron-updater": "^6.3.0",
-    "dotenv": "^16.6.1"
+    "dotenv": "^16.6.1",
+    "chart.js": "^4.4.0",
+    "react-chartjs-2": "^5.2.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import Settings from './components/Settings.jsx';
 import { beautifyNote, getSuggestions, logEvent, transcribeAudio, summarizeNote } from './api.js';
 import Sidebar from './components/Sidebar.jsx';
 import Drafts from './components/Drafts.jsx';
+import Login from './components/Login.jsx';
 
 // Utility to convert HTML strings into plain text by stripping tags.  The
 // ReactQuill editor stores content as HTML; our backend accepts plain
@@ -20,6 +21,9 @@ function stripHtml(html) {
 
 // Basic skeleton component implementing the toolbar, tab system and suggestion panel.
 function App() {
+  const [token, setToken] = useState(() =>
+    typeof window !== 'undefined' ? localStorage.getItem('token') : null
+  );
   // Track which tab is active: 'draft' or 'beautified'
   const [activeTab, setActiveTab] = useState('draft');
   // Store the beautified text once generated
@@ -132,6 +136,11 @@ function App() {
         'Chief Complaint: \n\nInterval History: \n\nReview of Systems: \n\nPhysical Exam: \n\nAssessment & Plan: ',
     },
   ];
+
+  // If there is no JWT stored, show the login form instead of the main app
+  if (!token) {
+    return <Login onLoggedIn={(tok) => setToken(tok)} />;
+  }
 
   // When the user clicks the Beautify button, run a placeholder transformation.
   // In the real app this will call the LLM API to reformat the note.

--- a/src/api.js
+++ b/src/api.js
@@ -4,6 +4,35 @@
 // operations with dummy data.
 
 /**
+ * Authenticate a user and retrieve a JWT from the backend. The token is
+ * returned to the caller so it can be persisted in localStorage or other
+ * storage. Throws an error when authentication fails.
+ *
+ * @param {string} username
+ * @param {string} password
+ * @param {string} role
+ * @returns {Promise<string>} JWT access token
+ */
+export async function login(username, password, role = 'admin') {
+  const baseUrl =
+    import.meta?.env?.VITE_API_URL ||
+    window.__BACKEND_URL__ ||
+    window.location.origin;
+  const resp = await fetch(`${baseUrl}/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password, role }),
+  });
+  if (!resp.ok) {
+    const err = await resp.json().catch(() => ({}));
+    throw new Error(err.message || 'Login failed');
+  }
+  const data = await resp.json();
+  // Backend returns token under access_token
+  return data.access_token;
+}
+
+/**
  * Beautify (reformat) the clinical note.  In this stub it simply
  * capitalises the text and trims whitespace.
  * @param {string} text
@@ -157,8 +186,15 @@ export async function getMetrics() {
       total_notes: 0,
       total_beautify: 0,
       total_suggest: 0,
+      total_summary: 0,
+      total_chart_upload: 0,
+      total_audio: 0,
       avg_note_length: 0,
       avg_beautify_time: 0,
+      revenue_per_visit: 0,
+      coding_distribution: {},
+      denial_rates: {},
+      timeseries: { daily: [], weekly: [] },
     };
   }
   const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,6 +1,27 @@
 // Admin dashboard placeholder.  Displays key metrics for the pilot.
 import { useState, useEffect } from 'react';
 import { getMetrics } from '../api.js';
+import { Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend
+);
 
 function Dashboard() {
   // Initialise metrics as an empty object so that property accesses
@@ -65,6 +86,12 @@ function Dashboard() {
       current: metrics.avg_beautify_time ? metrics.avg_beautify_time.toFixed(1) : 0,
       direction: 'lower',
     },
+    {
+      title: 'Revenue per Visit',
+      baseline: 0,
+      current: metrics.revenue_per_visit ? metrics.revenue_per_visit.toFixed(2) : 0,
+      direction: 'higher',
+    },
   ];
 
   /**
@@ -94,6 +121,30 @@ function Dashboard() {
       dir: effectiveDiff > 0 ? 'up' : effectiveDiff < 0 ? 'down' : null,
       diff: Math.abs(diff),
     };
+  };
+
+  const dailyData = {
+    labels: metrics.timeseries?.daily?.map((d) => d.date) || [],
+    datasets: [
+      {
+        label: 'Events',
+        data: metrics.timeseries?.daily?.map((d) => d.count) || [],
+        borderColor: 'rgba(54, 162, 235, 1)',
+        backgroundColor: 'rgba(54, 162, 235, 0.2)',
+      },
+    ],
+  };
+
+  const weeklyData = {
+    labels: metrics.timeseries?.weekly?.map((w) => w.week) || [],
+    datasets: [
+      {
+        label: 'Events',
+        data: metrics.timeseries?.weekly?.map((w) => w.count) || [],
+        borderColor: 'rgba(255, 99, 132, 1)',
+        backgroundColor: 'rgba(255, 99, 132, 0.2)',
+      },
+    ],
   };
   return (
     <div className="dashboard">
@@ -143,19 +194,39 @@ function Dashboard() {
       {metrics.timeseries && (
         <div className="timeseries" style={{ marginTop: '1rem' }}>
           <h3>Daily Events</h3>
-          <ul>
-            {metrics.timeseries.daily?.map((d) => (
-              <li key={d.date}>{d.date}: {d.count}</li>
-            ))}
-          </ul>
-          <h3>Weekly Events</h3>
-          <ul>
-            {metrics.timeseries.weekly?.map((w) => (
-              <li key={w.week}>{w.week}: {w.count}</li>
-            ))}
-          </ul>
+          <Line data={dailyData} />
+          <h3 style={{ marginTop: '1rem' }}>Weekly Events</h3>
+          <Line data={weeklyData} />
         </div>
       )}
+
+      {metrics.coding_distribution &&
+        Object.keys(metrics.coding_distribution).length > 0 && (
+          <div style={{ marginTop: '1rem' }}>
+            <h3>Coding Distribution</h3>
+            <ul>
+              {Object.entries(metrics.coding_distribution).map(([code, val]) => (
+                <li key={code}>
+                  {code}: {val}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+      {metrics.denial_rates &&
+        Object.keys(metrics.denial_rates).length > 0 && (
+          <div style={{ marginTop: '1rem' }}>
+            <h3>Denial Rates</h3>
+            <ul>
+              {Object.entries(metrics.denial_rates).map(([code, val]) => (
+                <li key={code}>
+                  {code}: {val}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
     </div>
   );
 }

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { login } from '../api.js';
+
+/**
+ * Simple login form that authenticates against the backend and stores the
+ * returned JWT in localStorage. On success the parent component is notified
+ * so the application can render the secured views.
+ */
+function Login({ onLoggedIn }) {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      const token = await login(username, password);
+      if (typeof window !== 'undefined') {
+        localStorage.setItem('token', token);
+      }
+      onLoggedIn(token);
+    } catch (err) {
+      setError(err.message || 'Login failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="login-form" style={{ maxWidth: '20rem', margin: '2rem auto' }}>
+      <h2>Login</h2>
+      <form onSubmit={handleSubmit}>
+        <div style={{ marginBottom: '0.5rem' }}>
+          <label>
+            Username
+            <input
+              type="text"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              required
+            />
+          </label>
+        </div>
+        <div style={{ marginBottom: '0.5rem' }}>
+          <label>
+            Password
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </label>
+        </div>
+        {error && <p style={{ color: 'red' }}>{error}</p>}
+        <button type="submit" disabled={loading}>
+          {loading ? 'Logging in…' : 'Login'}
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export default Login;


### PR DESCRIPTION
## Summary
- add login component that requests `/login` and saves JWT
- include token in metrics API and add stubbed metrics fields
- visualize daily and weekly events via Chart.js and show revenue, coding distribution, and denial rates

## Testing
- `npm test` (fails: Missing script "test")
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68926d2960408324ab28c9420e90d510