### PR TITLE
Implement diarised transcription and audio recording

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -454,19 +454,24 @@ async def summarize(req: NoteRequest) -> Dict[str, str]:
 
 
 @app.post("/transcribe")
-async def transcribe(file: UploadFile = File(...), diarize: bool = False) -> Dict[str, Any]:
+async def transcribe(
+    file: UploadFile = File(...), diarise: bool = False
+) -> Dict[str, str]:
     """Transcribe uploaded audio.
 
     The endpoint accepts an audio file (e.g. from the browser's
-    ``MediaRecorder`` API) and returns either a single transcript or, when
-    ``diarize`` is true, separate transcripts for provider and patient.
-    Actual transcription is delegated to :mod:`backend.audio_processing`.
+    ``MediaRecorder`` API) and returns a JSON object with separate
+    ``provider`` and ``patient`` transcripts.  When ``diarise`` is false,
+    the full transcription is returned under ``provider`` and ``patient``
+    is left empty.  Actual transcription is delegated to
+    :mod:`backend.audio_processing`.
     """
 
     audio_bytes = await file.read()
-    if diarize:
+    if diarise:
         return diarize_and_transcribe(audio_bytes)
-    return {"transcript": simple_transcribe(audio_bytes)}
+    text = simple_transcribe(audio_bytes)
+    return {"provider": text, "patient": ""}
 
 # Endpoint: set the OpenAI API key.  Accepts a JSON body with a single
 # field "key" and stores it in a local file.  Also updates the

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -279,8 +279,9 @@ function App() {
         mediaRecorder.onstop = async () => {
           const blob = new Blob(audioChunksRef.current, { type: 'audio/webm' });
           try {
-            const text = await transcribeAudio(blob);
-            setAudioTranscript(text);
+            const result = await transcribeAudio(blob, true);
+            const combined = `${result.provider || ''} ${result.patient || ''}`.trim();
+            setAudioTranscript(combined);
           } catch (err) {
             console.error('Transcription failed', err);
             setAudioTranscript('');
@@ -477,20 +478,6 @@ function App() {
                   {chartFileName}
                 </span>
               )}
-              {/* Record or stop audio recording */}
-              <button
-                onClick={handleRecordAudio}
-                style={{ marginLeft: '0.5rem' }}
-              >
-                {recording ? 'Stop Recording' : 'Record Audio'}
-              </button>
-              {audioTranscript && (
-                <span
-                  style={{ fontSize: '0.8rem', marginLeft: '0.5rem', color: 'var(--secondary)' }}
-                >
-                  Transcript: {audioTranscript}
-                </span>
-              )}
               {/* Toggle suggestion panel visibility */}
               <button
                 onClick={() => setShowSuggestions((s) => !s)}
@@ -531,6 +518,9 @@ function App() {
                       id="draft-input"
                       value={draftText}
                       onChange={handleDraftChange}
+                      onRecord={handleRecordAudio}
+                      recording={recording}
+                      transcript={audioTranscript}
                     />
                   ) : (
                     activeTab === 'beautified' ? (

--- a/src/components/NoteEditor.jsx
+++ b/src/components/NoteEditor.jsx
@@ -23,7 +23,7 @@ try {
   ReactQuill = null;
 }
 
-function NoteEditor({ id, value, onChange }) {
+function NoteEditor({ id, value, onChange, onRecord, recording = false, transcript = '' }) {
   // Maintain a local state for the editor's HTML value when using the
   // fallback <textarea>.  This allows the component to behave as a
   // controlled input in both modes.
@@ -43,29 +43,52 @@ function NoteEditor({ id, value, onChange }) {
     onChange(newVal);
   };
 
+  const toolbar = (
+    <div style={{ marginBottom: '0.5rem' }}>
+      {onRecord && (
+        <button type="button" onClick={onRecord}>
+          {recording ? 'Stop Recording' : 'Record Audio'}
+        </button>
+      )}
+      {transcript && (
+        <span
+          style={{ fontSize: '0.8rem', marginLeft: '0.5rem', color: 'var(--secondary)' }}
+        >
+          Transcript: {transcript}
+        </span>
+      )}
+    </div>
+  );
+
   // Render the rich text editor if available; otherwise render a textarea.
   if (ReactQuill) {
     return (
-      <ReactQuill
-        id={id}
-        theme="snow"
-        value={value}
-        // ReactQuill's onChange passes the new HTML string as the first
-        // argument.  We ignore the other args (delta, source, editor) and
-        // forward the HTML string to the parent onChange.
-        onChange={(content) => onChange(content)}
-        style={{ height: '100%', width: '100%' }}
-      />
+      <div style={{ height: '100%', width: '100%' }}>
+        {toolbar}
+        <ReactQuill
+          id={id}
+          theme="snow"
+          value={value}
+          // ReactQuill's onChange passes the new HTML string as the first
+          // argument.  We ignore the other args (delta, source, editor) and
+          // forward the HTML string to the parent onChange.
+          onChange={(content) => onChange(content)}
+          style={{ height: '100%', width: '100%' }}
+        />
+      </div>
     );
   }
   return (
-    <textarea
-      id={id}
-      value={localValue}
-      onChange={handleTextAreaChange}
-      style={{ width: '100%', height: '100%', padding: '0.5rem' }}
-      placeholder="Type your clinical note here..."
-    />
+    <div style={{ width: '100%', height: '100%' }}>
+      {toolbar}
+      <textarea
+        id={id}
+        value={localValue}
+        onChange={handleTextAreaChange}
+        style={{ width: '100%', height: '100%', padding: '0.5rem' }}
+        placeholder="Type your clinical note here..."
+      />
+    </div>
   );
 }
 

--- a/tests/test_audio_processing.py
+++ b/tests/test_audio_processing.py
@@ -1,0 +1,62 @@
+import backend.audio_processing as ap
+
+
+def test_simple_transcribe_uses_openai(monkeypatch):
+    class DummyResp:
+        text = "hello world"
+
+    class DummyCreate:
+        def create(self, model, file):  # noqa: ARG002
+            return DummyResp()
+
+    class DummyClient:
+        audio = type("obj", (), {"transcriptions": DummyCreate()})()
+
+    monkeypatch.setattr(ap, "OpenAI", lambda api_key=None: DummyClient())
+    monkeypatch.setattr(ap, "get_api_key", lambda: "key")
+    result = ap.simple_transcribe(b"data")
+    assert result == "hello world"
+
+
+def test_diarize_and_transcribe(monkeypatch):
+    transcripts = ["provider text", "patient text"]
+
+    def fake_simple(_):
+        return transcripts.pop(0)
+
+    class DummyDiarization:
+        def itertracks(self, yield_label=True):  # noqa: ARG002
+            yield ("turn1", None, "SPEAKER_00")
+            yield ("turn2", None, "SPEAKER_01")
+
+    class DummyPipeline:
+        @classmethod
+        def from_pretrained(cls, name):  # noqa: ARG002
+            return cls()
+
+        def __call__(self, path):  # noqa: ARG002
+            return DummyDiarization()
+
+    class DummyAudio:
+        def crop(self, path, turn):  # noqa: ARG002
+            return b"wave", 16000
+
+    class DummyTorchaudio:
+        @staticmethod
+        def save(buf, waveform, sr, format):  # noqa: ARG002
+            buf.write(b"audio")
+
+    monkeypatch.setattr(ap, "Pipeline", DummyPipeline)
+    monkeypatch.setattr(ap, "Audio", DummyAudio)
+    monkeypatch.setattr(ap, "torchaudio", DummyTorchaudio)
+    monkeypatch.setattr(ap, "simple_transcribe", fake_simple)
+    monkeypatch.setattr(ap, "_DIARISATION_AVAILABLE", True)
+    result = ap.diarize_and_transcribe(b"bytes")
+    assert result == {"provider": "provider text", "patient": "patient text"}
+
+
+def test_diarize_fallback_when_unavailable(monkeypatch):
+    monkeypatch.setattr(ap, "_DIARISATION_AVAILABLE", False)
+    monkeypatch.setattr(ap, "simple_transcribe", lambda b: "full text")
+    result = ap.diarize_and_transcribe(b"bytes")
+    assert result == {"provider": "full text", "patient": ""}


### PR DESCRIPTION
## Summary
- add diarised `/transcribe` endpoint returning provider and patient text
- wire up frontend recording and transcription with diarisation option
- cover audio transcription and diarisation with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68927258528883249896ce5e50d3124a