### PR TITLE
feat: add advanced PHI scrubber

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,5 @@ platformdirs
 pyjwt
 scrubadub
 python-multipart
+presidio-analyzer
+presidio-anonymizer

--- a/src/api.js
+++ b/src/api.js
@@ -204,6 +204,49 @@ export async function getMetrics() {
 }
 
 /**
+ * Retrieve persisted backend settings such as the advanced scrubber toggle.
+ * Returns an empty object if the backend is unreachable.
+ * @returns {Promise<object>}
+ */
+export async function getServerSettings() {
+  const baseUrl =
+    import.meta?.env?.VITE_API_URL ||
+    window.__BACKEND_URL__ ||
+    window.location.origin;
+  try {
+    const resp = await fetch(`${baseUrl}/settings`);
+    if (!resp.ok) return {};
+    return await resp.json();
+  } catch (e) {
+    console.error('Failed to fetch settings', e);
+    return {};
+  }
+}
+
+/**
+ * Persist backend settings.
+ * @param {object} settings
+ * @returns {Promise<object>}
+ */
+export async function updateServerSettings(settings) {
+  const baseUrl =
+    import.meta?.env?.VITE_API_URL ||
+    window.__BACKEND_URL__ ||
+    window.location.origin;
+  try {
+    const resp = await fetch(`${baseUrl}/settings`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(settings),
+    });
+    return await resp.json();
+  } catch (e) {
+    console.error('Failed to update settings', e);
+    return {};
+  }
+}
+
+/**
  * Send the OpenAI API key to the backend for persistent storage.  This
  * allows the user to configure the key through the UI instead of
  * environment variables.  If no backend is configured, the call

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -2,7 +2,7 @@
 // Allows the user to toggle which suggestion categories are shown and switch colour themes.
 
 import { useState } from 'react';
-import { setApiKey } from '../api.js';
+import { setApiKey, updateServerSettings } from '../api.js';
 
 function Settings({ settings, updateSettings }) {
   const [apiKeyInput, setApiKeyInput] = useState('');
@@ -29,6 +29,15 @@ function Settings({ settings, updateSettings }) {
       setApiKeyInput('');
       // Clear the status after a short delay
       setTimeout(() => setApiKeyStatus(''), 4000);
+    }
+  };
+  const handleAdvancedToggle = async () => {
+    const newVal = !settings.advancedScrubbing;
+    updateSettings({ ...settings, advancedScrubbing: newVal });
+    try {
+      await updateServerSettings({ advanced_scrubber: newVal });
+    } catch (e) {
+      console.error(e);
     }
   };
   return (
@@ -62,6 +71,16 @@ function Settings({ settings, updateSettings }) {
           onChange={handleThemeChange}
         />{' '}
         Modern Minimal
+      </label>
+
+      <h3>Privacy</h3>
+      <label style={{ display: 'block' }}>
+        <input
+          type="checkbox"
+          checked={settings.advancedScrubbing}
+          onChange={handleAdvancedToggle}
+        />{' '}
+        Enable advanced PHI scrubbing
       </label>
       <label style={{ display: 'block', marginBottom: '0.5rem' }}>
         <input

--- a/tests/test_deidentify.py
+++ b/tests/test_deidentify.py
@@ -1,0 +1,16 @@
+import backend.main as bm
+
+
+def test_deidentify_removes_phi(monkeypatch):
+    monkeypatch.setattr(bm, "USE_ADVANCED_SCRUBBER", True)
+    text = (
+        "Patient John Doe visited on 01/23/2020. Lives at 123 Main St. "
+        "Call 555-123-4567 or email john@example.com. SSN 123-45-6789."
+    )
+    cleaned = bm.deidentify(text)
+    assert "John Doe" not in cleaned
+    assert "555-123-4567" not in cleaned
+    assert "john@example.com" not in cleaned
+    assert "123-45-6789" not in cleaned
+    assert "123 Main St" not in cleaned
+    assert "01/23/2020" not in cleaned


### PR DESCRIPTION
## Summary
- integrate Presidio-based PHI scrubber with optional toggle
- store advanced scrubber flag via new /settings API and database table
- expose advanced scrubbing toggle in settings UI and React state
- test deidentify to ensure PHI is removed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68927273615c8324aef932bae2146120