### PR TITLE
feat: add role based authentication

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -10,10 +10,9 @@
  *
  * @param {string} username
  * @param {string} password
- * @param {string} role
  * @returns {Promise<string>} JWT access token
  */
-export async function login(username, password, role = 'admin') {
+export async function login(username, password) {
   const baseUrl =
     import.meta?.env?.VITE_API_URL ||
     window.__BACKEND_URL__ ||
@@ -21,7 +20,7 @@ export async function login(username, password, role = 'admin') {
   const resp = await fetch(`${baseUrl}/login`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ username, password, role }),
+    body: JSON.stringify({ username, password }),
   });
   if (!resp.ok) {
     const err = await resp.json().catch(() => ({}));

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -55,7 +55,11 @@ function Login({ onLoggedIn }) {
             />
           </label>
         </div>
-        {error && <p style={{ color: 'red' }}>{error}</p>}
+        {error && (
+          <p style={{ color: 'red' }} data-testid="login-error">
+            {error}
+          </p>
+        )}
         <button type="submit" disabled={loading}>
           {loading ? 'Logging in…' : 'Login'}
         </button>

--- a/src/components/__tests__/Login.test.jsx
+++ b/src/components/__tests__/Login.test.jsx
@@ -1,0 +1,54 @@
+/* @vitest-environment jsdom */
+import { fireEvent, render, screen, waitFor, cleanup } from '@testing-library/react';
+import { vi, expect, test, beforeEach, afterEach } from 'vitest';
+import Login from '../Login.jsx';
+
+vi.mock('../../api.js', () => ({
+  login: vi.fn(),
+}));
+
+const { login } = await import('../../api.js');
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.resetAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+test('stores token on successful login', async () => {
+  login.mockResolvedValue('tok');
+  const onLoggedIn = vi.fn();
+  render(<Login onLoggedIn={onLoggedIn} />);
+
+  fireEvent.change(screen.getByLabelText('Username'), {
+    target: { value: 'user' },
+  });
+  fireEvent.change(screen.getByLabelText('Password'), {
+    target: { value: 'pw' },
+  });
+  fireEvent.submit(screen.getByRole('button'));
+
+  await waitFor(() => expect(onLoggedIn).toHaveBeenCalledWith('tok'));
+  expect(localStorage.getItem('token')).toBe('tok');
+  expect(screen.queryByTestId('login-error')).toBeNull();
+});
+
+test('shows error on failed login', async () => {
+  login.mockRejectedValue(new Error('Bad creds'));
+  render(<Login onLoggedIn={() => {}} />);
+
+  fireEvent.change(screen.getByLabelText('Username'), {
+    target: { value: 'user' },
+  });
+  fireEvent.change(screen.getByLabelText('Password'), {
+    target: { value: 'pw' },
+  });
+  fireEvent.submit(screen.getByRole('button'));
+
+  await waitFor(() => screen.getByTestId('login-error'));
+  expect(screen.getByTestId('login-error').textContent).toBe('Bad creds');
+});
+

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,64 @@
+import hashlib
+import sqlite3
+
+from fastapi.testclient import TestClient
+
+import backend.main as main
+
+
+def setup_module(module):
+    """Use an in-memory database for isolation during authentication tests."""
+    main.db_conn = sqlite3.connect(':memory:', check_same_thread=False)
+    main.db_conn.row_factory = sqlite3.Row
+    main.db_conn.execute(
+        'CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT, eventType TEXT, timestamp REAL, details TEXT)'
+    )
+    main.db_conn.execute(
+        'CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password_hash TEXT, role TEXT)'
+    )
+    # Seed an initial admin user
+    admin_hash = hashlib.sha256(b'secret').hexdigest()
+    main.db_conn.execute(
+        'INSERT INTO users (username, password_hash, role) VALUES (?, ?, ?)',
+        ('admin', admin_hash, 'admin'),
+    )
+    main.db_conn.commit()
+
+
+def test_register_and_login():
+    client = TestClient(main.app)
+    # Login as admin
+    resp = client.post('/login', json={'username': 'admin', 'password': 'secret'})
+    assert resp.status_code == 200
+    admin_token = resp.json()['access_token']
+
+    # Register a new regular user
+    resp = client.post(
+        '/register',
+        json={'username': 'alice', 'password': 'pw', 'role': 'user'},
+        headers={'Authorization': f'Bearer {admin_token}'},
+    )
+    assert resp.status_code == 200
+
+    # New user can log in and receives token with correct role
+    resp = client.post('/login', json={'username': 'alice', 'password': 'pw'})
+    assert resp.status_code == 200
+    token = resp.json()['access_token']
+    payload = main.jwt.decode(token, main.JWT_SECRET, algorithms=[main.JWT_ALGORITHM])
+    assert payload['role'] == 'user'
+
+
+def test_role_enforcement():
+    client = TestClient(main.app)
+    # Login as non-admin user
+    resp = client.post('/login', json={'username': 'alice', 'password': 'pw'})
+    token = resp.json()['access_token']
+    # Non-admin should be forbidden from accessing metrics
+    resp = client.get('/metrics', headers={'Authorization': f'Bearer {token}'})
+    assert resp.status_code == 403
+
+
+def test_login_failure():
+    client = TestClient(main.app)
+    resp = client.post('/login', json={'username': 'alice', 'password': 'wrong'})
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- store users and hashed passwords in SQLite
- add /register and /login endpoints that issue role-aware JWTs
- restrict metrics and events to admin role and wire up frontend login

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689279193b108324a43661573dc73180