### PR TITLE
Add backend and frontend test suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: pip install -r backend/requirements.txt pytest pytest-cov
+      - run: pytest --cov=backend
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm ci
+      - run: npm test

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --cov=backend --cov-report=term-missing

--- a/src/components/__tests__/Login.test.jsx
+++ b/src/components/__tests__/Login.test.jsx
@@ -1,0 +1,34 @@
+/* @vitest-environment jsdom */
+import { render, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { vi, expect, test, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../api.js', () => ({ login: vi.fn() }));
+import { login } from '../../api.js';
+import Login from '../Login.jsx';
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.clearAllMocks();
+});
+
+afterEach(() => cleanup());
+
+test('successful login stores token and calls callback', async () => {
+  login.mockResolvedValue('token123');
+  const onLoggedIn = vi.fn();
+  const { getByLabelText, getByRole } = render(<Login onLoggedIn={onLoggedIn} />);
+  fireEvent.change(getByLabelText('Username'), { target: { value: 'u' } });
+  fireEvent.change(getByLabelText('Password'), { target: { value: 'p' } });
+  fireEvent.click(getByRole('button', { name: /login/i }));
+  await waitFor(() => expect(onLoggedIn).toHaveBeenCalledWith('token123'));
+  expect(localStorage.getItem('token')).toBe('token123');
+});
+
+test('shows error on failed login', async () => {
+  login.mockRejectedValue(new Error('bad'));
+  const { getByLabelText, getByRole, findByText } = render(<Login onLoggedIn={() => {}} />);
+  fireEvent.change(getByLabelText('Username'), { target: { value: 'u' } });
+  fireEvent.change(getByLabelText('Password'), { target: { value: 'p' } });
+  fireEvent.click(getByRole('button', { name: /login/i }));
+  expect(await findByText('bad')).toBeTruthy();
+});

--- a/src/components/__tests__/NoteEditor.test.jsx
+++ b/src/components/__tests__/NoteEditor.test.jsx
@@ -1,0 +1,23 @@
+/* @vitest-environment jsdom */
+import { render, cleanup, fireEvent } from '@testing-library/react';
+import { vi, expect, test, afterEach } from 'vitest';
+import NoteEditor from '../NoteEditor.jsx';
+
+afterEach(() => cleanup());
+
+test('calls onRecord when record button clicked', () => {
+  const onRecord = vi.fn();
+  const { getByText } = render(
+    <NoteEditor id="n" value="" onChange={() => {}} onRecord={onRecord} />
+  );
+  fireEvent.click(getByText('Record Audio'));
+  expect(onRecord).toHaveBeenCalled();
+});
+
+test('shows record button and transcript when provided', () => {
+  const { getByText } = render(
+    <NoteEditor id="a" value="" onChange={() => {}} onRecord={() => {}} recording transcript="done" />
+  );
+  expect(getByText('Stop Recording')).toBeTruthy();
+  expect(getByText(/Transcript: done/)).toBeTruthy();
+});

--- a/src/components/__tests__/SuggestionPanel.test.jsx
+++ b/src/components/__tests__/SuggestionPanel.test.jsx
@@ -1,0 +1,23 @@
+/* @vitest-environment jsdom */
+import { render, fireEvent, cleanup } from '@testing-library/react';
+import { vi, expect, test, afterEach } from 'vitest';
+import SuggestionPanel from '../SuggestionPanel.jsx';
+
+afterEach(() => cleanup());
+
+test('renders suggestions and handles click', () => {
+  const onInsert = vi.fn();
+  const { getByText } = render(
+    <SuggestionPanel suggestions={{ codes: ['A'], compliance: [], publicHealth: [], differentials: [] }} onInsert={onInsert} />
+  );
+  fireEvent.click(getByText('A'));
+  expect(onInsert).toHaveBeenCalledWith('A');
+});
+
+test('shows loading and toggles sections', () => {
+  const { getByText, getAllByText } = render(<SuggestionPanel loading />);
+  expect(getAllByText('Loading suggestions...').length).toBeGreaterThan(0);
+  const header = getByText('Codes & Rationale');
+  fireEvent.click(header);
+  expect(header.parentElement?.parentElement.querySelector('ul')).toBeNull();
+});

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1,0 +1,145 @@
+import json
+import sqlite3
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend import main
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    # Isolate database and events
+    db = sqlite3.connect(":memory:", check_same_thread=False)
+    db.row_factory = sqlite3.Row
+    db.execute(
+        "CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT, eventType TEXT NOT NULL, timestamp REAL NOT NULL, details TEXT)"
+    )
+    db.execute(
+        "CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)"
+    )
+    db.commit()
+    monkeypatch.setattr(main, "db_conn", db)
+    monkeypatch.setattr(main, "events", [])
+    return TestClient(main.app)
+
+
+def auth_header(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_login_and_settings(client):
+    resp = client.post("/login", json={"username": "alice", "role": "admin"})
+    assert resp.status_code == 200
+    token = resp.json()["access_token"]
+    assert token
+
+    resp = client.get("/settings")
+    assert resp.status_code == 200
+    assert "advanced_scrubber" in resp.json()
+
+    resp = client.post("/settings", json={"advanced_scrubber": True})
+    assert resp.json()["advanced_scrubber"] is True
+    # reset to keep other tests deterministic
+    client.post("/settings", json={"advanced_scrubber": False})
+
+    resp = client.post("/settings", json={"advanced_scrubber": None})
+    assert resp.status_code == 422
+
+
+def test_events_metrics_with_auth(client):
+    # no auth
+    resp = client.get("/events")
+    assert resp.status_code in {401, 403}
+
+    # user without admin role
+    token_user = client.post("/login", json={"username": "u", "role": "user"}).json()["access_token"]
+    resp = client.get("/events", headers=auth_header(token_user))
+    assert resp.status_code == 403
+
+    # log event and fetch with admin
+    token_admin = client.post("/login", json={"username": "a", "role": "admin"}).json()["access_token"]
+    client.post("/event", json={"eventType": "note_started"})
+    resp = client.get("/events", headers=auth_header(token_admin))
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+    resp = client.get("/metrics", headers=auth_header(token_admin))
+    assert resp.status_code == 200
+    assert resp.json()["total_notes"] >= 1
+
+
+def test_summarize_and_fallback(client, monkeypatch):
+    monkeypatch.setattr(main, "call_openai", lambda msgs: "great summary")
+    resp = client.post("/summarize", json={"text": "hello"})
+    assert resp.json()["summary"] == "great summary"
+
+    def boom(_):
+        raise RuntimeError("no key")
+
+    monkeypatch.setattr(main, "call_openai", boom)
+    long_text = "a" * 300
+    resp = client.post("/summarize", json={"text": long_text})
+    assert resp.status_code == 200
+    assert len(resp.json()["summary"]) <= 203  # truncated fallback
+
+
+def test_transcribe_endpoint(client, monkeypatch):
+    monkeypatch.setattr(main, "simple_transcribe", lambda b: "hello")
+    resp = client.post("/transcribe", files={"file": ("a.wav", b"bytes")})
+    assert resp.json()["provider"] == "hello"
+
+    resp = client.post("/transcribe")
+    assert resp.status_code == 422
+
+
+def test_apikey_validation(client, monkeypatch):
+    monkeypatch.setattr(main, "save_api_key", lambda key: None)
+    valid = "sk-" + "a" * 22
+    resp = client.post("/apikey", json={"key": valid})
+    assert resp.json()["status"] == "saved"
+
+    resp = client.post("/apikey", json={"key": ""})
+    assert resp.status_code == 400
+
+    resp = client.post("/apikey", json={"key": "abc"})
+    assert resp.status_code == 400
+
+
+def test_beautify_and_fallback(client, monkeypatch):
+    monkeypatch.setattr(main, "call_openai", lambda msgs: "nice note")
+    resp = client.post("/beautify", json={"text": "hello"})
+    assert resp.json()["beautified"] == "nice note"
+
+    def fail(_):
+        raise ValueError("bad")
+
+    monkeypatch.setattr(main, "call_openai", fail)
+    resp = client.post("/beautify", json={"text": "hi"})
+    assert resp.json()["beautified"] == "HI"
+
+
+def test_suggest_and_fallback(client, monkeypatch):
+    monkeypatch.setattr(
+        main,
+        "call_openai",
+        lambda msgs: json.dumps(
+            {
+                "codes": [{"code": "A1"}],
+                "compliance": ["c"],
+                "publicHealth": ["p"],
+                "differentials": ["d"],
+            }
+        ),
+    )
+    resp = client.post("/suggest", json={"text": "note"})
+    data = resp.json()
+    assert data["codes"][0]["code"] == "A1"
+
+    def boom(_):
+        raise RuntimeError("fail")
+
+    monkeypatch.setattr(main, "call_openai", boom)
+    resp = client.post("/suggest", json={"text": "cough"})
+    data = resp.json()
+    assert any(c["code"] == "99213" for c in data["codes"])


### PR DESCRIPTION
## Summary
- add pytest config and comprehensive FastAPI endpoint tests with mocked OpenAI calls
- add React Testing Library tests for core components and CI workflow

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689276a6e9a883248ccab41dedb8a565