### PR TITLE
feat: add customizable templates

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -151,6 +151,17 @@ db_conn.execute(
 )
 db_conn.commit()
 
+db_conn.execute(
+    "CREATE TABLE IF NOT EXISTS templates ("
+    "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+    "user TEXT NOT NULL,"
+    "clinic TEXT,"
+    "name TEXT NOT NULL,"
+    "content TEXT NOT NULL"
+    ")"
+)
+db_conn.commit()
+
 # Configure the database connection to return rows as dictionaries.  This
 # makes it easier to access columns by name when querying events for
 # metrics computations.
@@ -345,6 +356,14 @@ class EventModel(BaseModel):
     deficiency: Optional[bool] = None
 
 
+class TemplateModel(BaseModel):
+    """Template structure for note creation snippets."""
+
+    id: Optional[int] = None
+    name: str
+    content: str
+
+
 def deidentify(text: str) -> str:
     """Redact common protected health information from ``text``.
 
@@ -509,6 +528,49 @@ async def log_event(event: EventModel) -> Dict[str, str]:
     except Exception as exc:
         print(f"Error inserting event into database: {exc}")
     return {"status": "logged"}
+
+
+@app.get("/templates", response_model=List[TemplateModel])
+def get_templates(user=Depends(get_current_user)) -> List[TemplateModel]:
+    """Return custom templates for the current user and clinic."""
+
+    clinic = user.get("clinic")
+    cursor = db_conn.cursor()
+    rows = cursor.execute(
+        "SELECT id, name, content FROM templates WHERE user=? AND (clinic=? OR clinic IS NULL)",
+        (user["sub"], clinic),
+    ).fetchall()
+    return [TemplateModel(id=row["id"], name=row["name"], content=row["content"]) for row in rows]
+
+
+@app.post("/templates", response_model=TemplateModel)
+def create_template(tpl: TemplateModel, user=Depends(get_current_user)) -> TemplateModel:
+    """Create a new custom template for the user."""
+
+    clinic = user.get("clinic")
+    cursor = db_conn.cursor()
+    cursor.execute(
+        "INSERT INTO templates (user, clinic, name, content) VALUES (?, ?, ?, ?)",
+        (user["sub"], clinic, tpl.name, tpl.content),
+    )
+    db_conn.commit()
+    tpl_id = cursor.lastrowid
+    return TemplateModel(id=tpl_id, name=tpl.name, content=tpl.content)
+
+
+@app.delete("/templates/{template_id}")
+def delete_template(template_id: int, user=Depends(get_current_user)) -> Dict[str, str]:
+    """Delete a custom template owned by the current user."""
+
+    cursor = db_conn.cursor()
+    cursor.execute(
+        "DELETE FROM templates WHERE id=? AND user=?",
+        (template_id, user["sub"]),
+    )
+    db_conn.commit()
+    if cursor.rowcount == 0:
+        raise HTTPException(status_code=404, detail="Template not found")
+    return {"status": "deleted"}
 
 
 # Endpoint: aggregate metrics from the logged events.  Returns counts of

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ import Sidebar from './components/Sidebar.jsx';
 import Drafts from './components/Drafts.jsx';
 import Login from './components/Login.jsx';
 import ClipboardExportButtons from './components/ClipboardExportButtons.jsx';
+import TemplatesModal from './components/TemplatesModal.jsx';
 
 // Utility to convert HTML strings into plain text by stripping tags.  The
 // ReactQuill editor stores content as HTML; our backend accepts plain
@@ -69,6 +70,7 @@ function App() {
 
   // Control visibility of the suggestion panel (for sliding effect)
   const [showSuggestions, setShowSuggestions] = useState(true);
+  const [showTemplatesModal, setShowTemplatesModal] = useState(false);
 
   // Track the current patient ID for draft saving
   const [patientID, setPatientID] = useState('');
@@ -176,6 +178,31 @@ function App() {
       name: 'Follow-up Visit Template',
       content:
         'Chief Complaint: \n\nInterval History: \n\nReview of Systems: \n\nPhysical Exam: \n\nAssessment & Plan: ',
+    },
+    {
+      name: 'Paediatrics Template',
+      content:
+        'Chief Complaint: \n\nHistory of Present Illness: \n\nGrowth Parameters: \n\nDevelopment: \n\nImmunisations: \n\nAssessment & Plan: ',
+    },
+    {
+      name: 'Geriatrics Template',
+      content:
+        'Chief Complaint: \n\nFunctional Status: \n\nCognitive Assessment: \n\nMedications: \n\nSupport Systems: \n\nAssessment & Plan: ',
+    },
+    {
+      name: 'Psychiatry Template',
+      content:
+        'Chief Complaint: \n\nHistory of Present Illness: \n\nMental Status Exam: \n\nRisk Assessment: \n\nAssessment & Plan: ',
+    },
+    {
+      name: 'Cardiology Template',
+      content:
+        'Chief Complaint: \n\nHistory of Present Illness: \n\nCardiac Risk Factors: \n\nExam: \n\nDiagnostics: \n\nAssessment & Plan: ',
+    },
+    {
+      name: 'Dermatology Template',
+      content:
+        'Chief Complaint: \n\nHistory of Present Illness: \n\nSkin Exam: \n\nAssessment: \n\nPlan: ',
     },
   ];
 
@@ -457,21 +484,9 @@ function App() {
                 onChange={(e) => setPatientID(e.target.value)}
                 className="patient-input"
               />
-              <select
-                onChange={(e) => {
-                  const idx = parseInt(e.target.value, 10);
-                  if (!isNaN(idx)) insertTemplate(templates[idx].content);
-                  e.target.selectedIndex = 0;
-                }}
-                className="template-select"
-              >
-                <option value="">Insert Template</option>
-                {templates.map((tpl, idx) => (
-                  <option key={tpl.name} value={idx}>
-                    {tpl.name}
-                  </option>
-                ))}
-              </select>
+              <button onClick={() => setShowTemplatesModal(true)}>
+                Templates
+              </button>
               <button
                 disabled={loadingBeautify || !draftText.trim()}
                 onClick={handleBeautify}
@@ -605,6 +620,16 @@ function App() {
         {view === 'logs' && <Logs />}
         </div>
       </div>
+      {showTemplatesModal && (
+        <TemplatesModal
+          baseTemplates={templates}
+          onSelect={(content) => {
+            insertTemplate(content);
+            setShowTemplatesModal(false);
+          }}
+          onClose={() => setShowTemplatesModal(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/api.js
+++ b/src/api.js
@@ -255,6 +255,66 @@ export async function updateServerSettings(settings) {
 }
 
 /**
+ * Retrieve custom templates for the current user from the backend.
+ * Returns an empty array if the backend is unreachable.
+ * @returns {Promise<Array<{id:number,name:string,content:string}>>}
+ */
+export async function getTemplates() {
+  const baseUrl =
+    import.meta?.env?.VITE_API_URL ||
+    window.__BACKEND_URL__ ||
+    window.location.origin;
+  if (!baseUrl) return [];
+  const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  const resp = await fetch(`${baseUrl}/templates`, { headers });
+  if (!resp.ok) return [];
+  return await resp.json();
+}
+
+/**
+ * Persist a custom template for the current user.
+ * @param {{name:string, content:string}} tpl
+ * @returns {Promise<object>}
+ */
+export async function createTemplate(tpl) {
+  const baseUrl =
+    import.meta?.env?.VITE_API_URL ||
+    window.__BACKEND_URL__ ||
+    window.location.origin;
+  if (!baseUrl) return tpl;
+  const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+  const headers = token
+    ? { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` }
+    : { 'Content-Type': 'application/json' };
+  const resp = await fetch(`${baseUrl}/templates`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(tpl),
+  });
+  return await resp.json();
+}
+
+/**
+ * Delete a custom template by its identifier.
+ * @param {number} id
+ * @returns {Promise<void>}
+ */
+export async function deleteTemplate(id) {
+  const baseUrl =
+    import.meta?.env?.VITE_API_URL ||
+    window.__BACKEND_URL__ ||
+    window.location.origin;
+  if (!baseUrl) return;
+  const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  await fetch(`${baseUrl}/templates/${id}`, {
+    method: 'DELETE',
+    headers,
+  });
+}
+
+/**
  * Send the OpenAI API key to the backend for persistent storage.  This
  * allows the user to configure the key through the UI instead of
  * environment variables.  If no backend is configured, the call

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -1,12 +1,13 @@
 // Settings page component for RevenuePilot.
 // Allows the user to toggle which suggestion categories are shown and switch colour themes.
 
-import { useState } from 'react';
-import { setApiKey, updateServerSettings } from '../api.js';
+import { useState, useEffect } from 'react';
+import { setApiKey, updateServerSettings, getTemplates, deleteTemplate } from '../api.js';
 
 function Settings({ settings, updateSettings }) {
   const [apiKeyInput, setApiKeyInput] = useState('');
   const [apiKeyStatus, setApiKeyStatus] = useState('');
+  const [templates, setTemplates] = useState([]);
   const handleToggle = (key) => {
     updateSettings({ ...settings, [key]: !settings[key] });
   };
@@ -36,6 +37,17 @@ function Settings({ settings, updateSettings }) {
     updateSettings({ ...settings, advancedScrubbing: newVal });
     try {
       await updateServerSettings({ advanced_scrubber: newVal });
+    } catch (e) {
+      console.error(e);
+    }
+  };
+  useEffect(() => {
+    getTemplates().then(setTemplates).catch(() => setTemplates([]));
+  }, []);
+  const handleDeleteTemplate = async (id) => {
+    try {
+      await deleteTemplate(id);
+      setTemplates((prev) => prev.filter((t) => t.id !== id));
     } catch (e) {
       console.error(e);
     }
@@ -152,6 +164,16 @@ function Settings({ settings, updateSettings }) {
         style={{ width: '100%', marginTop: '0.5rem', padding: '0.5rem', borderRadius: '4px', border: '1px solid var(--disabled)' }}
         placeholder="e.g. Commercial payer X requires three ROS for 99214; Include time spent on counselling for CPT 99406"
       />
+      <h3>Templates</h3>
+      <ul>
+        {templates.map((tpl) => (
+          <li key={tpl.id}>
+            {tpl.name}{' '}
+            <button onClick={() => handleDeleteTemplate(tpl.id)}>Delete</button>
+          </li>
+        ))}
+        {templates.length === 0 && <li>No templates</li>}
+      </ul>
     </div>
   );
 }

--- a/src/components/TemplatesModal.jsx
+++ b/src/components/TemplatesModal.jsx
@@ -1,0 +1,69 @@
+import { useState, useEffect } from 'react';
+import { getTemplates, createTemplate } from '../api.js';
+
+function TemplatesModal({ baseTemplates, onSelect, onClose }) {
+  const [templates, setTemplates] = useState(baseTemplates);
+  const [name, setName] = useState('');
+  const [content, setContent] = useState('');
+
+  useEffect(() => {
+    getTemplates().then((data) => setTemplates([...baseTemplates, ...data]));
+  }, [baseTemplates]);
+
+  const handleCreate = async () => {
+    if (!name.trim() || !content.trim()) return;
+    try {
+      const tpl = await createTemplate({ name: name.trim(), content: content.trim() });
+      setTemplates((prev) => [...prev, tpl]);
+      setName('');
+      setContent('');
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal card">
+        <h3>Templates</h3>
+        <ul>
+          {templates.map((tpl) => (
+            <li key={tpl.id || tpl.name}>
+              <button
+                onClick={() => onSelect(tpl.content)}
+                style={{ margin: '0.25rem 0' }}
+              >
+                {tpl.name}
+              </button>
+            </li>
+          ))}
+        </ul>
+        <h4>Create Template</h4>
+        <input
+          type="text"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          style={{ width: '100%', marginBottom: '0.5rem' }}
+        />
+        <textarea
+          placeholder="Content"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          rows={4}
+          style={{ width: '100%' }}
+        />
+        <div style={{ marginTop: '0.5rem' }}>
+          <button onClick={handleCreate} disabled={!name.trim() || !content.trim()}>
+            Save
+          </button>
+          <button onClick={onClose} style={{ marginLeft: '0.5rem' }}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default TemplatesModal;

--- a/src/components/__tests__/Dashboard.test.jsx
+++ b/src/components/__tests__/Dashboard.test.jsx
@@ -1,7 +1,9 @@
 /* @vitest-environment jsdom */
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, cleanup } from '@testing-library/react';
 import Dashboard from '../Dashboard.jsx';
-import { vi, beforeEach, test, expect } from 'vitest';
+import { vi, beforeEach, test, expect, afterEach } from 'vitest';
+
+HTMLCanvasElement.prototype.getContext = vi.fn();
 
 vi.mock('../../api.js', () => ({
   getMetrics: vi.fn().mockResolvedValue({
@@ -22,6 +24,10 @@ vi.mock('../../api.js', () => ({
     timeseries: { daily: [{ date: '2024-01-01', count: 1 }], weekly: [{ week: '2024-01', count: 1 }] },
   }),
 }));
+
+afterEach(() => {
+  cleanup();
+});
 
 const token = [
   btoa(JSON.stringify({ alg: 'none', typ: 'JWT' })),

--- a/src/components/__tests__/TemplatesModal.test.jsx
+++ b/src/components/__tests__/TemplatesModal.test.jsx
@@ -1,0 +1,37 @@
+/* @vitest-environment jsdom */
+import { render, fireEvent, cleanup } from '@testing-library/react';
+import { vi, test, expect, afterEach } from 'vitest';
+import TemplatesModal from '../TemplatesModal.jsx';
+
+vi.mock('../../api.js', () => ({
+  getTemplates: vi.fn().mockResolvedValue([{ id: 1, name: 'Custom', content: 'C' }]),
+  createTemplate: vi.fn(async (tpl) => ({ id: 2, ...tpl })),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+test('lists and selects templates', async () => {
+  const onSelect = vi.fn();
+  const { getByText, findByText } = render(
+    <TemplatesModal
+      baseTemplates={[{ name: 'Base', content: 'B' }]}
+      onSelect={onSelect}
+      onClose={() => {}}
+    />,
+  );
+  await findByText('Custom');
+  fireEvent.click(getByText('Base'));
+  expect(onSelect).toHaveBeenCalledWith('B');
+});
+
+test('creates template', async () => {
+  const { getByPlaceholderText, getByText, findByText } = render(
+    <TemplatesModal baseTemplates={[]} onSelect={() => {}} onClose={() => {}} />,
+  );
+  fireEvent.change(getByPlaceholderText('Name'), { target: { value: 'Extra' } });
+  fireEvent.change(getByPlaceholderText('Content'), { target: { value: 'X' } });
+  fireEvent.click(getByText('Save'));
+  await findByText('Extra');
+});

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,45 @@
+import sqlite3
+from fastapi.testclient import TestClient
+
+import backend.main as main
+
+
+def setup_module(module):
+    """Set up in-memory DB with templates table."""
+    main.db_conn = sqlite3.connect(':memory:', check_same_thread=False)
+    main.db_conn.row_factory = sqlite3.Row
+    main.db_conn.execute(
+        'CREATE TABLE templates (id INTEGER PRIMARY KEY AUTOINCREMENT, user TEXT, clinic TEXT, name TEXT, content TEXT)'
+    )
+    main.db_conn.commit()
+
+
+def test_create_and_list_templates():
+    client = TestClient(main.app)
+    token = main.create_token('alice', 'user')
+    resp = client.post(
+        '/templates',
+        json={'name': 'Custom', 'content': 'Note'},
+        headers={'Authorization': f'Bearer {token}'},
+    )
+    assert resp.status_code == 200
+    tpl_id = resp.json()['id']
+    assert tpl_id
+    resp = client.get('/templates', headers={'Authorization': f'Bearer {token}'})
+    data = resp.json()
+    assert any(t['name'] == 'Custom' for t in data)
+
+
+def test_delete_template():
+    client = TestClient(main.app)
+    token = main.create_token('alice', 'user')
+    resp = client.post(
+        '/templates',
+        json={'name': 'Temp', 'content': 'X'},
+        headers={'Authorization': f'Bearer {token}'},
+    )
+    tpl_id = resp.json()['id']
+    resp = client.delete(f'/templates/{tpl_id}', headers={'Authorization': f'Bearer {token}'})
+    assert resp.status_code == 200
+    resp = client.get('/templates', headers={'Authorization': f'Bearer {token}'})
+    assert all(t['id'] != tpl_id for t in resp.json())


### PR DESCRIPTION
## Summary
- extend built-in note templates for multiple specialties
- add templates modal with custom template support
- provide backend template endpoints and settings management

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68927b4004a08324ad30076ca0fedb1f