### PR TITLE
feat: internationalization and prompt customization

### DIFF
--- a/backend/prompt_templates.example.yaml
+++ b/backend/prompt_templates.example.yaml
@@ -1,0 +1,10 @@
+specialty:
+  cardiology:
+    beautify:
+      en: "Cardiology specific beautify instruction"
+      es: "Instrucción de embellecer específica de cardiología"
+payer:
+  medicare:
+    suggest:
+      en: "Follow Medicare coding rules"
+      es: "Siga las reglas de codificación de Medicare"

--- a/backend/prompts.py
+++ b/backend/prompts.py
@@ -7,91 +7,134 @@ according to the RevenuePilot plan.  When integrating with the OpenAI API,
 call `openai.ChatCompletion.create` with the returned messages.
 """
 
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
+import json
+import os
+from functools import lru_cache
+try:
+    import yaml
+except Exception:  # pragma: no cover - yaml is optional
+    yaml = None
 
 
-def build_beautify_prompt(text: str) -> List[Dict[str, str]]:
-    """
-    Construct a prompt for reformatting a clinical note into a clean,
-    professional format.  The assistant must not alter the clinical
-    content or add new information; it should simply improve phrasing,
-    spelling and organisation.
-
-    Args:
-        text: The draft clinical note (already de‑identified).
-    Returns:
-        A list of messages suitable for the OpenAI chat completion API.
-    """
-    return [
-        {
-            "role": "system",
-            "content": (
-                "You are a highly skilled clinical documentation specialist. Your task is to take "
-                "an unformatted draft note and return a polished, professional version. Do not "
-                "alter the underlying clinical facts or invent new information. Correct grammar "
-                "and spelling, improve clarity and readability, and organise the content into a "
-                "standard SOAP format (Subjective, Objective, Assessment, Plan) where appropriate. "
-                "If the note does not contain all four sections, preserve the existing content and "
-                "structure sensibly. Do not include any patient identifiers or PHI. Do not add "
-                "extra commentary, headings or markup beyond the improved note itself."
-            ),
-        },
-        {"role": "user", "content": text},
-    ]
+@lru_cache()
+def _load_custom_templates() -> Dict[str, Any]:
+    """Load custom prompt templates from a JSON or YAML file if present."""
+    base = os.path.dirname(__file__)
+    for name in ("prompt_templates.json", "prompt_templates.yaml", "prompt_templates.yml"):
+        path = os.path.join(base, name)
+        if os.path.exists(path):
+            with open(path, "r", encoding="utf-8") as f:
+                if name.endswith("json"):
+                    return json.load(f)
+                if yaml:
+                    return yaml.safe_load(f)
+    return {}
 
 
-def build_suggest_prompt(text: str) -> List[Dict[str, str]]:
-    """
-    Construct a prompt for generating coding, compliance and differential
-    suggestions.  The AI should parse the clinical note and produce a
-    JSON object with the requested fields.  The assistant must base its
-    suggestions on the provided note and avoid fabricating findings.
+def _get_custom_instruction(category: str, lang: str, specialty: Optional[str], payer: Optional[str]) -> Optional[str]:
+    templates = _load_custom_templates()
+    for key, group in ((specialty, "specialty"), (payer, "payer")):
+        if key:
+            data = templates.get(group, {}).get(key, {})
+            instr = data.get(category)
+            if isinstance(instr, dict):
+                return instr.get(lang)
+            if instr:
+                return instr
+    return None
 
-    Args:
-        text: The draft clinical note (already de‑identified).
-    Returns:
-        A list of messages for the OpenAI chat completion API.
-    """
-    instructions = (
-        "You are an expert medical coder, compliance officer and clinical decision support assistant. "
-        "Analyse the following de‑identified clinical note and return a JSON object with four keys:\n"
-        "- codes: an array of objects with two fields: code (string) and rationale (string). Include only the most relevant CPT and ICD‑10 codes based solely on the information provided. Do not guess codes that are not supported by the note. Limit to a maximum of five codes.\n"
-        "- compliance: an array of succinct strings highlighting missing documentation elements, audit risks or compliance tips (e.g., incomplete history, missing ROS, insufficient exam). Focus on areas that could cause downcoding or denials.\n"
-        "- public_health: an array of preventative measures, vaccinations or screenings that may apply given the patient’s context. Suggest generic recommendations (e.g., influenza vaccine, smoking cessation) without assuming personal details.\n"
-        "- differentials: an array of plausible differential diagnoses suggested by the note. Limit to a maximum of five differentials and ensure they are consistent with the symptoms described.\n"
-        "Return only valid JSON without any surrounding Markdown. Do not fabricate information beyond the note. If no suggestions apply to a category, return an empty array for that key."
-    )
+
+def build_beautify_prompt(
+    text: str,
+    lang: str = "en",
+    specialty: Optional[str] = None,
+    payer: Optional[str] = None,
+) -> List[Dict[str, str]]:
+    """Build a beautify prompt in the requested language."""
+    default_instructions = {
+        "en": (
+            "You are a highly skilled clinical documentation specialist. Your task is to take "
+            "an unformatted draft note and return a polished, professional version. Do not "
+            "alter the underlying clinical facts or invent new information. Correct grammar "
+            "and spelling, improve clarity and readability, and organise the content into a "
+            "standard SOAP format (Subjective, Objective, Assessment, Plan) where appropriate. "
+            "If the note does not contain all four sections, preserve the existing content and "
+            "structure sensibly. Do not include any patient identifiers or PHI. Do not add "
+            "extra commentary, headings or markup beyond the improved note itself."
+        ),
+        "es": (
+            "Usted es un especialista altamente capacitado en documentación clínica. Su tarea es tomar una nota clínica sin "
+            "formato y devolver una versión pulida y profesional. No debe alterar los hechos clínicos subyacentes ni inventar "
+            "nueva información. Corrija la gramática y la ortografía, mejore la claridad y la legibilidad y organice el contenido "
+            "en un formato estándar SOAP (Subjetivo, Objetivo, Evaluación, Plan) cuando corresponda. Si la nota no contiene las "
+            "cuatro secciones, preserve el contenido existente y organícelo de manera sensata. No incluya identificadores del "
+            "paciente ni PHI. No agregue comentarios adicionales, encabezados ni marcas más allá de la nota mejorada."
+        ),
+    }
+    instructions = _get_custom_instruction("beautify", lang, specialty, payer) or default_instructions.get(lang, default_instructions["en"])
     return [
         {"role": "system", "content": instructions},
         {"role": "user", "content": text},
     ]
 
 
-def build_summary_prompt(text: str) -> List[Dict[str, str]]:
-    """
-    Construct a prompt for generating a patient‑friendly summary of a clinical note.
-    The assistant should translate clinical jargon into plain language that a
-    non‑medical reader can understand.  It should preserve the key facts (e.g.,
-    diagnoses, treatments and follow‑up instructions) but avoid sensitive
-    identifiers or billing codes.  The output should be concise (1–2
-    paragraphs) and written at roughly an 8th grade reading level.
-
-    Args:
-        text: The de‑identified clinical note and any additional context.
-    Returns:
-        A list of messages suitable for the OpenAI chat completion API.
-    """
+def build_suggest_prompt(
+    text: str,
+    lang: str = "en",
+    specialty: Optional[str] = None,
+    payer: Optional[str] = None,
+) -> List[Dict[str, str]]:
+    """Build a suggestions prompt in the requested language."""
+    default_instructions = {
+        "en": (
+            "You are an expert medical coder, compliance officer and clinical decision support assistant. "
+            "Analyse the following de‑identified clinical note and return a JSON object with four keys:\n"
+            "- codes: an array of objects with two fields: code (string) and rationale (string). Include only the most relevant CPT and ICD‑10 codes based solely on the information provided. Do not guess codes that are not supported by the note. Limit to a maximum of five codes.\n"
+            "- compliance: an array of succinct strings highlighting missing documentation elements, audit risks or compliance tips (e.g., incomplete history, missing ROS, insufficient exam). Focus on areas that could cause downcoding or denials.\n"
+            "- public_health: an array of preventative measures, vaccinations or screenings that may apply given the patient’s context. Suggest generic recommendations (e.g., influenza vaccine, smoking cessation) without assuming personal details.\n"
+            "- differentials: an array of plausible differential diagnoses suggested by the note. Limit to a maximum of five differentials and ensure they are consistent with the symptoms described.\n"
+            "Return only valid JSON without any surrounding Markdown. Do not fabricate information beyond the note. If no suggestions apply to a category, return an empty array for that key."
+        ),
+        "es": (
+            "Usted es un experto codificador médico, responsable de cumplimiento y asistente de apoyo a la decisión clínica. "
+            "Analice la siguiente nota clínica desidentificada y devuelva un objeto JSON con cuatro claves:\n"
+            "- codes: una matriz de objetos con dos campos: code (cadena) y rationale (cadena). Incluya solo los códigos CPT e ICD‑10 más relevantes basados únicamente en la información proporcionada. No suponga códigos que no estén respaldados por la nota. Limítese a un máximo de cinco códigos.\n"
+            "- compliance: una matriz de cadenas breves que resalten elementos faltantes de documentación, riesgos de auditoría o consejos de cumplimiento (por ejemplo, historial incompleto, ROS faltante, examen insuficiente). Concéntrese en áreas que podrían causar reducción de códigos o denegaciones.\n"
+            "- public_health: una matriz de medidas preventivas, vacunaciones o cribados que puedan aplicar según el contexto del paciente. Sugiera recomendaciones genéricas (por ejemplo, vacuna contra la gripe, dejar de fumar) sin asumir detalles personales.\n"
+            "- differentials: una matriz de diagnósticos diferenciales plausibles sugeridos por la nota. Limítese a un máximo de cinco diferenciales y asegúrese de que sean coherentes con los síntomas descritos.\n"
+            "Devuelva solo JSON válido sin ningún Markdown adicional. No fabrique información más allá de la nota. Si no hay sugerencias para una categoría, devuelva un array vacío para esa clave."
+        ),
+    }
+    instructions = _get_custom_instruction("suggest", lang, specialty, payer) or default_instructions.get(lang, default_instructions["en"])
     return [
-        {
-            "role": "system",
-            "content": (
-                "You are an expert clinical communicator.  Rewrite the following clinical note "
-                "into a concise summary that a patient can easily understand.  Preserve all "
-                "important medical facts (symptoms, diagnoses, treatments, follow‑up), but remove "
-                "billing codes and technical jargon.  Write in plain language at about an 8th "
-                "grade reading level.  Do not invent information that is not present in the note. "
-                "Do not include any patient identifiers or PHI."
-            ),
-        },
+        {"role": "system", "content": instructions},
+        {"role": "user", "content": text},
+    ]
+
+
+def build_summary_prompt(
+    text: str,
+    lang: str = "en",
+    specialty: Optional[str] = None,
+    payer: Optional[str] = None,
+) -> List[Dict[str, str]]:
+    """Build a summary prompt in the requested language."""
+    default_instructions = {
+        "en": (
+            "You are an expert clinical communicator.  Rewrite the following clinical note "
+            "into a concise summary that a patient can easily understand.  Preserve all "
+            "important medical facts (symptoms, diagnoses, treatments, follow‑up), but remove "
+            "billing codes and technical jargon.  Write in plain language at about an 8th "
+            "grade reading level.  Do not invent information that is not present in the note. "
+            "Do not include any patient identifiers or PHI."
+        ),
+        "es": (
+            "Usted es un experto comunicador clínico. Reescriba la siguiente nota clínica en un resumen conciso que un paciente pueda entender fácilmente. Preserve todos los hechos médicos importantes (síntomas, diagnósticos, tratamientos, seguimiento), pero elimine los códigos de facturación y la jerga técnica. Escriba en un lenguaje sencillo equivalente a un nivel de lectura de octavo grado. No invente información que no esté presente en la nota. No incluya identificadores del paciente ni PHI."
+        ),
+    }
+    instructions = _get_custom_instruction("summary", lang, specialty, payer) or default_instructions.get(lang, default_instructions["en"])
+    return [
+        {"role": "system", "content": instructions},
         {"role": "user", "content": text},
     ]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ scrubadub
 python-multipart
 presidio-analyzer
 presidio-anonymizer
+pyyaml

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,6 +19,7 @@ This document provides a high‑level overview of the components that make up th
 
 - **FastAPI application** (`main.py`): Exposes endpoints to beautify notes (`/beautify`), suggest codes and compliance (`/suggest`), generate patient‑friendly summaries (`/summarize`), record analytics events (`/event`), return aggregated metrics (`/metrics`), stream events (`/events`) and set the OpenAI API key (`/apikey`).  It also initialises a SQLite database in the user's data directory to persist events.
 - **Prompt templates** (`prompts.py`): Contains functions to build chat prompts for beautification, suggestion generation and summarisation.  Each prompt includes system instructions emphasising de‑identification, no hallucination and JSON output formats.
+ - **Prompt templates** (`prompts.py`): Contains functions to build chat prompts for beautification, suggestion generation and summarisation.  Each prompt includes system instructions emphasising de‑identification, no hallucination and JSON output formats.  Prompts accept a `lang` parameter (`en` or `es`) and may load overrides from `backend/prompt_templates.json` or `.yaml` keyed by specialty or payer.
 - **OpenAI client wrapper** (`openai_client.py`): Wraps `openai.ChatCompletion.create` and reads the API key either from the environment or from `openai_key.txt`.  It hides the details of the OpenAI SDK from the rest of the codebase.
 - **Audio processing** (`audio_processing.py`): Provides stubbed functions for diarisation and transcription.  They return empty strings and need to be implemented with real speech‑to‑text libraries (e.g. Whisper, pyannote).  This module demonstrates the expected API and highlights a current gap in functionality.
 
@@ -44,3 +45,7 @@ This document provides a high‑level overview of the components that make up th
 ## Deployment Notes
 
 The current repository is designed for local development.  The `start.sh` script (or `start.ps1` on Windows) runs `uvicorn` for the backend on port 8000 and `npm run dev` for the React frontend on port 5173, setting `VITE_API_URL` accordingly.  In production, the frontend can be bundled with Electron and the backend can be packaged with Gunicorn/Uvicorn.  The roadmap includes tasks for Electron packaging, code‑signing, auto‑updates and migration to a full database such as Postgres.
+
+## Customising Prompt Templates
+
+Prompt instructions can be tailored per specialty or payer.  Create a `backend/prompt_templates.json` or `backend/prompt_templates.yaml` file with entries under `specialty` or `payer` that map to custom `beautify`, `suggest`, or `summary` instructions.  Each instruction can provide translations via `en` and `es` keys.  When a request supplies matching `specialty` or `payer` values, the custom text overrides the default prompts.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,12 @@
         "chart.js": "^4.4.0",
         "dotenv": "^16.6.1",
         "electron-updater": "^6.3.0",
+        "i18next": "^25.3.2",
         "pdfkit": "^0.13.0",
         "react": "^18.2.0",
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.2.0",
+        "react-i18next": "^15.6.1",
         "react-quill": "^2.0.0"
       },
       "devDependencies": {
@@ -300,7 +302,6 @@
       "version": "7.28.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
       "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -5290,6 +5291,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -5357,6 +5367,37 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.0.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.3.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.3.2.tgz",
+      "integrity": "sha512-JSnbZDxRVbphc5jiptxr3o2zocy5dEqpVm9qCGdJwRNO+9saUJS0/u4LnM/13C23fUEWxAylPqKU/NpMV/IjqA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/iconv-corefoundation": {
@@ -7204,6 +7245,32 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.6.1.tgz",
+      "integrity": "sha512-uGrzSsOUUe2sDBG/+FJq2J1MM+Y4368/QW8OLEKSFvnDflHBbZhSd1u3UkW0Z06rMhZmnB/AQrhCpYfE5/5XNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -8319,7 +8386,7 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -8628,6 +8695,15 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -19,10 +19,12 @@
     "chart.js": "^4.4.0",
     "dotenv": "^16.6.1",
     "electron-updater": "^6.3.0",
+    "i18next": "^25.3.2",
     "pdfkit": "^0.13.0",
     "react": "^18.2.0",
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.2.0",
+    "react-i18next": "^15.6.1",
     "react-quill": "^2.0.0"
   },
   "devDependencies": {

--- a/src/api.js
+++ b/src/api.js
@@ -81,7 +81,7 @@ export async function saveSettings(settings) {
  * @param {string} text
  * @returns {Promise<string>}
  */
-export async function beautifyNote(text) {
+export async function beautifyNote(text, lang = 'en') {
   const baseUrl =
     import.meta?.env?.VITE_API_URL ||
     window.__BACKEND_URL__ ||
@@ -91,7 +91,7 @@ export async function beautifyNote(text) {
     const resp = await fetch(`${baseUrl}/beautify`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ text }),
+      body: JSON.stringify({ text, lang }),
     });
     const data = await resp.json();
     return data.beautified;
@@ -116,7 +116,7 @@ export async function getSuggestions(text, context = {}) {
     // Construct the request payload.  Always include the main note text; add
     // optional chart, rules and audio transcript when provided.  The backend
     // should ignore any empty or missing fields.
-    const payload = { text };
+    const payload = { text, lang: context.lang };
     if (context.chart) payload.chart = context.chart;
     if (context.rules && Array.isArray(context.rules) && context.rules.length > 0) {
       payload.rules = context.rules;
@@ -375,7 +375,7 @@ export async function summarizeNote(text, context = {}) {
     window.__BACKEND_URL__ ||
     window.location.origin;
   if (baseUrl) {
-    const payload = { text };
+    const payload = { text, lang: context.lang };
     if (context.chart) payload.chart = context.chart;
     if (context.audio) payload.audio = context.audio;
     try {

--- a/src/components/ClipboardExportButtons.jsx
+++ b/src/components/ClipboardExportButtons.jsx
@@ -1,19 +1,25 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { logEvent } from '../api.js';
 
 function ClipboardExportButtons({ beautified, summary, patientID }) {
+  const { t } = useTranslation();
   const [feedback, setFeedback] = useState('');
 
   const copy = async (text, type) => {
     try {
-      await navigator.clipboard.writeText(text);
-      setFeedback(`${type === 'beautified' ? 'Beautified' : 'Summary'} copied`);
+        await navigator.clipboard.writeText(text);
+        setFeedback(
+          type === 'beautified'
+            ? t('clipboard.beautifiedCopied')
+            : t('clipboard.summaryCopied')
+        );
       if (patientID) {
         logEvent('copy', { patientID, type, length: text.length }).catch(() => {});
       }
       setTimeout(() => setFeedback(''), 2000);
     } catch {
-      setFeedback('Copy failed');
+        setFeedback(t('clipboard.copyFailed'));
     }
   };
 
@@ -23,8 +29,8 @@ function ClipboardExportButtons({ beautified, summary, patientID }) {
         ? window.require('electron').ipcRenderer
         : null;
       if (!ipcRenderer) return;
-      await ipcRenderer.invoke('export-note', { beautified, summary });
-      setFeedback('Exported');
+        await ipcRenderer.invoke('export-note', { beautified, summary });
+        setFeedback(t('clipboard.exported'));
       if (patientID) {
         logEvent('export', {
           patientID,
@@ -34,21 +40,21 @@ function ClipboardExportButtons({ beautified, summary, patientID }) {
       }
       setTimeout(() => setFeedback(''), 2000);
     } catch {
-      setFeedback('Export failed');
+        setFeedback(t('clipboard.exportFailed'));
     }
   };
 
   return (
     <>
-      <button disabled={!beautified} onClick={() => copy(beautified, 'beautified')}>
-        Copy Beautified
-      </button>
-      <button disabled={!summary} onClick={() => copy(summary, 'summary')}>
-        Copy Summary
-      </button>
-      <button disabled={!beautified && !summary} onClick={exportNote}>
-        Export
-      </button>
+        <button disabled={!beautified} onClick={() => copy(beautified, 'beautified')}>
+          {t('clipboard.copyBeautified')}
+        </button>
+        <button disabled={!summary} onClick={() => copy(summary, 'summary')}>
+          {t('clipboard.copySummary')}
+        </button>
+        <button disabled={!beautified && !summary} onClick={exportNote}>
+          {t('clipboard.export')}
+        </button>
       {feedback && <span className="copy-feedback">{feedback}</span>}
     </>
   );

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,5 +1,6 @@
 // Admin dashboard placeholder.  Displays key metrics for the pilot.
 import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { getMetrics } from '../api.js';
 import { Line, Bar, Pie } from 'react-chartjs-2';
 import {
@@ -27,9 +28,10 @@ ChartJS.register(
   Legend
 );
 
-function Dashboard() {
-  // Determine user role from JWT; only admins may view this component.
-  const token =
+  function Dashboard() {
+    const { t } = useTranslation();
+    // Determine user role from JWT; only admins may view this component.
+    const token =
     typeof window !== 'undefined' ? localStorage.getItem('token') : null;
   let role = null;
   if (token) {
@@ -39,9 +41,9 @@ function Dashboard() {
       role = null;
     }
   }
-  if (role !== 'admin') {
-    return <p>Access denied</p>;
-  }
+    if (role !== 'admin') {
+      return <p>{t('dashboard.accessDenied')}</p>;
+    }
 
   // Metrics returned from the API and filter state.
   const [metrics, setMetrics] = useState({});
@@ -57,73 +59,73 @@ function Dashboard() {
   // one decimal place; otherwise show zero.
   const cards = [
     {
-      title: 'Total Notes Created',
+      title: t('dashboard.cards.totalNotes'),
       baseline: 0,
       current: metrics.total_notes || 0,
       direction: 'higher',
     },
     {
-      title: 'Beautified Notes',
+      title: t('dashboard.cards.beautifiedNotes'),
       baseline: 0,
       current: metrics.total_beautify || 0,
       direction: 'higher',
     },
     {
-      title: 'Suggestions Requested',
+      title: t('dashboard.cards.suggestionsRequested'),
       baseline: 0,
       current: metrics.total_suggest || 0,
       direction: 'higher',
     },
     {
-      title: 'Summaries Generated',
+      title: t('dashboard.cards.summariesGenerated'),
       baseline: 0,
       current: metrics.total_summary || 0,
       direction: 'higher',
     },
     {
-      title: 'Chart Uploads',
+      title: t('dashboard.cards.chartUploads'),
       baseline: 0,
       current: metrics.total_chart_upload || 0,
       direction: 'higher',
     },
     {
-      title: 'Audio Recordings',
+      title: t('dashboard.cards.audioRecordings'),
       baseline: 0,
       current: metrics.total_audio || 0,
       direction: 'higher',
     },
     {
-      title: 'Average Note Length (chars)',
+      title: t('dashboard.cards.avgNoteLength'),
       baseline: 0,
       current: metrics.avg_note_length ? metrics.avg_note_length.toFixed(1) : 0,
       direction: 'higher',
     },
     {
-      title: 'Average Beautify Time (s)',
+      title: t('dashboard.cards.avgBeautifyTime'),
       baseline: 0,
       current: metrics.avg_beautify_time ? metrics.avg_beautify_time.toFixed(1) : 0,
       direction: 'lower',
     },
     {
-      title: 'Revenue per Visit',
+      title: t('dashboard.cards.revenuePerVisit'),
       baseline: 0,
       current: metrics.revenue_per_visit ? metrics.revenue_per_visit.toFixed(2) : 0,
       direction: 'higher',
     },
     {
-      title: 'Average Time to Close Note (s)',
+      title: t('dashboard.cards.avgCloseTime'),
       baseline: 0,
       current: metrics.avg_close_time ? metrics.avg_close_time.toFixed(1) : 0,
       direction: 'lower',
     },
     {
-      title: 'Denial Rate (%)',
+      title: t('dashboard.cards.denialRate'),
       baseline: 0,
       current: metrics.denial_rate ? (metrics.denial_rate * 100).toFixed(1) : 0,
       direction: 'lower',
     },
     {
-      title: 'Deficiency Rate (%)',
+      title: t('dashboard.cards.deficiencyRate'),
       baseline: 0,
       current: metrics.deficiency_rate ? (metrics.deficiency_rate * 100).toFixed(1) : 0,
       direction: 'lower',
@@ -200,53 +202,53 @@ function Dashboard() {
     ],
   };
 
-  const denialData = {
-    labels: Object.keys(metrics.denial_rates || {}),
-    datasets: [
-      {
-        label: 'Denial Rate (%)',
-        data: Object.values(metrics.denial_rates || {}).map((r) => r * 100),
-        backgroundColor: 'rgba(255, 159, 64, 0.6)',
-      },
-    ],
-  };
+    const denialData = {
+      labels: Object.keys(metrics.denial_rates || {}),
+      datasets: [
+        {
+          label: t('dashboard.denialRateLabel'),
+          data: Object.values(metrics.denial_rates || {}).map((r) => r * 100),
+          backgroundColor: 'rgba(255, 159, 64, 0.6)',
+        },
+      ],
+    };
   return (
-    <div className="dashboard">
-      <h2>Analytics Dashboard</h2>
-      <div className="filters" style={{ marginBottom: '1rem' }}>
-        <label>
-          Start
-          <input
-            type="date"
-            value={inputs.start}
-            onChange={(e) => setInputs({ ...inputs, start: e.target.value })}
-          />
-        </label>
-        <label style={{ marginLeft: '0.5rem' }}>
-          End
-          <input
-            type="date"
-            value={inputs.end}
-            onChange={(e) => setInputs({ ...inputs, end: e.target.value })}
-          />
-        </label>
-        <label style={{ marginLeft: '0.5rem' }}>
-          Clinician
-          <input
-            type="text"
-            value={inputs.clinician}
-            onChange={(e) =>
-              setInputs({ ...inputs, clinician: e.target.value })
-            }
-          />
-        </label>
-        <button
-          style={{ marginLeft: '0.5rem' }}
-          onClick={() => setFilters(inputs)}
-        >
-          Apply
-        </button>
-      </div>
+      <div className="dashboard">
+        <h2>{t('dashboard.title')}</h2>
+        <div className="filters" style={{ marginBottom: '1rem' }}>
+          <label>
+            {t('dashboard.start')}
+            <input
+              type="date"
+              value={inputs.start}
+              onChange={(e) => setInputs({ ...inputs, start: e.target.value })}
+            />
+          </label>
+          <label style={{ marginLeft: '0.5rem' }}>
+            {t('dashboard.end')}
+            <input
+              type="date"
+              value={inputs.end}
+              onChange={(e) => setInputs({ ...inputs, end: e.target.value })}
+            />
+          </label>
+          <label style={{ marginLeft: '0.5rem' }}>
+            {t('dashboard.clinician')}
+            <input
+              type="text"
+              value={inputs.clinician}
+              onChange={(e) =>
+                setInputs({ ...inputs, clinician: e.target.value })
+              }
+            />
+          </label>
+          <button
+            style={{ marginLeft: '0.5rem' }}
+            onClick={() => setFilters(inputs)}
+          >
+            {t('dashboard.apply')}
+          </button>
+        </div>
       <div className="metrics-grid">
         {cards.map((m) => {
           const change = computeChange(m);
@@ -267,9 +269,9 @@ function Dashboard() {
           }
           return (
             <div key={m.title} className="metric-card">
-              <h3>{m.title}</h3>
-              <p><strong>Baseline:</strong> {m.baseline}</p>
-              <p><strong>Current:</strong> {m.current}</p>
+                <h3>{m.title}</h3>
+                <p><strong>{t('dashboard.baseline')}</strong> {m.baseline}</p>
+                <p><strong>{t('dashboard.current')}</strong> {m.current}</p>
               {arrow && (
                 <p style={{ color: colour, fontWeight: 'bold' }}>{diffLabel}</p>
               )}
@@ -291,26 +293,26 @@ function Dashboard() {
       </div>
       {metrics.timeseries && (
         <div className="timeseries" style={{ marginTop: '1rem' }}>
-          <h3>Daily Events</h3>
-          <Line data={dailyData} data-testid="daily-line" />
-          <h3 style={{ marginTop: '1rem' }}>Weekly Events</h3>
-          <Line data={weeklyData} data-testid="weekly-line" />
+            <h3>{t('dashboard.dailyEvents')}</h3>
+            <Line data={dailyData} data-testid="daily-line" />
+            <h3 style={{ marginTop: '1rem' }}>{t('dashboard.weeklyEvents')}</h3>
+            <Line data={weeklyData} data-testid="weekly-line" />
         </div>
       )}
 
       {metrics.coding_distribution &&
         Object.keys(metrics.coding_distribution).length > 0 && (
           <div style={{ marginTop: '1rem' }}>
-            <h3>Coding Distribution</h3>
-            <Pie data={codingData} data-testid="codes-pie" />
+              <h3>{t('dashboard.codingDistribution')}</h3>
+              <Pie data={codingData} data-testid="codes-pie" />
           </div>
         )}
 
       {metrics.denial_rates &&
         Object.keys(metrics.denial_rates).length > 0 && (
           <div style={{ marginTop: '1rem' }}>
-            <h3>Denial Rates</h3>
-            <Bar data={denialData} data-testid="denial-bar" />
+              <h3>{t('dashboard.denialRates')}</h3>
+              <Bar data={denialData} data-testid="denial-bar" />
           </div>
         )}
     </div>

--- a/src/components/Drafts.jsx
+++ b/src/components/Drafts.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
 /**
  * Drafts view component.  Lists saved drafts by patient ID and allows
@@ -10,6 +11,7 @@ import { useEffect, useState } from 'react';
  * localStorage and updates the list.
  */
 function Drafts({ onOpenDraft }) {
+  const { t } = useTranslation();
   const [drafts, setDrafts] = useState([]);
 
   // Load drafts from localStorage on mount
@@ -40,14 +42,14 @@ function Drafts({ onOpenDraft }) {
   };
 
   return (
-    <div className="drafts-view">
-      <h2>Saved Drafts</h2>
-      {drafts.length === 0 ? (
-        <p>No drafts saved.</p>
-      ) : (
-        <ul className="drafts-list">
-          {drafts.map((draft) => (
-            <li key={draft.patientID} className="draft-item">
+      <div className="drafts-view">
+        <h2>{t('drafts.title')}</h2>
+        {drafts.length === 0 ? (
+          <p>{t('drafts.none')}</p>
+        ) : (
+          <ul className="drafts-list">
+            {drafts.map((draft) => (
+              <li key={draft.patientID} className="draft-item">
               <div className="draft-info">
                 <button
                   className="draft-open-btn"
@@ -57,14 +59,14 @@ function Drafts({ onOpenDraft }) {
                 </button>
                 <span className="draft-snippet">{draft.snippet}{draft.snippet.length >= 100 ? '…' : ''}</span>
               </div>
-              <button
-                className="draft-delete-btn"
-                onClick={() => handleDelete(draft.patientID)}
-                title="Delete draft"
-              >
-                ✕
-              </button>
-            </li>
+                <button
+                  className="draft-delete-btn"
+                  onClick={() => handleDelete(draft.patientID)}
+                  title={t('drafts.delete')}
+                >
+                  ✕
+                </button>
+              </li>
           ))}
         </ul>
       )}

--- a/src/components/Help.jsx
+++ b/src/components/Help.jsx
@@ -1,67 +1,30 @@
 // Help page component explaining how to use the RevenuePilot app.
+import { useTranslation } from 'react-i18next';
 
 function Help() {
+  const { t } = useTranslation();
   return (
     <div className="help-page" style={{ padding: '1rem', overflowY: 'auto' }}>
-      <h2>Welcome to RevenuePilot</h2>
-      <p>
-        This short guide will walk you through the basics of using the RevenuePilot
-        app.  Whether you&rsquo;re creating your first clinical note or reviewing
-        analytics, the app is designed to assist you at every step.
-      </p>
-      <h3>Writing a Note</h3>
+      <h2>{t('help.welcomeTitle')}</h2>
+      <p>{t('help.intro')}</p>
+      <h3>{t('help.writingTitle')}</h3>
       <ul>
-        <li>
-          Use the <strong>Original Note</strong> tab to type or paste your draft clinical note.
-        </li>
-        <li>
-          The AI suggestion panel on the right will populate codes, compliance
-          alerts, public health prompts, and differential diagnoses as you type.
-        </li>
-        <li>
-          When you&rsquo;re ready to produce a polished version, click <strong>Beautify</strong>.
-          A separate <strong>Beautified Note</strong> tab will appear with a cleaned, professional
-          version of your draft.  Your original text remains untouched.
-        </li>
-        <li>
-          Use the <strong>Copy</strong> button to copy the beautified note to your clipboard for
-          pasting into your EHR or another system.
-        </li>
-        <li>
-          You can insert predefined templates from the dropdown in the toolbar (e.g., SOAP
-          note, wellness visit, follow‑up).  Selecting a template replaces your draft
-          with the template content and lets you fill in the sections.
-        </li>
-        <li>
-          Enter a <strong>Patient ID</strong> in the toolbar to automatically save and
-          reload drafts.  RevenuePilot stores your draft locally under that ID, so you
-          can return to finish documentation later.
-        </li>
+        <li dangerouslySetInnerHTML={{ __html: t('help.writing1') }} />
+        <li dangerouslySetInnerHTML={{ __html: t('help.writing2') }} />
+        <li dangerouslySetInnerHTML={{ __html: t('help.writing3') }} />
+        <li dangerouslySetInnerHTML={{ __html: t('help.writing4') }} />
+        <li dangerouslySetInnerHTML={{ __html: t('help.writing5') }} />
+        <li dangerouslySetInnerHTML={{ __html: t('help.writing6') }} />
       </ul>
-      <h3>Viewing Analytics</h3>
+      <h3>{t('help.analyticsTitle')}</h3>
       <ul>
-        <li>
-          Click <strong>Dashboard</strong> in the toolbar to switch to the analytics view.
-        </li>
-        <li>
-          The dashboard shows key metrics such as average revenue per visit,
-          documentation deficiency rates, and provider confidence.  These
-          metrics will update as you use RevenuePilot.
-        </li>
-        <li>
-          To return to your notes, click <strong>Back to Notes</strong> in the toolbar.
-        </li>
+        <li dangerouslySetInnerHTML={{ __html: t('help.analytics1') }} />
+        <li dangerouslySetInnerHTML={{ __html: t('help.analytics2') }} />
+        <li dangerouslySetInnerHTML={{ __html: t('help.analytics3') }} />
       </ul>
-      <h3>Privacy & Compliance</h3>
-      <p>
-        RevenuePilot takes patient privacy seriously.  Notes are de‑identified on
-        your device before being sent to AI services; phone numbers, dates,
-        addresses, emails and other identifiers are scrubbed to protect PHI.
-      </p>
-      <p>
-        If you have any questions or encounter issues, please reach out to
-        your project manager or support team for assistance.
-      </p>
+      <h3>{t('help.privacyTitle')}</h3>
+      <p>{t('help.privacy1')}</p>
+      <p>{t('help.privacy2')}</p>
     </div>
   );
 }

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { login } from '../api.js';
 
 /**
@@ -7,6 +8,7 @@ import { login } from '../api.js';
  * so the application can render the secured views.
  */
 function Login({ onLoggedIn }) {
+  const { t } = useTranslation();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState(null);
@@ -31,40 +33,40 @@ function Login({ onLoggedIn }) {
 
   return (
     <div className="login-form" style={{ maxWidth: '20rem', margin: '2rem auto' }}>
-      <h2>Login</h2>
-      <form onSubmit={handleSubmit}>
-        <div style={{ marginBottom: '0.5rem' }}>
-          <label>
-            Username
-            <input
-              type="text"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-              required
-            />
-          </label>
-        </div>
-        <div style={{ marginBottom: '0.5rem' }}>
-          <label>
-            Password
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-            />
-          </label>
-        </div>
+        <h2>{t('login.title')}</h2>
+        <form onSubmit={handleSubmit}>
+          <div style={{ marginBottom: '0.5rem' }}>
+            <label>
+              {t('login.username')}
+              <input
+                type="text"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                required
+              />
+            </label>
+          </div>
+          <div style={{ marginBottom: '0.5rem' }}>
+            <label>
+              {t('login.password')}
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+              />
+            </label>
+          </div>
         {error && (
           <p style={{ color: 'red' }} data-testid="login-error">
             {error}
           </p>
         )}
-        <button type="submit" disabled={loading}>
-          {loading ? 'Logging in…' : 'Login'}
-        </button>
-      </form>
-    </div>
+          <button type="submit" disabled={loading}>
+            {loading ? t('login.loggingIn') : t('login.login')}
+          </button>
+        </form>
+      </div>
   );
 }
 

--- a/src/components/Logs.jsx
+++ b/src/components/Logs.jsx
@@ -4,6 +4,7 @@
 // user actions and verify that events are being logged correctly.
 
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { getEvents } from '../api.js';
 
 function formatTimestamp(ts) {
@@ -15,9 +16,10 @@ function formatTimestamp(ts) {
   }
 }
 
-export default function Logs() {
-  const [events, setEvents] = useState([]);
-  const [loading, setLoading] = useState(true);
+  export default function Logs() {
+    const { t } = useTranslation();
+    const [events, setEvents] = useState([]);
+    const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     // Fetch events when component mounts
@@ -31,19 +33,14 @@ export default function Logs() {
   }, []);
 
   return (
-    <div className="logs-page" style={{ padding: '1rem', overflowY: 'auto' }}>
-      <h2>Event Log</h2>
-      <p style={{ fontSize: '0.9rem', color: '#6B7280' }}>
-        This log shows recent actions captured by the app. Use it to verify
-        that events such as note creation, beautification, suggestions,
-        summaries, chart uploads and audio recordings are being logged and
-        processed.
-      </p>
-      {loading ? (
-        <p>Loading…</p>
-      ) : events.length === 0 ? (
-        <p>No events recorded yet.</p>
-      ) : (
+      <div className="logs-page" style={{ padding: '1rem', overflowY: 'auto' }}>
+        <h2>{t('logs.title')}</h2>
+        <p style={{ fontSize: '0.9rem', color: '#6B7280' }}>{t('logs.intro')}</p>
+        {loading ? (
+          <p>{t('logs.loading')}</p>
+        ) : events.length === 0 ? (
+          <p>{t('logs.none')}</p>
+        ) : (
         <div style={{ border: '1px solid var(--disabled)', borderRadius: '4px', padding: '0.5rem', maxHeight: '60vh', overflowY: 'scroll' }}>
           {events.map((ev, idx) => (
             <div key={idx} style={{ marginBottom: '0.5rem' }}>

--- a/src/components/NoteEditor.jsx
+++ b/src/components/NoteEditor.jsx
@@ -8,6 +8,7 @@
 // development can proceed without breaking the UI.
 
 import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 let ReactQuill;
 try {
   // Dynamically require ReactQuill to avoid breaking when the package is
@@ -24,6 +25,7 @@ try {
 }
 
 function NoteEditor({ id, value, onChange, onRecord, recording = false, transcript = '' }) {
+  const { t } = useTranslation();
   // Maintain a local state for the editor's HTML value when using the
   // fallback <textarea>.  This allows the component to behave as a
   // controlled input in both modes.
@@ -46,15 +48,15 @@ function NoteEditor({ id, value, onChange, onRecord, recording = false, transcri
   const toolbar = (
     <div style={{ marginBottom: '0.5rem' }}>
       {onRecord && (
-        <button type="button" onClick={onRecord}>
-          {recording ? 'Stop Recording' : 'Record Audio'}
-        </button>
+          <button type="button" onClick={onRecord}>
+            {recording ? t('noteEditor.stopRecording') : t('noteEditor.recordAudio')}
+          </button>
       )}
       {transcript && (
         <span
           style={{ fontSize: '0.8rem', marginLeft: '0.5rem', color: 'var(--secondary)' }}
         >
-          Transcript: {transcript}
+            {t('noteEditor.transcript')} {transcript}
         </span>
       )}
     </div>
@@ -86,8 +88,8 @@ function NoteEditor({ id, value, onChange, onRecord, recording = false, transcri
         value={localValue}
         onChange={handleTextAreaChange}
         style={{ width: '100%', height: '100%', padding: '0.5rem' }}
-        placeholder="Type your clinical note here..."
-      />
+          placeholder={t('noteEditor.placeholder')}
+        />
     </div>
   );
 }

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,23 +1,25 @@
 // Sidebar navigation component.  Provides top-level navigation and a collapse toggle.
+import { useTranslation } from 'react-i18next';
 
 function Sidebar({ collapsed, toggleCollapsed, onNavigate }) {
+  const { t } = useTranslation();
   const items = [
-    { key: 'note', label: 'Notes' },
-    { key: 'drafts', label: 'Drafts' },
-    { key: 'dashboard', label: 'Analytics' },
-    { key: 'logs', label: 'Logs' },
-    { key: 'settings', label: 'Settings' },
-    { key: 'help', label: 'Help' },
+    { key: 'note', label: t('sidebar.notes') },
+    { key: 'drafts', label: t('sidebar.drafts') },
+    { key: 'dashboard', label: t('sidebar.analytics') },
+    { key: 'logs', label: t('sidebar.logs') },
+    { key: 'settings', label: t('sidebar.settings') },
+    { key: 'help', label: t('sidebar.help') },
   ];
   return (
     <div className={`sidebar ${collapsed ? 'collapsed' : ''}`}>
       <button
         className="collapse-btn"
         onClick={toggleCollapsed}
-        title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-      >
-        ☰
-      </button>
+          title={collapsed ? t('sidebar.expand') : t('sidebar.collapse')}
+        >
+          ☰
+        </button>
       <nav className="nav-items">
         {items.map((item) => (
           <button key={item.key} onClick={() => onNavigate(item.key)}>

--- a/src/components/SuggestionPanel.jsx
+++ b/src/components/SuggestionPanel.jsx
@@ -1,20 +1,22 @@
 // Suggestion panel rendering four expandable cards.  Clicking a suggestion
 // inserts it into the note editor via the onInsert callback.
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
-function SuggestionPanel({
-  suggestions,
-  loading,
-  className = '',
-  onInsert,
-}) {
-  // suggestions: { codes: [], compliance: [], publicHealth: [], differentials: [] }
-  const cards = [
-    { type: 'codes', key: 'codes', title: 'Codes & Rationale', items: suggestions?.codes || [] },
-    { type: 'compliance', key: 'compliance', title: 'Compliance Alerts', items: suggestions?.compliance || [] },
-    { type: 'public-health', key: 'publicHealth', title: 'Public Health', items: suggestions?.publicHealth || [] },
-    { type: 'differentials', key: 'differentials', title: 'Differentials', items: suggestions?.differentials || [] },
-  ];
+  function SuggestionPanel({
+    suggestions,
+    loading,
+    className = '',
+    onInsert,
+  }) {
+    const { t } = useTranslation();
+    // suggestions: { codes: [], compliance: [], publicHealth: [], differentials: [] }
+    const cards = [
+      { type: 'codes', key: 'codes', title: t('suggestion.codes'), items: suggestions?.codes || [] },
+      { type: 'compliance', key: 'compliance', title: t('suggestion.compliance'), items: suggestions?.compliance || [] },
+      { type: 'public-health', key: 'publicHealth', title: t('suggestion.publicHealth'), items: suggestions?.publicHealth || [] },
+      { type: 'differentials', key: 'differentials', title: t('suggestion.differentials'), items: suggestions?.differentials || [] },
+    ];
 
   const [openState, setOpenState] = useState({
     codes: true,
@@ -28,20 +30,20 @@ function SuggestionPanel({
   };
 
   const renderItems = (items) => {
-    if (loading) {
-      return (
-        <li style={{ color: '#9AA3B2', fontStyle: 'italic' }}>
-          Loading suggestions...
-        </li>
-      );
-    }
-    if (!items || items.length === 0) {
-      return (
-        <li style={{ color: '#9AA3B2', fontStyle: 'italic' }}>
-          No suggestions yet
-        </li>
-      );
-    }
+      if (loading) {
+        return (
+          <li style={{ color: '#9AA3B2', fontStyle: 'italic' }}>
+            {t('suggestion.loading')}
+          </li>
+        );
+      }
+      if (!items || items.length === 0) {
+        return (
+          <li style={{ color: '#9AA3B2', fontStyle: 'italic' }}>
+            {t('suggestion.none')}
+          </li>
+        );
+      }
     return items.map((item, idx) => {
       if (typeof item === 'object' && item !== null && 'code' in item) {
         const text = item.rationale

--- a/src/components/TemplatesModal.jsx
+++ b/src/components/TemplatesModal.jsx
@@ -1,7 +1,9 @@
 import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { getTemplates, createTemplate } from '../api.js';
 
 function TemplatesModal({ baseTemplates, onSelect, onClose }) {
+  const { t } = useTranslation();
   const [templates, setTemplates] = useState(baseTemplates);
   const [name, setName] = useState('');
   const [content, setContent] = useState('');
@@ -24,45 +26,45 @@ function TemplatesModal({ baseTemplates, onSelect, onClose }) {
 
   return (
     <div className="modal-overlay">
-      <div className="modal card">
-        <h3>Templates</h3>
-        <ul>
-          {templates.map((tpl) => (
-            <li key={tpl.id || tpl.name}>
-              <button
-                onClick={() => onSelect(tpl.content)}
-                style={{ margin: '0.25rem 0' }}
-              >
-                {tpl.name}
-              </button>
-            </li>
-          ))}
-        </ul>
-        <h4>Create Template</h4>
-        <input
-          type="text"
-          placeholder="Name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          style={{ width: '100%', marginBottom: '0.5rem' }}
-        />
-        <textarea
-          placeholder="Content"
-          value={content}
-          onChange={(e) => setContent(e.target.value)}
-          rows={4}
-          style={{ width: '100%' }}
-        />
-        <div style={{ marginTop: '0.5rem' }}>
-          <button onClick={handleCreate} disabled={!name.trim() || !content.trim()}>
-            Save
-          </button>
-          <button onClick={onClose} style={{ marginLeft: '0.5rem' }}>
-            Close
-          </button>
+        <div className="modal card">
+          <h3>{t('templatesModal.title')}</h3>
+          <ul>
+            {templates.map((tpl) => (
+              <li key={tpl.id || tpl.name}>
+                <button
+                  onClick={() => onSelect(tpl.content)}
+                  style={{ margin: '0.25rem 0' }}
+                >
+                  {tpl.name}
+                </button>
+              </li>
+            ))}
+          </ul>
+          <h4>{t('templatesModal.create')}</h4>
+          <input
+            type="text"
+            placeholder={t('templatesModal.name')}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            style={{ width: '100%', marginBottom: '0.5rem' }}
+          />
+          <textarea
+            placeholder={t('templatesModal.content')}
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            rows={4}
+            style={{ width: '100%' }}
+          />
+          <div style={{ marginTop: '0.5rem' }}>
+            <button onClick={handleCreate} disabled={!name.trim() || !content.trim()}>
+              {t('templatesModal.save')}
+            </button>
+            <button onClick={onClose} style={{ marginLeft: '0.5rem' }}>
+              {t('templatesModal.close')}
+            </button>
+          </div>
         </div>
       </div>
-    </div>
   );
 }
 

--- a/src/components/__tests__/ClipboardExportButtons.test.jsx
+++ b/src/components/__tests__/ClipboardExportButtons.test.jsx
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 import { render, fireEvent, waitFor, cleanup } from '@testing-library/react';
 import { vi, describe, test, expect, beforeEach, afterEach } from 'vitest';
+import '../../i18n.js';
 import ClipboardExportButtons from '../ClipboardExportButtons.jsx';
 import * as api from '../../api.js';
 

--- a/src/components/__tests__/Dashboard.test.jsx
+++ b/src/components/__tests__/Dashboard.test.jsx
@@ -2,6 +2,7 @@
 import { render, waitFor, cleanup } from '@testing-library/react';
 import Dashboard from '../Dashboard.jsx';
 import { vi, beforeEach, test, expect, afterEach } from 'vitest';
+import '../../i18n.js';
 
 HTMLCanvasElement.prototype.getContext = vi.fn();
 

--- a/src/components/__tests__/Login.test.jsx
+++ b/src/components/__tests__/Login.test.jsx
@@ -2,6 +2,7 @@
 
 import { render, fireEvent, waitFor, cleanup } from '@testing-library/react';
 import { vi, expect, test, beforeEach, afterEach } from 'vitest';
+import '../../i18n.js';
 
 vi.mock('../../api.js', () => ({ login: vi.fn() }));
 import { login } from '../../api.js';

--- a/src/components/__tests__/NoteEditor.test.jsx
+++ b/src/components/__tests__/NoteEditor.test.jsx
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 import { render, cleanup, fireEvent } from '@testing-library/react';
 import { vi, expect, test, afterEach } from 'vitest';
+import '../../i18n.js';
 import NoteEditor from '../NoteEditor.jsx';
 
 afterEach(() => cleanup());

--- a/src/components/__tests__/Settings.test.jsx
+++ b/src/components/__tests__/Settings.test.jsx
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import { vi, expect, test, beforeEach } from 'vitest';
+import '../../i18n.js';
 
 vi.mock('../../api.js', () => ({ setApiKey: vi.fn(), saveSettings: vi.fn() }));
 import { saveSettings } from '../../api.js';
@@ -11,14 +12,15 @@ beforeEach(() => {
 });
 
 test('saveSettings called when preferences change', async () => {
-  const settings = {
-    theme: 'modern',
-    enableCodes: true,
-    enableCompliance: true,
-    enablePublicHealth: true,
-    enableDifferentials: true,
-    rules: [],
-  };
+    const settings = {
+      theme: 'modern',
+      enableCodes: true,
+      enableCompliance: true,
+      enablePublicHealth: true,
+      enableDifferentials: true,
+      rules: [],
+      lang: 'en',
+    };
   const updateSettings = vi.fn();
   const { getByLabelText } = render(
     <Settings settings={settings} updateSettings={updateSettings} />

--- a/src/components/__tests__/SuggestionPanel.test.jsx
+++ b/src/components/__tests__/SuggestionPanel.test.jsx
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 import { render, fireEvent, cleanup } from '@testing-library/react';
 import { vi, expect, test, afterEach } from 'vitest';
+import '../../i18n.js';
 import SuggestionPanel from '../SuggestionPanel.jsx';
 
 afterEach(() => cleanup());

--- a/src/components/__tests__/TemplatesModal.test.jsx
+++ b/src/components/__tests__/TemplatesModal.test.jsx
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 import { render, fireEvent, cleanup } from '@testing-library/react';
 import { vi, test, expect, afterEach } from 'vitest';
+import '../../i18n.js';
 import TemplatesModal from '../TemplatesModal.jsx';
 
 vi.mock('../../api.js', () => ({

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,16 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import en from './locales/en.json';
+import es from './locales/es.json';
+
+i18n.use(initReactI18next).init({
+  resources: {
+    en: { translation: en },
+    es: { translation: es },
+  },
+  lng: 'en',
+  fallbackLng: 'en',
+  interpolation: { escapeValue: false },
+});
+
+export default i18n;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,151 @@
+{
+  "clipboard": {
+    "copyBeautified": "Copy Beautified",
+    "copySummary": "Copy Summary",
+    "export": "Export",
+    "beautifiedCopied": "Beautified copied",
+    "summaryCopied": "Summary copied",
+    "copyFailed": "Copy failed",
+    "exported": "Exported",
+    "exportFailed": "Export failed"
+  },
+  "dashboard": {
+    "accessDenied": "Access denied",
+    "title": "Analytics Dashboard",
+    "start": "Start",
+    "end": "End",
+    "clinician": "Clinician",
+    "apply": "Apply",
+    "dailyEvents": "Daily Events",
+    "weeklyEvents": "Weekly Events",
+    "codingDistribution": "Coding Distribution",
+    "denialRates": "Denial Rates",
+    "denialRateLabel": "Denial Rate (%)",
+    "cards": {
+      "totalNotes": "Total Notes Created",
+      "beautifiedNotes": "Beautified Notes",
+      "suggestionsRequested": "Suggestions Requested",
+      "summariesGenerated": "Summaries Generated",
+      "chartUploads": "Chart Uploads",
+      "audioRecordings": "Audio Recordings",
+      "avgNoteLength": "Average Note Length (chars)",
+      "avgBeautifyTime": "Average Beautify Time (s)",
+      "revenuePerVisit": "Revenue per Visit",
+      "avgCloseTime": "Average Time to Close Note (s)",
+      "denialRate": "Denial Rate (%)",
+      "deficiencyRate": "Deficiency Rate (%)"
+    },
+    "baseline": "Baseline:",
+    "current": "Current:"
+  },
+  "drafts": {
+    "title": "Saved Drafts",
+    "none": "No drafts saved.",
+    "delete": "Delete draft"
+  },
+  "help": {
+    "welcomeTitle": "Welcome to RevenuePilot",
+    "intro": "This short guide will walk you through the basics of using the RevenuePilot app. Whether you’re creating your first clinical note or reviewing analytics, the app is designed to assist you at every step.",
+    "writingTitle": "Writing a Note",
+    "writing1": "Use the <strong>Original Note</strong> tab to type or paste your draft clinical note.",
+    "writing2": "The AI suggestion panel on the right will populate codes, compliance alerts, public health prompts, and differential diagnoses as you type.",
+    "writing3": "When you’re ready to produce a polished version, click <strong>Beautify</strong>. A separate <strong>Beautified Note</strong> tab will appear with a cleaned, professional version of your draft. Your original text remains untouched.",
+    "writing4": "Use the <strong>Copy</strong> button to copy the beautified note to your clipboard for pasting into your EHR or another system.",
+    "writing5": "You can insert predefined templates from the dropdown in the toolbar (e.g., SOAP note, wellness visit, follow‑up). Selecting a template replaces your draft with the template content and lets you fill in the sections.",
+    "writing6": "Enter a <strong>Patient ID</strong> in the toolbar to automatically save and reload drafts. RevenuePilot stores your draft locally under that ID, so you can return to finish documentation later.",
+    "analyticsTitle": "Viewing Analytics",
+    "analytics1": "Click <strong>Dashboard</strong> in the toolbar to switch to the analytics view.",
+    "analytics2": "The dashboard shows key metrics such as average revenue per visit, documentation deficiency rates, and provider confidence. These metrics will update as you use RevenuePilot.",
+    "analytics3": "To return to your notes, click <strong>Back to Notes</strong> in the toolbar.",
+    "privacyTitle": "Privacy & Compliance",
+    "privacy1": "RevenuePilot takes patient privacy seriously. Notes are de‑identified on your device before being sent to AI services; phone numbers, dates, addresses, emails and other identifiers are scrubbed to protect PHI.",
+    "privacy2": "If you have any questions or encounter issues, please reach out to your project manager or support team for assistance."
+  },
+  "login": {
+    "title": "Login",
+    "username": "Username",
+    "password": "Password",
+    "loggingIn": "Logging in…",
+    "login": "Login"
+  },
+  "logs": {
+    "title": "Event Log",
+    "intro": "This log shows recent actions captured by the app. Use it to verify that events such as note creation, beautification, suggestions, summaries, chart uploads and audio recordings are being logged and processed.",
+    "loading": "Loading…",
+    "none": "No events recorded yet."
+  },
+  "noteEditor": {
+    "stopRecording": "Stop Recording",
+    "recordAudio": "Record Audio",
+    "transcript": "Transcript:",
+    "placeholder": "Type your clinical note here..."
+  },
+  "settings": {
+    "title": "Settings",
+    "apiKey": "OpenAI API Key",
+    "apiKeyHelp": "Enter your OpenAI API key here. The key will be stored securely on your machine and used by the backend to call the language model. You can update it at any time.",
+    "saveKey": "Save Key",
+    "theme": "Theme",
+    "modern": "Modern Minimal",
+    "dark": "Dark Elegance",
+    "warm": "Warm Professional",
+    "suggestionCategories": "Suggestion Categories",
+    "showCodes": "Show Codes & Rationale",
+    "showCompliance": "Show Compliance Alerts",
+    "showPublicHealth": "Show Public Health Prompts",
+    "showDifferentials": "Show Differential Diagnoses",
+    "customRules": "Custom Clinical Rules",
+    "customRulesHelp": "Enter one rule per line. These rules will be passed to the AI model to customise suggestions based on payer or clinic‑specific requirements.",
+    "customRulesPlaceholder": "e.g. Commercial payer X requires three ROS for 99214; Include time spent on counselling for CPT 99406",
+    "language": "Language",
+    "templates": "Templates",
+    "noTemplates": "No templates",
+    "english": "English",
+    "spanish": "Spanish"
+  },
+  "sidebar": {
+    "notes": "Notes",
+    "drafts": "Drafts",
+    "analytics": "Analytics",
+    "logs": "Logs",
+    "settings": "Settings",
+    "help": "Help",
+    "expand": "Expand sidebar",
+    "collapse": "Collapse sidebar"
+  },
+  "suggestion": {
+    "codes": "Codes & Rationale",
+    "compliance": "Compliance Alerts",
+    "publicHealth": "Public Health",
+    "differentials": "Differentials",
+    "loading": "Loading suggestions...",
+    "none": "No suggestions yet"
+  },
+  "templatesModal": {
+    "title": "Templates",
+    "create": "Create Template",
+    "name": "Name",
+    "content": "Content",
+    "save": "Save",
+    "close": "Close",
+    "delete": "Delete"
+  },
+  "app": {
+    "back": "Back to Notes",
+    "file": "File",
+    "patientId": "Patient ID",
+    "templates": "Templates",
+    "beautifying": "Beautifying…",
+    "beautify": "Beautify",
+    "summarizing": "Summarizing…",
+    "summarize": "Summarize",
+    "saveDraft": "Save Draft",
+    "changeChart": "Change Chart",
+    "uploadChart": "Upload Chart",
+    "hideSuggestions": "Hide Suggestions",
+    "showSuggestions": "Show Suggestions",
+    "originalNote": "Original Note",
+    "beautifiedNote": "Beautified Note",
+    "summary": "Summary"
+  }
+}

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1,0 +1,151 @@
+{
+  "clipboard": {
+    "copyBeautified": "Copiar embellecido",
+    "copySummary": "Copiar resumen",
+    "export": "Exportar",
+    "beautifiedCopied": "Nota embellecida copiada",
+    "summaryCopied": "Resumen copiado",
+    "copyFailed": "Error al copiar",
+    "exported": "Exportado",
+    "exportFailed": "Error al exportar"
+  },
+  "dashboard": {
+    "accessDenied": "Acceso denegado",
+    "title": "Panel de análisis",
+    "start": "Inicio",
+    "end": "Fin",
+    "clinician": "Clínico",
+    "apply": "Aplicar",
+    "dailyEvents": "Eventos diarios",
+    "weeklyEvents": "Eventos semanales",
+    "codingDistribution": "Distribución de códigos",
+    "denialRates": "Tasas de denegación",
+    "denialRateLabel": "Tasa de denegación (%)",
+    "cards": {
+      "totalNotes": "Notas totales creadas",
+      "beautifiedNotes": "Notas embellecidas",
+      "suggestionsRequested": "Sugerencias solicitadas",
+      "summariesGenerated": "Resúmenes generados",
+      "chartUploads": "Cargas de gráficos",
+      "audioRecordings": "Grabaciones de audio",
+      "avgNoteLength": "Longitud media de la nota (caracteres)",
+      "avgBeautifyTime": "Tiempo medio de embellecimiento (s)",
+      "revenuePerVisit": "Ingresos por visita",
+      "avgCloseTime": "Tiempo medio para cerrar la nota (s)",
+      "denialRate": "Tasa de denegación (%)",
+      "deficiencyRate": "Tasa de deficiencia (%)"
+    },
+    "baseline": "Línea base:",
+    "current": "Actual:"
+  },
+  "drafts": {
+    "title": "Borradores guardados",
+    "none": "No hay borradores guardados.",
+    "delete": "Eliminar borrador"
+  },
+  "help": {
+    "welcomeTitle": "Bienvenido a RevenuePilot",
+    "intro": "Esta guía rápida le mostrará los fundamentos del uso de la aplicación RevenuePilot. Ya sea que esté creando su primera nota clínica o revisando analíticas, la aplicación está diseñada para asistirle en cada paso.",
+    "writingTitle": "Escribir una nota",
+    "writing1": "Use la <strong>Nota original</strong> para escribir o pegar su borrador de nota clínica.",
+    "writing2": "El panel de sugerencias de IA a la derecha completará códigos, alertas de cumplimiento, indicaciones de salud pública y diagnósticos diferenciales a medida que escribe.",
+    "writing3": "Cuando esté listo para producir una versión pulida, haga clic en <strong>Embellecer</strong>. Aparecerá una pestaña separada de <strong>Nota embellecida</strong> con una versión limpia y profesional de su borrador. Su texto original permanece intacto.",
+    "writing4": "Use el botón <strong>Copiar</strong> para copiar la nota embellecida al portapapeles y pegarla en su EHR u otro sistema.",
+    "writing5": "Puede insertar plantillas predefinidas desde el menú en la barra de herramientas (por ejemplo, nota SOAP, visita de bienestar, seguimiento). Seleccionar una plantilla reemplaza su borrador con el contenido de la plantilla y le permite completar las secciones.",
+    "writing6": "Introduzca un <strong>ID de paciente</strong> en la barra de herramientas para guardar y recargar automáticamente los borradores. RevenuePilot almacena su borrador localmente bajo ese ID para que pueda terminar la documentación más tarde.",
+    "analyticsTitle": "Ver analíticas",
+    "analytics1": "Haga clic en <strong>Panel</strong> en la barra de herramientas para cambiar a la vista de analíticas.",
+    "analytics2": "El panel muestra métricas clave como ingresos medios por visita, tasas de deficiencia de documentación y confianza del proveedor. Estas métricas se actualizarán a medida que use RevenuePilot.",
+    "analytics3": "Para volver a sus notas, haga clic en <strong>Volver a las notas</strong> en la barra de herramientas.",
+    "privacyTitle": "Privacidad y cumplimiento",
+    "privacy1": "RevenuePilot se toma en serio la la privacidad del paciente. Las notas se desidentifican en su dispositivo antes de enviarse a los servicios de IA; se eliminan números de teléfono, fechas, direcciones, correos electrónicos y otros identificadores para proteger la PHI.",
+    "privacy2": "Si tiene alguna pregunta o encuentra problemas, póngase en contacto con su jefe de proyecto o equipo de soporte para obtener ayuda."
+  },
+  "login": {
+    "title": "Iniciar sesión",
+    "username": "Nombre de usuario",
+    "password": "Contraseña",
+    "loggingIn": "Iniciando sesión…",
+    "login": "Entrar"
+  },
+  "logs": {
+    "title": "Registro de eventos",
+    "intro": "Este registro muestra acciones recientes capturadas por la aplicación. Úselo para verificar que eventos como creación de notas, embellecimiento, sugerencias, resúmenes, cargas de gráficos y grabaciones de audio se están registrando y procesando.",
+    "loading": "Cargando…",
+    "none": "No se han registrado eventos."
+  },
+  "noteEditor": {
+    "stopRecording": "Detener grabación",
+    "recordAudio": "Grabar audio",
+    "transcript": "Transcripción:",
+    "placeholder": "Escriba aquí su nota clínica..."
+  },
+  "settings": {
+    "title": "Configuración",
+    "apiKey": "Clave de API de OpenAI",
+    "apiKeyHelp": "Introduzca aquí su clave de API de OpenAI. La clave se almacenará de forma segura en su máquina y será utilizada por el backend para llamar al modelo de lenguaje. Puede actualizarla en cualquier momento.",
+    "saveKey": "Guardar clave",
+    "theme": "Tema",
+    "modern": "Minimal moderno",
+    "dark": "Elegancia oscura",
+    "warm": "Profesional cálido",
+    "suggestionCategories": "Categorías de sugerencias",
+    "showCodes": "Mostrar códigos y justificación",
+    "showCompliance": "Mostrar alertas de cumplimiento",
+    "showPublicHealth": "Mostrar indicaciones de salud pública",
+    "showDifferentials": "Mostrar diagnósticos diferenciales",
+    "customRules": "Reglas clínicas personalizadas",
+    "customRulesHelp": "Introduzca una regla por línea. Estas reglas se pasarán al modelo de IA para personalizar las sugerencias según requisitos del pagador o de la clínica.",
+    "customRulesPlaceholder": "p. ej., El pagador comercial X requiere tres ROS para 99214; Incluir tiempo dedicado a asesoría para CPT 99406",
+    "language": "Idioma",
+    "templates": "Plantillas",
+    "noTemplates": "Sin plantillas",
+    "english": "Inglés",
+    "spanish": "Español"
+  },
+  "sidebar": {
+    "notes": "Notas",
+    "drafts": "Borradores",
+    "analytics": "Analíticas",
+    "logs": "Registros",
+    "settings": "Configuración",
+    "help": "Ayuda",
+    "expand": "Expandir barra lateral",
+    "collapse": "Contraer barra lateral"
+  },
+  "suggestion": {
+    "codes": "Códigos y justificación",
+    "compliance": "Alertas de cumplimiento",
+    "publicHealth": "Salud pública",
+    "differentials": "Diagnósticos diferenciales",
+    "loading": "Cargando sugerencias...",
+    "none": "Sin sugerencias aún"
+  },
+  "templatesModal": {
+    "title": "Plantillas",
+    "create": "Crear plantilla",
+    "name": "Nombre",
+    "content": "Contenido",
+    "save": "Guardar",
+    "close": "Cerrar",
+    "delete": "Eliminar"
+  },
+  "app": {
+    "back": "Volver a las notas",
+    "file": "Archivo",
+    "patientId": "ID de paciente",
+    "templates": "Plantillas",
+    "beautifying": "Embelleciendo…",
+    "beautify": "Embellecer",
+    "summarizing": "Resumiendo…",
+    "summarize": "Resumir",
+    "saveDraft": "Guardar borrador",
+    "changeChart": "Cambiar gráfico",
+    "uploadChart": "Subir gráfico",
+    "hideSuggestions": "Ocultar sugerencias",
+    "showSuggestions": "Mostrar sugerencias",
+    "originalNote": "Nota original",
+    "beautifiedNote": "Nota embellecida",
+    "summary": "Resumen"
+  }
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import './styles/variables.css';
 import './styles/app.css';
+import './i18n.js';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,22 @@
+from backend import prompts
+
+
+def test_beautify_prompt_language():
+    en = prompts.build_beautify_prompt("note", lang="en")
+    es = prompts.build_beautify_prompt("nota", lang="es")
+    assert "clinical documentation specialist" in en[0]["content"]
+    assert "documentación clínica" in es[0]["content"]
+
+
+def test_suggest_prompt_language():
+    en = prompts.build_suggest_prompt("note", lang="en")
+    es = prompts.build_suggest_prompt("nota", lang="es")
+    assert "medical coder" in en[0]["content"]
+    assert "codificador médico" in es[0]["content"]
+
+
+def test_summary_prompt_language():
+    en = prompts.build_summary_prompt("note", lang="en")
+    es = prompts.build_summary_prompt("nota", lang="es")
+    assert "clinical communicator" in en[0]["content"]
+    assert "comunicador clínico" in es[0]["content"]


### PR DESCRIPTION
## Summary
- add i18n framework with English and Spanish resources and language selector in settings
- allow API and prompt builders to accept `lang` and custom templates for specialty or payer
- document customizing prompt templates

## Testing
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892857f2ec08324a153a7cfd3088579