### PR TITLE
Fix prompt and DB setup errors in backend tests

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -357,6 +357,9 @@ class NoteRequest(BaseModel):
     lang: str = "en"
     specialty: Optional[str] = None
     payer: Optional[str] = None
+    age: Optional[int] = None
+    sex: Optional[str] = None
+    region: Optional[str] = None
 
 
 
@@ -977,7 +980,15 @@ async def suggest(req: NoteRequest) -> SuggestionsResponse:
     # SuggestionsResponse schema.  If anything fails, we fall back to
     # the simple rule-based engine defined previously.
     try:
-        messages = build_suggest_prompt(cleaned_for_prompt, req.lang, req.specialty, req.payer)
+        messages = build_suggest_prompt(
+            cleaned_for_prompt,
+            req.lang,
+            req.specialty,
+            req.payer,
+            req.age,
+            req.sex,
+            req.region,
+        )
         response_content = call_openai(messages)
         # The model should return raw JSON.  Parse it into a Python dict.
         data = json.loads(response_content)

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -17,7 +17,7 @@ def client(monkeypatch, tmp_path):
         "CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT, eventType TEXT NOT NULL, timestamp REAL NOT NULL, details TEXT)"
     )
     db.execute(
-        "CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password_hash TEXT, role TEXT)"
+        "CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE NOT NULL, password_hash TEXT NOT NULL, role TEXT NOT NULL)"
     )
     db.execute(
         "CREATE TABLE settings (user_id INTEGER PRIMARY KEY, theme TEXT NOT NULL, categories TEXT NOT NULL, rules TEXT NOT NULL)"
@@ -30,9 +30,6 @@ def client(monkeypatch, tmp_path):
     db.execute(
         "INSERT INTO users (username, password_hash, role) VALUES (?, ?, ?)",
         ("user", pwd, "user"),
-    )
-    db.execute(
-        "CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE NOT NULL, password_hash TEXT NOT NULL, role TEXT NOT NULL)"
     )
     db.commit()
     monkeypatch.setattr(main, "db_conn", db)


### PR DESCRIPTION
## Summary
- add demographic-aware guideline text to suggestion prompts
- extend NoteRequest with optional age, sex, and region fields
- fix test database setup to avoid duplicate users table

## Testing
- `pytest --cov=backend`


------
https://chatgpt.com/codex/tasks/task_e_68928fc6f2808324b2e9a46912ce08c5