### PR TITLE
Add tests for register endpoint and App component

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - run: pip install -r backend/requirements.txt pytest pytest-cov
-      - run: pytest --cov=backend
+      - run: pip install -r backend/requirements.txt pytest pytest-cov pytest-asyncio httpx
+      - run: pytest
   frontend:
     runs-on: ubuntu-latest
     steps:

--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -1,0 +1,11 @@
+/* @vitest-environment jsdom */
+import { render } from '@testing-library/react';
+import { test, expect } from 'vitest';
+import '../i18n.js';
+import App from '../App.jsx';
+
+test('renders login form when no token', () => {
+  localStorage.clear();
+  const { getByLabelText } = render(<App />);
+  expect(getByLabelText(/username/i)).toBeTruthy();
+});

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,0 +1,49 @@
+import sqlite3
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from backend import main
+
+
+@pytest.mark.asyncio
+async def test_register_endpoint(monkeypatch):
+    # Set up in-memory database with users table
+    db = sqlite3.connect(":memory:", check_same_thread=False)
+    db.row_factory = sqlite3.Row
+    db.execute(
+        "CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE NOT NULL, password_hash TEXT NOT NULL, role TEXT NOT NULL)"
+    )
+    db.commit()
+    monkeypatch.setattr(main, "db_conn", db)
+
+    # Pre-create an admin user
+    admin_hash = main.hash_password("pw")
+    db.execute(
+        "INSERT INTO users (username, password_hash, role) VALUES (?, ?, ?)",
+        ("admin", admin_hash, "admin"),
+    )
+    db.commit()
+
+    transport = ASGITransport(app=main.app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        token = main.create_token("admin", "admin")
+        resp = await ac.post(
+            "/register",
+            json={"username": "bob", "password": "pw", "role": "user"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+
+        # New user can log in
+        resp = await ac.post("/login", json={"username": "bob", "password": "pw"})
+        assert resp.status_code == 200
+        assert "access_token" in resp.json()
+
+        # Non-admin should be rejected
+        user_token = main.create_token("bob", "user")
+        resp = await ac.post(
+            "/register",
+            json={"username": "eve", "password": "pw", "role": "user"},
+            headers={"Authorization": f"Bearer {user_token}"},
+        )
+        assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- add async FastAPI register endpoint test
- add React Testing Library test for App
- install pytest-asyncio & httpx in CI and run pytest

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68929e7553908324a88ae22bbb44b8b6