### PR TITLE
Add Spanish internationalization support and tests

### DIFF
--- a/backend/prompts.py
+++ b/backend/prompts.py
@@ -71,7 +71,8 @@ def build_beautify_prompt(
             "nueva información. Corrija la gramática y la ortografía, mejore la claridad y la legibilidad y organice el contenido "
             "en un formato estándar SOAP (Subjetivo, Objetivo, Evaluación, Plan) cuando corresponda. Si la nota no contiene las "
             "cuatro secciones, preserve el contenido existente y organícelo de manera sensata. No incluya identificadores del "
-            "paciente ni PHI. No agregue comentarios adicionales, encabezados ni marcas más allá de la nota mejorada."
+            "paciente ni PHI. No agregue comentarios adicionales, encabezados ni marcas más allá de la nota mejorada. La nota "
+            "devuelta debe estar en español."
         ),
     }
     instructions = _get_custom_instruction("beautify", lang, specialty, payer) or default_instructions.get(lang, default_instructions["en"])
@@ -108,7 +109,7 @@ def build_suggest_prompt(
             "- compliance: una matriz de cadenas breves que resalten elementos faltantes de documentación, riesgos de auditoría o consejos de cumplimiento (por ejemplo, historial incompleto, ROS faltante, examen insuficiente). Concéntrese en áreas que podrían causar reducción de códigos o denegaciones.\n"
             "- public_health: una matriz de medidas preventivas, vacunaciones o cribados que puedan aplicar según el contexto del paciente. Sugiera recomendaciones genéricas (por ejemplo, vacuna contra la gripe, dejar de fumar) sin asumir detalles personales.\n"
             "- differentials: una matriz de diagnósticos diferenciales plausibles sugeridos por la nota. Limítese a un máximo de cinco diferenciales y asegúrese de que sean coherentes con los síntomas descritos.\n"
-            "Devuelva solo JSON válido sin ningún Markdown adicional. No fabrique información más allá de la nota. Si no hay sugerencias para una categoría, devuelva un array vacío para esa clave."
+            "Devuelva solo JSON válido sin ningún Markdown adicional. No fabrique información más allá de la nota. Si no hay sugerencias para una categoría, devuelva un array vacío para esa clave. Todas las cadenas devueltas deben estar en español."
         ),
     }
     instructions = _get_custom_instruction("suggest", lang, specialty, payer) or default_instructions.get(lang, default_instructions["en"])
@@ -148,7 +149,7 @@ def build_summary_prompt(
             "Do not include any patient identifiers or PHI."
         ),
         "es": (
-            "Usted es un experto comunicador clínico. Reescriba la siguiente nota clínica en un resumen conciso que un paciente pueda entender fácilmente. Preserve todos los hechos médicos importantes (síntomas, diagnósticos, tratamientos, seguimiento), pero elimine los códigos de facturación y la jerga técnica. Escriba en un lenguaje sencillo equivalente a un nivel de lectura de octavo grado. No invente información que no esté presente en la nota. No incluya identificadores del paciente ni PHI."
+            "Usted es un experto comunicador clínico. Reescriba la siguiente nota clínica en un resumen conciso que un paciente pueda entender fácilmente. Preserve todos los hechos médicos importantes (síntomas, diagnósticos, tratamientos, seguimiento), pero elimine los códigos de facturación y la jerga técnica. Escriba en un lenguaje sencillo equivalente a un nivel de lectura de octavo grado. No invente información que no esté presente en la nota. No incluya identificadores del paciente ni PHI. El resumen debe estar en español."
         ),
     }
     instructions = _get_custom_instruction("summary", lang, specialty, payer) or default_instructions.get(lang, default_instructions["en"])

--- a/src/components/__tests__/Settings.test.jsx
+++ b/src/components/__tests__/Settings.test.jsx
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import { vi, expect, test, beforeEach } from 'vitest';
-import '../../i18n.js';
+import i18n from '../../i18n.js';
 
 vi.mock('../../api.js', () => ({ setApiKey: vi.fn(), saveSettings: vi.fn() }));
 import { saveSettings } from '../../api.js';
@@ -27,4 +27,22 @@ test('saveSettings called when preferences change', async () => {
   );
   await fireEvent.click(getByLabelText('Show Codes & Rationale'));
   await waitFor(() => expect(saveSettings).toHaveBeenCalled());
+});
+
+test('renders Spanish translations when lang is es', () => {
+  const settings = {
+    theme: 'modern',
+    enableCodes: true,
+    enableCompliance: true,
+    enablePublicHealth: true,
+    enableDifferentials: true,
+    rules: [],
+    lang: 'es',
+  };
+  i18n.changeLanguage('es');
+  const { getAllByText } = render(
+    <Settings settings={settings} updateSettings={() => {}} />
+  );
+  expect(getAllByText('Configuración').length).toBeGreaterThan(0);
+  expect(getAllByText('Idioma').length).toBeGreaterThan(0);
 });

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -139,6 +139,18 @@ def test_summarize_and_fallback(client, monkeypatch):
     assert len(resp.json()["summary"]) <= 203  # truncated fallback
 
 
+def test_summarize_spanish_language(client, monkeypatch):
+    def fake_call_openai(msgs):
+        # Ensure the system prompt is in Spanish
+        assert "comunicador clínico" in msgs[0]["content"]
+        return "resumen"
+
+    monkeypatch.setattr(main, "call_openai", fake_call_openai)
+    resp = client.post("/summarize", json={"text": "hola", "lang": "es"})
+    assert resp.status_code == 200
+    assert resp.json()["summary"] == "resumen"
+
+
 def test_transcribe_endpoint(client, monkeypatch):
     monkeypatch.setattr(main, "simple_transcribe", lambda b: "hello")
     monkeypatch.setattr(

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -6,6 +6,7 @@ def test_beautify_prompt_language():
     es = prompts.build_beautify_prompt("nota", lang="es")
     assert "clinical documentation specialist" in en[0]["content"]
     assert "documentación clínica" in es[0]["content"]
+    assert "en español" in es[0]["content"]
 
 
 def test_suggest_prompt_language():
@@ -13,6 +14,7 @@ def test_suggest_prompt_language():
     es = prompts.build_suggest_prompt("nota", lang="es")
     assert "medical coder" in en[0]["content"]
     assert "codificador médico" in es[0]["content"]
+    assert "en español" in es[0]["content"]
 
 
 def test_summary_prompt_language():
@@ -20,3 +22,4 @@ def test_summary_prompt_language():
     es = prompts.build_summary_prompt("nota", lang="es")
     assert "clinical communicator" in en[0]["content"]
     assert "comunicador clínico" in es[0]["content"]
+    assert "en español" in es[0]["content"]


### PR DESCRIPTION
## Summary
- ensure prompts produce Spanish when requested
- add Spanish-specific tests for prompts, API, and UI

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68929e8d82b08324b07b5309bda27c27