### PR TITLE
Integrate public health guideline API

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -34,6 +34,7 @@ from .openai_client import call_openai
 from .key_manager import get_api_key, save_api_key, APP_NAME
 from platformdirs import user_data_dir
 from .audio_processing import simple_transcribe, diarize_and_transcribe
+from .public_health import get_public_health_suggestions
 
 import json
 import sqlite3
@@ -258,6 +259,7 @@ class UserSettings(BaseModel):
     }
     rules: List[str] = []
     lang: str = "en"
+    region: str = ""
 
 
 def hash_password(password: str) -> str:
@@ -300,13 +302,20 @@ async def get_user_settings(user=Depends(require_role("user"))) -> Dict[str, Any
     """Return the current user's saved settings or defaults if none exist."""
     try:
         row = db_conn.execute(
-            "SELECT theme, categories, rules, lang FROM settings s JOIN users u ON s.user_id=u.id WHERE u.username=?",
+            "SELECT theme, categories, rules, lang, region FROM settings s JOIN users u ON s.user_id=u.id WHERE u.username=?",
             (user["sub"],),
         ).fetchone()
     except sqlite3.OperationalError:
-        db_conn.execute("ALTER TABLE settings ADD COLUMN lang TEXT NOT NULL DEFAULT 'en'")
+        try:
+            db_conn.execute("ALTER TABLE settings ADD COLUMN lang TEXT NOT NULL DEFAULT 'en'")
+        except Exception:
+            pass
+        try:
+            db_conn.execute("ALTER TABLE settings ADD COLUMN region TEXT")
+        except Exception:
+            pass
         row = db_conn.execute(
-            "SELECT theme, categories, rules, lang FROM settings s JOIN users u ON s.user_id=u.id WHERE u.username=?",
+            "SELECT theme, categories, rules, lang, region FROM settings s JOIN users u ON s.user_id=u.id WHERE u.username=?",
             (user["sub"],),
         ).fetchone()
     if row:
@@ -315,6 +324,7 @@ async def get_user_settings(user=Depends(require_role("user"))) -> Dict[str, Any
             "categories": json.loads(row["categories"]),
             "rules": json.loads(row["rules"]),
             "lang": row["lang"],
+            "region": row["region"] or "",
         }
     return UserSettings().dict()
 
@@ -330,25 +340,34 @@ async def save_user_settings(model: UserSettings, user=Depends(require_role("use
         raise HTTPException(status_code=400, detail="User not found")
     try:
         db_conn.execute(
-            "INSERT OR REPLACE INTO settings (user_id, theme, categories, rules, lang) VALUES (?, ?, ?, ?, ?)",
+            "INSERT OR REPLACE INTO settings (user_id, theme, categories, rules, lang, region) VALUES (?, ?, ?, ?, ?, ?)",
             (
                 row["id"],
                 model.theme,
                 json.dumps(model.categories),
                 json.dumps(model.rules),
                 model.lang,
+                model.region,
             ),
         )
     except sqlite3.OperationalError:
-        db_conn.execute("ALTER TABLE settings ADD COLUMN lang TEXT NOT NULL DEFAULT 'en'")
+        try:
+            db_conn.execute("ALTER TABLE settings ADD COLUMN lang TEXT NOT NULL DEFAULT 'en'")
+        except Exception:
+            pass
+        try:
+            db_conn.execute("ALTER TABLE settings ADD COLUMN region TEXT")
+        except Exception:
+            pass
         db_conn.execute(
-            "INSERT OR REPLACE INTO settings (user_id, theme, categories, rules, lang) VALUES (?, ?, ?, ?, ?)",
+            "INSERT OR REPLACE INTO settings (user_id, theme, categories, rules, lang, region) VALUES (?, ?, ?, ?, ?, ?)",
             (
                 row["id"],
                 model.theme,
                 json.dumps(model.categories),
                 json.dumps(model.rules),
                 model.lang,
+                model.region,
             ),
         )
     db_conn.commit()
@@ -1067,6 +1086,10 @@ async def suggest(req: NoteRequest) -> SuggestionsResponse:
         public_health_raw = data.get("publicHealth", data.get("public_health", []))
         public_health = [str(x) for x in public_health_raw]
         diffs = [str(x) for x in data.get("differentials", [])]
+        # Augment public health suggestions with external guidelines
+        extra_ph = get_public_health_suggestions(req.age, req.sex, req.region)
+        if extra_ph:
+            public_health = list(dict.fromkeys(public_health + extra_ph))
         # If all categories are empty, raise an error to fall back to rule-based suggestions.
         if not (codes_list or compliance or public_health or diffs):
             raise ValueError("No suggestions returned from LLM")
@@ -1130,6 +1153,9 @@ async def suggest(req: NoteRequest) -> SuggestionsResponse:
             public_health.append("Consider influenza vaccine")
         if not diffs:
             diffs.append("Routine follow-up")
+        extra_ph = get_public_health_suggestions(req.age, req.sex, req.region)
+        if extra_ph:
+            public_health = list(dict.fromkeys(public_health + extra_ph))
         return SuggestionsResponse(
             codes=codes,
             compliance=compliance,

--- a/backend/public_health.py
+++ b/backend/public_health.py
@@ -1,0 +1,51 @@
+"""Fetch public health guidelines based on demographics.
+
+This module retrieves public health recommendations from an external API
+according to patient age, sex and region.  The API base URL can be
+configured via the ``PUBLIC_HEALTH_API_URL`` environment variable.  The
+function returns a list of plain string suggestions.  Network failures or
+unexpected responses result in an empty list so callers can fail gracefully.
+"""
+from __future__ import annotations
+
+import os
+from typing import List, Optional
+
+import requests
+
+BASE_URL = os.getenv("PUBLIC_HEALTH_API_URL", "https://public-health.example.com/guidelines")
+
+
+def get_public_health_suggestions(age: Optional[int], sex: Optional[str], region: Optional[str]) -> List[str]:
+    """Return public health suggestions for the given demographics.
+
+    Args:
+        age: Patient age in years.
+        sex: Patient sex or gender.
+        region: Geographic region or country code.
+    Returns:
+        A list of recommendation strings.  Returns an empty list on error or
+        when insufficient demographics are provided.
+    """
+    if age is None or not sex or not region:
+        return []
+    params = {"age": age, "sex": sex, "region": region}
+    try:
+        resp = requests.get(BASE_URL, params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        # The API is expected to return a JSON object with a ``suggestions``
+        # field containing a list of strings.  If the structure differs,
+        # fallback to an empty list.
+        items = []
+        if isinstance(data, dict):
+            raw = data.get("suggestions") or data.get("data") or data.get("results")
+            if isinstance(raw, list):
+                items = raw
+        elif isinstance(data, list):
+            items = data
+        return [str(x) for x in items]
+    except Exception as exc:  # pragma: no cover - best effort logging
+        # Print error so it surfaces in logs but don't crash the caller.
+        print(f"Public health API error: {exc}")
+        return []

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -80,7 +80,6 @@ function App() {
   // Demographic details used for public health suggestions
   const [age, setAge] = useState('');
   const [sex, setSex] = useState('');
-  const [region, setRegion] = useState('');
   // Suggestions fetched from the API
   const [suggestions, setSuggestions] = useState({
     codes: [],
@@ -103,6 +102,7 @@ function App() {
     // these rules are appended to the prompt sent to the AI model.  Each
     // entry should be a concise guideline such as “Payer X requires ROS for 99214”.
     rules: [],
+    region: '',
   };
   // User settings controlling theme and which suggestion categories are enabled.
   // Load any previously saved settings from ``localStorage`` on first render.
@@ -393,6 +393,9 @@ function App() {
         rules: settingsState.rules,
         audio: audioTranscript,
         lang: settingsState.lang,
+        age: age ? parseInt(age, 10) : undefined,
+        sex,
+        region: settingsState.region,
       })
         .then((data) => {
           setSuggestions(data);
@@ -405,7 +408,7 @@ function App() {
     }, 600); // 600ms delay
     // Cleanup function cancels the previous timer if draftText changes again
     return () => clearTimeout(timer);
-  }, [draftText, audioTranscript, age, sex, region]);
+  }, [draftText, audioTranscript, age, sex, settingsState.region]);
 
   // Effect: apply theme colours to CSS variables when the theme changes
   useEffect(() => {

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -169,14 +169,30 @@ function Settings({ settings, updateSettings }) {
         style={{ width: '100%', marginTop: '0.5rem', padding: '0.5rem', borderRadius: '4px', border: '1px solid var(--disabled)' }}
         placeholder={t('settings.customRulesPlaceholder')}
       />
-      <h3>{t('settings.language')}</h3>
-      <select value={settings.lang} onChange={handleLangChange}>
-        <option value="en">{t('settings.english')}</option>
-        <option value="es">{t('settings.spanish')}</option>
-      </select>
+  <h3>{t('settings.language')}</h3>
+  <select value={settings.lang} onChange={handleLangChange}>
+    <option value="en">{t('settings.english')}</option>
+    <option value="es">{t('settings.spanish')}</option>
+  </select>
 
-      <h3>{t('settings.templates')}</h3>
-      <ul>
+  <h3>{t('settings.region')}</h3>
+  <input
+    type="text"
+    value={settings.region || ''}
+    onChange={async (e) => {
+      const updated = { ...settings, region: e.target.value };
+      updateSettings(updated);
+      try {
+        await saveSettings(updated);
+      } catch (err) {
+        console.error(err);
+      }
+    }}
+    style={{ width: '100%', marginBottom: '0.5rem', padding: '0.5rem', borderRadius: '4px', border: '1px solid var(--disabled)' }}
+  />
+
+  <h3>{t('settings.templates')}</h3>
+  <ul>
         {templates.map((tpl) => (
           <li key={tpl.id}>
             {tpl.name}{' '}

--- a/src/components/__tests__/Settings.test.jsx
+++ b/src/components/__tests__/Settings.test.jsx
@@ -20,6 +20,7 @@ test('saveSettings called when preferences change', async () => {
       enableDifferentials: true,
       rules: [],
       lang: 'en',
+      region: '',
     };
   const updateSettings = vi.fn();
   const { getByLabelText } = render(

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -101,7 +101,8 @@
     "templates": "Templates",
     "noTemplates": "No templates",
     "english": "English",
-    "spanish": "Spanish"
+    "spanish": "Spanish",
+    "region": "Region"
   },
   "sidebar": {
     "notes": "Notes",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -101,7 +101,8 @@
     "templates": "Plantillas",
     "noTemplates": "Sin plantillas",
     "english": "Inglés",
-    "spanish": "Español"
+    "spanish": "Español",
+    "region": "Región"
   },
   "sidebar": {
     "notes": "Notas",

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -232,3 +232,27 @@ def test_suggest_with_demographics(client, monkeypatch):
         json={"text": "note", "age": 30, "sex": "female", "region": "US"},
     )
     assert resp.status_code == 200
+
+
+def test_suggest_includes_public_health_from_api(client, monkeypatch):
+    def fake_call_openai(msgs):
+        return json.dumps({"codes": [], "compliance": [], "publicHealth": [], "differentials": []})
+
+    monkeypatch.setattr(main, "call_openai", fake_call_openai)
+    monkeypatch.setattr(prompts, "get_guidelines", lambda *args, **kwargs: {})
+
+    def fake_ph(age, sex, region):
+        assert age == 50
+        assert sex == "male"
+        assert region == "US"
+        return ["Shingles vaccine"]
+
+    monkeypatch.setattr(main, "get_public_health_suggestions", fake_ph)
+
+    resp = client.post(
+        "/suggest",
+        json={"text": "note", "age": 50, "sex": "male", "region": "US"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "Shingles vaccine" in data["publicHealth"]

--- a/tests/test_public_health.py
+++ b/tests/test_public_health.py
@@ -1,0 +1,32 @@
+import requests
+from backend import public_health
+
+
+class DummyResp:
+    def __init__(self, data):
+        self._data = data
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._data
+
+
+def test_get_public_health_suggestions(monkeypatch):
+    def fake_get(url, params=None, timeout=10):
+        assert params == {"age": 40, "sex": "male", "region": "US"}
+        return DummyResp({"suggestions": ["Flu shot", "BP check"]})
+
+    monkeypatch.setattr(public_health.requests, "get", fake_get)
+    result = public_health.get_public_health_suggestions(40, "male", "US")
+    assert result == ["Flu shot", "BP check"]
+
+
+def test_get_public_health_suggestions_error(monkeypatch):
+    def fake_get(*args, **kwargs):
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(public_health.requests, "get", fake_get)
+    result = public_health.get_public_health_suggestions(40, "male", "US")
+    assert result == []


### PR DESCRIPTION
## Summary
- add `public_health` module to fetch region-based guideline suggestions
- persist user region in settings and incorporate into `/suggest`
- expose region option in settings UI and send with suggestion requests
- add tests for public health API and suggestion integration

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68929eb6583c8324bec28e8ed783ec5c