### PR TITLE
Enforce admin-only access for metrics, events and templates

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -198,8 +198,9 @@ def create_token(username: str, role: str, clinic: str | None = None) -> str:
 
 def get_current_user(
     credentials: HTTPAuthorizationCredentials = Depends(security),
+    required_role: str | None = None,
 ):
-    """Decode the provided JWT and return its payload."""
+    """Decode the provided JWT and optionally enforce a required role."""
     token = credentials.credentials
     try:
         data = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
@@ -207,6 +208,11 @@ def get_current_user(
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired token",
+        )
+    if required_role and data.get("role") not in (required_role, "admin"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Insufficient privileges",
         )
     return data
 
@@ -219,13 +225,8 @@ def require_role(role: str):
     still permitting administrators to perform regular user actions.
     """
 
-    def checker(user=Depends(get_current_user)):
-        if user.get("role") not in (role, "admin"):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Insufficient privileges",
-            )
-        return user
+    def checker(credentials: HTTPAuthorizationCredentials = Depends(security)):
+        return get_current_user(credentials, required_role=role)
 
     return checker
 
@@ -628,7 +629,7 @@ async def log_event(event: EventModel) -> Dict[str, str]:
 
 
 @app.get("/templates", response_model=List[TemplateModel])
-def get_templates(user=Depends(require_role("user"))) -> List[TemplateModel]:
+def get_templates(user=Depends(require_role("admin"))) -> List[TemplateModel]:
     """Return custom templates for the current user and clinic."""
 
     clinic = user.get("clinic")
@@ -641,7 +642,7 @@ def get_templates(user=Depends(require_role("user"))) -> List[TemplateModel]:
 
 
 @app.post("/templates", response_model=TemplateModel)
-def create_template(tpl: TemplateModel, user=Depends(require_role("user"))) -> TemplateModel:
+def create_template(tpl: TemplateModel, user=Depends(require_role("admin"))) -> TemplateModel:
     """Create a new custom template for the user."""
 
     clinic = user.get("clinic")
@@ -656,7 +657,7 @@ def create_template(tpl: TemplateModel, user=Depends(require_role("user"))) -> T
 
 
 @app.put("/templates/{template_id}", response_model=TemplateModel)
-def update_template(template_id: int, tpl: TemplateModel, user=Depends(require_role("user"))) -> TemplateModel:
+def update_template(template_id: int, tpl: TemplateModel, user=Depends(require_role("admin"))) -> TemplateModel:
     """Update an existing custom template owned by the current user."""
 
     cursor = db_conn.cursor()
@@ -671,7 +672,7 @@ def update_template(template_id: int, tpl: TemplateModel, user=Depends(require_r
 
 
 @app.delete("/templates/{template_id}")
-def delete_template(template_id: int, user=Depends(require_role("user"))) -> Dict[str, str]:
+def delete_template(template_id: int, user=Depends(require_role("admin"))) -> Dict[str, str]:
     """Delete a custom template owned by the current user."""
 
     cursor = db_conn.cursor()

--- a/src/api.js
+++ b/src/api.js
@@ -270,6 +270,12 @@ export async function getMetrics(filters = {}) {
   const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
   const headers = token ? { Authorization: `Bearer ${token}` } : {};
   const resp = await fetch(`${baseUrl}/metrics?${params.toString()}`, { headers });
+  if (resp.status === 401 || resp.status === 403) {
+    throw new Error('Unauthorized');
+  }
+  if (!resp.ok) {
+    throw new Error('Failed to fetch metrics');
+  }
   return await resp.json();
 }
 
@@ -293,7 +299,12 @@ export async function getTemplates() {
   const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
   const headers = token ? { Authorization: `Bearer ${token}` } : {};
   const resp = await fetch(`${baseUrl}/templates`, { headers });
-  if (!resp.ok) return [];
+  if (resp.status === 401 || resp.status === 403) {
+    throw new Error('Unauthorized');
+  }
+  if (!resp.ok) {
+    throw new Error('Failed to fetch templates');
+  }
   return await resp.json();
 }
 
@@ -317,6 +328,12 @@ export async function createTemplate(tpl) {
     headers,
     body: JSON.stringify(tpl),
   });
+  if (resp.status === 401 || resp.status === 403) {
+    throw new Error('Unauthorized');
+  }
+  if (!resp.ok) {
+    throw new Error('Failed to create template');
+  }
   return await resp.json();
 }
 
@@ -341,6 +358,12 @@ export async function updateTemplate(id, tpl) {
     headers,
     body: JSON.stringify(tpl),
   });
+  if (resp.status === 401 || resp.status === 403) {
+    throw new Error('Unauthorized');
+  }
+  if (!resp.ok) {
+    throw new Error('Failed to update template');
+  }
   return await resp.json();
 }
 
@@ -357,10 +380,16 @@ export async function deleteTemplate(id) {
   if (!baseUrl) return;
   const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
   const headers = token ? { Authorization: `Bearer ${token}` } : {};
-  await fetch(`${baseUrl}/templates/${id}`, {
+  const resp = await fetch(`${baseUrl}/templates/${id}`, {
     method: 'DELETE',
     headers,
   });
+  if (resp.status === 401 || resp.status === 403) {
+    throw new Error('Unauthorized');
+  }
+  if (!resp.ok) {
+    throw new Error('Failed to delete template');
+  }
 }
 
 /**
@@ -463,11 +492,19 @@ export async function getEvents() {
     return [];
   }
   try {
-    const resp = await fetch(`${baseUrl}/events`);
+    const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+    const headers = token ? { Authorization: `Bearer ${token}` } : {};
+    const resp = await fetch(`${baseUrl}/events`, { headers });
+    if (resp.status === 401 || resp.status === 403) {
+      throw new Error('Unauthorized');
+    }
+    if (!resp.ok) {
+      throw new Error('Failed to fetch events');
+    }
     const data = await resp.json();
     return Array.isArray(data) ? data : [];
   } catch (err) {
     console.error('Error fetching events:', err);
-    return [];
+    throw err;
   }
 }

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -49,9 +49,18 @@ ChartJS.register(
   const [metrics, setMetrics] = useState({});
   const [filters, setFilters] = useState({ start: '', end: '', clinician: '' });
   const [inputs, setInputs] = useState(filters);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
-    getMetrics(filters).then((data) => setMetrics(data));
+    getMetrics(filters)
+      .then((data) => setMetrics(data))
+      .catch((err) => {
+        if (err.message === 'Unauthorized' && typeof window !== 'undefined') {
+          window.location.href = '/';
+        } else {
+          setError(err.message);
+        }
+      });
   }, [filters]);
 
   // Define display cards using the fetched metrics.  Missing values will
@@ -277,6 +286,7 @@ ChartJS.register(
   return (
       <div className="dashboard">
         <h2>{t('dashboard.title')}</h2>
+        {error && <p style={{ color: 'red' }}>{error}</p>}
         <div className="filters" style={{ marginBottom: '1rem' }}>
           <label>
             {t('dashboard.start')}

--- a/src/components/Logs.jsx
+++ b/src/components/Logs.jsx
@@ -20,14 +20,24 @@ function formatTimestamp(ts) {
     const { t } = useTranslation();
     const [events, setEvents] = useState([]);
     const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
 
   useEffect(() => {
     // Fetch events when component mounts
     async function load() {
       setLoading(true);
-      const data = await getEvents();
-      setEvents(data);
-      setLoading(false);
+      try {
+        const data = await getEvents();
+        setEvents(data);
+      } catch (err) {
+        if (err.message === 'Unauthorized' && typeof window !== 'undefined') {
+          window.location.href = '/';
+        } else {
+          setError(err.message);
+        }
+      } finally {
+        setLoading(false);
+      }
     }
     load();
   }, []);
@@ -36,6 +46,7 @@ function formatTimestamp(ts) {
       <div className="logs-page" style={{ padding: '1rem', overflowY: 'auto' }}>
         <h2>{t('logs.title')}</h2>
         <p style={{ fontSize: '0.9rem', color: '#6B7280' }}>{t('logs.intro')}</p>
+        {error && <p style={{ color: 'red' }}>{error}</p>}
         {loading ? (
           <p>{t('logs.loading')}</p>
         ) : events.length === 0 ? (

--- a/src/components/TemplatesModal.jsx
+++ b/src/components/TemplatesModal.jsx
@@ -8,9 +8,18 @@ function TemplatesModal({ baseTemplates, onSelect, onClose }) {
   const [name, setName] = useState('');
   const [content, setContent] = useState('');
   const [editingId, setEditingId] = useState(null);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
-    getTemplates().then((data) => setTemplates([...baseTemplates, ...data]));
+    getTemplates()
+      .then((data) => setTemplates([...baseTemplates, ...data]))
+      .catch((e) => {
+        if (e.message === 'Unauthorized' && typeof window !== 'undefined') {
+          window.location.href = '/';
+        } else {
+          setError(e.message);
+        }
+      });
   }, [baseTemplates]);
 
   const handleSave = async () => {
@@ -27,7 +36,11 @@ function TemplatesModal({ baseTemplates, onSelect, onClose }) {
       setContent('');
       setEditingId(null);
     } catch (e) {
-      console.error(e);
+      if (e.message === 'Unauthorized' && typeof window !== 'undefined') {
+        window.location.href = '/';
+      } else {
+        setError(e.message);
+      }
     }
   };
 
@@ -42,7 +55,11 @@ function TemplatesModal({ baseTemplates, onSelect, onClose }) {
       await deleteTemplate(id);
       setTemplates((prev) => prev.filter((t) => t.id !== id));
     } catch (e) {
-      console.error(e);
+      if (e.message === 'Unauthorized' && typeof window !== 'undefined') {
+        window.location.href = '/';
+      } else {
+        setError(e.message);
+      }
     }
   };
 
@@ -50,6 +67,7 @@ function TemplatesModal({ baseTemplates, onSelect, onClose }) {
     <div className="modal-overlay">
         <div className="modal card">
           <h3>{t('templatesModal.title')}</h3>
+          {error && <p style={{ color: 'red' }}>{error}</p>}
           <ul>
             {templates.map((tpl) => (
               <li key={tpl.id || tpl.name}>

--- a/tests/test_blockers.py
+++ b/tests/test_blockers.py
@@ -72,6 +72,16 @@ def test_metrics_requires_authentication():
     assert response.status_code in {401, 403}
 
 
+def test_events_requires_authentication():
+    response = client.get("/events")
+    assert response.status_code in {401, 403}
+
+
+def test_templates_requires_authentication():
+    response = client.get("/templates")
+    assert response.status_code in {401, 403}
+
+
 def test_metrics_contains_timeseries_data():
     """The metrics endpoint should return time‑series data for charts.
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -16,7 +16,7 @@ def setup_module(module):
 
 def test_create_update_and_list_templates():
     client = TestClient(main.app)
-    token = main.create_token('alice', 'user', clinic='clinic1')
+    token = main.create_token('alice', 'admin', clinic='clinic1')
     resp = client.post(
         '/templates',
         json={'name': 'Custom', 'content': 'Note'},
@@ -39,7 +39,7 @@ def test_create_update_and_list_templates():
 
 def test_delete_template():
     client = TestClient(main.app)
-    token = main.create_token('alice', 'user', clinic='clinic1')
+    token = main.create_token('alice', 'admin', clinic='clinic1')
     resp = client.post(
         '/templates',
         json={'name': 'Temp', 'content': 'X'},
@@ -54,14 +54,14 @@ def test_delete_template():
 
 def test_template_scoped_by_clinic():
     client = TestClient(main.app)
-    token_a = main.create_token('alice', 'user', clinic='clinicA')
+    token_a = main.create_token('alice', 'admin', clinic='clinicA')
     resp = client.post(
         '/templates',
         json={'name': 'Scoped', 'content': 'S'},
         headers={'Authorization': f'Bearer {token_a}'},
     )
     tpl_id = resp.json()['id']
-    token_b = main.create_token('alice', 'user', clinic='clinicB')
+    token_b = main.create_token('alice', 'admin', clinic='clinicB')
     resp = client.get('/templates', headers={'Authorization': f'Bearer {token_b}'})
     assert all(t['id'] != tpl_id for t in resp.json())
 
@@ -70,3 +70,10 @@ def test_templates_require_auth():
     client = TestClient(main.app)
     resp = client.get('/templates')
     assert resp.status_code in {401, 403}
+
+
+def test_templates_require_admin_role():
+    client = TestClient(main.app)
+    token = main.create_token('alice', 'user', clinic='clinic1')
+    resp = client.get('/templates', headers={'Authorization': f'Bearer {token}'})
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- enforce role checks at token decode and require admin role for template routes
- surface auth errors in API helpers and UI, redirecting unauthorised users
- test admin-only endpoints for unauthenticated access and non-admin tokens

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892a4c8d1b88324a94f09406c53ab72