### PR TITLE
feat: add SQL grouped metrics with timeseries

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -696,10 +696,18 @@ async def get_metrics(
     clinician: Optional[str] = None,
     user=Depends(require_role("admin")),
 ) -> Dict[str, Any]:
-    """Aggregate analytics from logged events with optional filtering."""
+    """Aggregate analytics from logged events with optional filtering.
+
+    The endpoint now uses SQL aggregation to build daily and weekly
+    time‑series buckets directly within SQLite rather than iterating over
+    each event in Python.  This keeps the implementation reasonably
+    efficient even as the number of logged events grows."""
 
     cursor = db_conn.cursor()
 
+    # ------------------------------------------------------------------
+    # Build a WHERE clause based on optional query parameters
+    # ------------------------------------------------------------------
     conditions: List[str] = []
     params: List[Any] = []
     if start:
@@ -722,119 +730,108 @@ async def get_metrics(
 
     where_clause = f"WHERE {' AND '.join(conditions)}" if conditions else ""
 
+    # ------------------------------------------------------------------
+    # Aggregate overall totals/averages using SQL
+    # ------------------------------------------------------------------
+    totals_query = f"""
+        SELECT
+            SUM(CASE WHEN eventType IN ('note_started','note_saved') THEN 1 ELSE 0 END) AS total_notes,
+            SUM(CASE WHEN eventType='beautify' THEN 1 ELSE 0 END)        AS total_beautify,
+            SUM(CASE WHEN eventType='suggest' THEN 1 ELSE 0 END)         AS total_suggest,
+            SUM(CASE WHEN eventType='summary' THEN 1 ELSE 0 END)         AS total_summary,
+            SUM(CASE WHEN eventType='chart_upload' THEN 1 ELSE 0 END)    AS total_chart_upload,
+            SUM(CASE WHEN eventType='audio_recorded' THEN 1 ELSE 0 END)  AS total_audio,
+            AVG(CAST(json_extract(details, '$.length')      AS REAL))     AS avg_note_length,
+            AVG(CAST(json_extract(details, '$.revenue')     AS REAL))     AS revenue_per_visit,
+            AVG(CAST(json_extract(details, '$.timeToClose') AS REAL))     AS avg_close_time
+        FROM events {where_clause}
+    """
+    cursor.execute(totals_query, params)
+    row = cursor.fetchone()
+    totals = dict(row) if row else {}
+
+    total_notes = totals.get("total_notes", 0) or 0
+    total_beautify = totals.get("total_beautify", 0) or 0
+    total_suggest = totals.get("total_suggest", 0) or 0
+    total_summary = totals.get("total_summary", 0) or 0
+    total_chart_upload = totals.get("total_chart_upload", 0) or 0
+    total_audio = totals.get("total_audio", 0) or 0
+    avg_length = totals.get("avg_note_length") or 0
+    avg_revenue = totals.get("revenue_per_visit") or 0
+    avg_close_time = totals.get("avg_close_time") or 0
+
+    # ------------------------------------------------------------------
+    # Build daily and weekly time series via SQL GROUP BY
+    # ------------------------------------------------------------------
+    daily_query = f"""
+        SELECT
+            date(datetime(timestamp, 'unixepoch')) AS date,
+            SUM(CASE WHEN eventType IN ('note_started','note_saved') THEN 1 ELSE 0 END) AS notes,
+            SUM(CASE WHEN eventType='beautify' THEN 1 ELSE 0 END)   AS beautify,
+            SUM(CASE WHEN eventType='suggest' THEN 1 ELSE 0 END)    AS suggest,
+            SUM(CASE WHEN eventType='summary' THEN 1 ELSE 0 END)    AS summary,
+            SUM(CASE WHEN eventType='chart_upload' THEN 1 ELSE 0 END) AS chart_upload,
+            SUM(CASE WHEN eventType='audio_recorded' THEN 1 ELSE 0 END) AS audio,
+            AVG(CAST(json_extract(details, '$.length')      AS REAL)) AS avg_note_length,
+            AVG(CAST(json_extract(details, '$.revenue')     AS REAL)) AS revenue_per_visit,
+            AVG(CAST(json_extract(details, '$.timeToClose') AS REAL)) AS avg_close_time
+        FROM events {where_clause}
+        GROUP BY date
+        ORDER BY date
+    """
+    cursor.execute(daily_query, params)
+    daily_list = [dict(row) for row in cursor.fetchall()]
+
+    weekly_query = f"""
+        SELECT
+            strftime('%Y-%W', datetime(timestamp, 'unixepoch')) AS week,
+            SUM(CASE WHEN eventType IN ('note_started','note_saved') THEN 1 ELSE 0 END) AS notes,
+            SUM(CASE WHEN eventType='beautify' THEN 1 ELSE 0 END)   AS beautify,
+            SUM(CASE WHEN eventType='suggest' THEN 1 ELSE 0 END)    AS suggest,
+            SUM(CASE WHEN eventType='summary' THEN 1 ELSE 0 END)    AS summary,
+            SUM(CASE WHEN eventType='chart_upload' THEN 1 ELSE 0 END) AS chart_upload,
+            SUM(CASE WHEN eventType='audio_recorded' THEN 1 ELSE 0 END) AS audio,
+            AVG(CAST(json_extract(details, '$.length')      AS REAL)) AS avg_note_length,
+            AVG(CAST(json_extract(details, '$.revenue')     AS REAL)) AS revenue_per_visit,
+            AVG(CAST(json_extract(details, '$.timeToClose') AS REAL)) AS avg_close_time
+        FROM events {where_clause}
+        GROUP BY week
+        ORDER BY week
+    """
+    cursor.execute(weekly_query, params)
+    weekly_list = [dict(row) for row in cursor.fetchall()]
+
+    # ------------------------------------------------------------------
+    # Additional aggregations that are easier in Python
+    # (e.g. denial rates, coding distribution, beautify time)
+    # ------------------------------------------------------------------
     cursor.execute(
         f"SELECT eventType, timestamp, details FROM events {where_clause} ORDER BY timestamp",
         params,
     )
     rows = cursor.fetchall()
 
-    total_notes = total_beautify = total_suggest = 0
-    total_summary = total_chart_upload = total_audio = 0
-
     code_counts: Dict[str, int] = {}
     denial_counts: Dict[str, List[int]] = {}
     denial_totals = [0, 0]
     deficiency_totals = [0, 0]
 
-    length_sum = length_count = 0.0
-    revenue_sum = revenue_count = 0.0
-    close_sum = close_count = 0.0
     beautify_time_sum = beautify_time_count = 0.0
-
-    daily: Dict[str, Dict[str, Any]] = {}
-    weekly: Dict[str, Dict[str, Any]] = {}
+    beautify_daily: Dict[str, List[float]] = {}
+    beautify_weekly: Dict[str, List[float]] = {}
     last_start_for_patient: Dict[str, float] = {}
 
     for row in rows:
-        evt = row['eventType']
-        ts = row['timestamp']
+        evt = row["eventType"]
+        ts = row["timestamp"]
         try:
-            details = json.loads(row['details'] or '{}')
+            details = json.loads(row["details"] or "{}")
         except Exception:
             details = {}
 
-        day = datetime.utcfromtimestamp(ts).strftime('%Y-%m-%d')
-        week = datetime.utcfromtimestamp(ts).strftime('%Y-%W')
-        for bucket, key, label in ((daily, day, 'date'), (weekly, week, 'week')):
-            if key not in bucket:
-                bucket[key] = {
-                    label: key,
-                    'notes': 0,
-                    'beautify': 0,
-                    'suggest': 0,
-                    'summary': 0,
-                    'chart_upload': 0,
-                    'audio': 0,
-                    'length_sum': 0.0,
-                    'length_count': 0,
-                    'revenue_sum': 0.0,
-                    'revenue_count': 0,
-                    'close_sum': 0.0,
-                    'close_count': 0,
-                    'beautify_time_sum': 0.0,
-                    'beautify_time_count': 0,
-                }
-
-        def incr(b):
-            if evt in ('note_started', 'note_saved'):
-                b['notes'] += 1
-            elif evt == 'beautify':
-                b['beautify'] += 1
-            elif evt == 'suggest':
-                b['suggest'] += 1
-            elif evt == 'summary':
-                b['summary'] += 1
-            elif evt == 'chart_upload':
-                b['chart_upload'] += 1
-            elif evt == 'audio_recorded':
-                b['audio'] += 1
-
-        incr(daily[day])
-        incr(weekly[week])
-
-        if evt in ('note_started', 'note_saved'):
-            total_notes += 1
-        elif evt == 'beautify':
-            total_beautify += 1
-        elif evt == 'suggest':
-            total_suggest += 1
-        elif evt == 'summary':
-            total_summary += 1
-        elif evt == 'chart_upload':
-            total_chart_upload += 1
-        elif evt == 'audio_recorded':
-            total_audio += 1
-
-        length = details.get('length')
-        if isinstance(length, (int, float)):
-            length_sum += length
-            length_count += 1
-            daily[day]['length_sum'] += length
-            daily[day]['length_count'] += 1
-            weekly[week]['length_sum'] += length
-            weekly[week]['length_count'] += 1
-
-        rev = details.get('revenue')
-        if isinstance(rev, (int, float)):
-            revenue_sum += rev
-            revenue_count += 1
-            daily[day]['revenue_sum'] += rev
-            daily[day]['revenue_count'] += 1
-            weekly[week]['revenue_sum'] += rev
-            weekly[week]['revenue_count'] += 1
-
-        ttc = details.get('timeToClose')
-        if isinstance(ttc, (int, float)):
-            close_sum += ttc
-            close_count += 1
-            daily[day]['close_sum'] += ttc
-            daily[day]['close_count'] += 1
-            weekly[week]['close_sum'] += ttc
-            weekly[week]['close_count'] += 1
-
-        codes = details.get('codes')
+        codes = details.get("codes")
         if isinstance(codes, list):
-            denial_flag = details.get('denial') if isinstance(details.get('denial'), bool) else None
+            denial_flag = details.get("denial") if isinstance(details.get("denial"), bool) else None
             for code in codes:
                 code_counts[code] = code_counts.get(code, 0) + 1
                 if denial_flag is not None:
@@ -844,70 +841,75 @@ async def get_metrics(
                         totals[1] += 1
                     denial_counts[code] = totals
 
-        denial = details.get('denial')
+        denial = details.get("denial")
         if isinstance(denial, bool):
             denial_totals[0] += 1
             if denial:
                 denial_totals[1] += 1
-        deficiency = details.get('deficiency')
+
+        deficiency = details.get("deficiency")
         if isinstance(deficiency, bool):
             deficiency_totals[0] += 1
             if deficiency:
                 deficiency_totals[1] += 1
 
-        patient_id = details.get('patientID') or details.get('patientId') or details.get('patient_id')
-        if evt == 'note_started' and patient_id:
+        patient_id = (
+            details.get("patientID")
+            or details.get("patientId")
+            or details.get("patient_id")
+        )
+        if evt == "note_started" and patient_id:
             last_start_for_patient[patient_id] = ts
-        if evt == 'beautify' and patient_id and patient_id in last_start_for_patient:
+        if evt == "beautify" and patient_id and patient_id in last_start_for_patient:
             duration = ts - last_start_for_patient[patient_id]
             if duration >= 0:
                 beautify_time_sum += duration
                 beautify_time_count += 1
-                daily[day]['beautify_time_sum'] += duration
-                daily[day]['beautify_time_count'] += 1
-                weekly[week]['beautify_time_sum'] += duration
-                weekly[week]['beautify_time_count'] += 1
+                day = datetime.utcfromtimestamp(ts).strftime("%Y-%m-%d")
+                week = datetime.utcfromtimestamp(ts).strftime("%Y-%W")
+                daily_rec = beautify_daily.setdefault(day, [0.0, 0])
+                daily_rec[0] += duration
+                daily_rec[1] += 1
+                weekly_rec = beautify_weekly.setdefault(week, [0.0, 0])
+                weekly_rec[0] += duration
+                weekly_rec[1] += 1
 
-    avg_length = length_sum / length_count if length_count else 0
-    avg_revenue = revenue_sum / revenue_count if revenue_count else 0
-    avg_close_time = close_sum / close_count if close_count else 0
-    avg_beautify_time = beautify_time_sum / beautify_time_count if beautify_time_count else 0
-    denial_rates = {code: (v[1] / v[0] if v[0] else 0) for code, v in denial_counts.items()}
+    avg_beautify_time = (
+        beautify_time_sum / beautify_time_count if beautify_time_count else 0
+    )
+
+    # attach beautify averages to the SQL-produced time series
+    for entry in daily_list:
+        bt = beautify_daily.get(entry["date"])
+        entry["avg_beautify_time"] = bt[0] / bt[1] if bt and bt[1] else 0
+    for entry in weekly_list:
+        bt = beautify_weekly.get(entry["week"])
+        entry["avg_beautify_time"] = bt[0] / bt[1] if bt and bt[1] else 0
+
+    denial_rates = {
+        code: (v[1] / v[0] if v[0] else 0) for code, v in denial_counts.items()
+    }
     overall_denial = denial_totals[1] / denial_totals[0] if denial_totals[0] else 0
-    deficiency_rate = deficiency_totals[1] / deficiency_totals[0] if deficiency_totals[0] else 0
-
-    def finalize(bucket: Dict[str, Dict[str, Any]]):
-        out = []
-        for key in sorted(bucket.keys()):
-            entry = bucket[key]
-            entry['avg_note_length'] = entry['length_sum'] / entry['length_count'] if entry['length_count'] else 0
-            entry['revenue_per_visit'] = entry['revenue_sum'] / entry['revenue_count'] if entry['revenue_count'] else 0
-            entry['avg_beautify_time'] = entry['beautify_time_sum'] / entry['beautify_time_count'] if entry['beautify_time_count'] else 0
-            entry['avg_close_time'] = entry['close_sum'] / entry['close_count'] if entry['close_count'] else 0
-            for k in ['length_sum','length_count','revenue_sum','revenue_count','close_sum','close_count','beautify_time_sum','beautify_time_count']:
-                entry.pop(k, None)
-            out.append(entry)
-        return out
-
-    daily_list = finalize(daily)
-    weekly_list = finalize(weekly)
+    deficiency_rate = (
+        deficiency_totals[1] / deficiency_totals[0] if deficiency_totals[0] else 0
+    )
 
     return {
-        'total_notes': total_notes,
-        'total_beautify': total_beautify,
-        'total_suggest': total_suggest,
-        'total_summary': total_summary,
-        'total_chart_upload': total_chart_upload,
-        'total_audio': total_audio,
-        'avg_note_length': avg_length,
-        'avg_beautify_time': avg_beautify_time,
-        'avg_close_time': avg_close_time,
-        'revenue_per_visit': avg_revenue,
-        'coding_distribution': code_counts,
-        'denial_rate': overall_denial,
-        'denial_rates': denial_rates,
-        'deficiency_rate': deficiency_rate,
-        'timeseries': {'daily': daily_list, 'weekly': weekly_list},
+        "total_notes": total_notes,
+        "total_beautify": total_beautify,
+        "total_suggest": total_suggest,
+        "total_summary": total_summary,
+        "total_chart_upload": total_chart_upload,
+        "total_audio": total_audio,
+        "avg_note_length": avg_length,
+        "avg_beautify_time": avg_beautify_time,
+        "avg_close_time": avg_close_time,
+        "revenue_per_visit": avg_revenue,
+        "coding_distribution": code_counts,
+        "denial_rate": overall_denial,
+        "denial_rates": denial_rates,
+        "deficiency_rate": deficiency_rate,
+        "timeseries": {"daily": daily_list, "weekly": weekly_list},
     }
 @app.post("/summarize")
 async def summarize(req: NoteRequest) -> Dict[str, str]:

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -201,7 +201,25 @@ ChartJS.register(
         borderColor: 'rgba(0,0,0,1)',
         backgroundColor: 'rgba(0,0,0,0.2)',
       },
+      {
+        label: t('dashboard.cards.avgNoteLength'),
+        data: metrics.timeseries?.daily?.map((d) => d.avg_note_length || 0) || [],
+        borderColor: 'rgba(99,255,132,1)',
+        backgroundColor: 'rgba(99,255,132,0.2)',
+        yAxisID: 'y1',
+      },
     ],
+  };
+
+  const dailyOptions = {
+    scales: {
+      y: { beginAtZero: true },
+      y1: {
+        beginAtZero: true,
+        position: 'right',
+        grid: { drawOnChartArea: false },
+      },
+    },
   };
 
   const weeklyLabels = metrics.timeseries?.weekly?.map((w) => w.week) || [];
@@ -244,7 +262,25 @@ ChartJS.register(
         borderColor: 'rgba(0,0,0,1)',
         backgroundColor: 'rgba(0,0,0,0.2)',
       },
+      {
+        label: t('dashboard.cards.avgNoteLength'),
+        data: metrics.timeseries?.weekly?.map((w) => w.avg_note_length || 0) || [],
+        borderColor: 'rgba(99,255,132,1)',
+        backgroundColor: 'rgba(99,255,132,0.2)',
+        yAxisID: 'y1',
+      },
     ],
+  };
+
+  const weeklyOptions = {
+    scales: {
+      y: { beginAtZero: true },
+      y1: {
+        beginAtZero: true,
+        position: 'right',
+        grid: { drawOnChartArea: false },
+      },
+    },
   };
 
   const codingData = {
@@ -356,9 +392,9 @@ ChartJS.register(
       {metrics.timeseries && (
         <div className="timeseries" style={{ marginTop: '1rem' }}>
             <h3>{t('dashboard.dailyEvents')}</h3>
-            <Line data={dailyData} data-testid="daily-line" />
+            <Line data={dailyData} options={dailyOptions} data-testid="daily-line" />
             <h3 style={{ marginTop: '1rem' }}>{t('dashboard.weeklyEvents')}</h3>
-            <Line data={weeklyData} data-testid="weekly-line" />
+            <Line data={weeklyData} options={weeklyOptions} data-testid="weekly-line" />
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- aggregate events in `/metrics` with SQL GROUP BY and optional date filters
- expose daily and weekly timeseries with averages
- chart average note length in dashboard with dual‑axis line charts

## Testing
- `pytest tests/test_blockers.py::test_metrics_contains_timeseries_data -q`


------
https://chatgpt.com/codex/tasks/task_e_6892a4dc7d9c83248f8163502f7462f0