### PR TITLE
feat: specialty and payer-specific prompt overrides

### DIFF
--- a/backend/migrations.py
+++ b/backend/migrations.py
@@ -4,10 +4,11 @@ import sqlite3
 def ensure_settings_table(conn: sqlite3.Connection) -> None:
     """Ensure the settings table exists with all required columns.
 
-    This helper can be used during application startup or as a standalone
-    migration step.  It creates the ``settings`` table if it does not exist
-    and adds the ``lang`` column when missing.
+    This helper may be invoked during application startup or as a
+    standalone migration.  It creates the ``settings`` table when missing
+    and adds any new columns required by the application.
     """
+
     conn.execute(
         "CREATE TABLE IF NOT EXISTS settings ("
         "user_id INTEGER PRIMARY KEY,"
@@ -15,11 +16,16 @@ def ensure_settings_table(conn: sqlite3.Connection) -> None:
         "categories TEXT NOT NULL,"
         "rules TEXT NOT NULL,"
         "lang TEXT NOT NULL DEFAULT 'en',"
+        "specialty TEXT,"
+        "payer TEXT,"
         "FOREIGN KEY(user_id) REFERENCES users(id)"
         ")"
     )
-    # Check existing columns to handle upgrades from older schemas.
     columns = {row[1] for row in conn.execute("PRAGMA table_info(settings)")}
     if "lang" not in columns:
         conn.execute("ALTER TABLE settings ADD COLUMN lang TEXT NOT NULL DEFAULT 'en'")
+    if "specialty" not in columns:
+        conn.execute("ALTER TABLE settings ADD COLUMN specialty TEXT")
+    if "payer" not in columns:
+        conn.execute("ALTER TABLE settings ADD COLUMN payer TEXT")
     conn.commit()

--- a/backend/prompt_templates.example.yaml
+++ b/backend/prompt_templates.example.yaml
@@ -1,10 +1,21 @@
+# Example prompt template overrides.
+# Copy this file to prompt_templates.yaml or prompt_templates.json and
+# customise as needed.
+
+default:
+  beautify:
+    en: "Base instruction applied to all notes"
+
 specialty:
   cardiology:
     beautify:
       en: "Cardiology specific beautify instruction"
       es: "Instrucción de embellecer específica de cardiología"
+
 payer:
   medicare:
     suggest:
       en: "Follow Medicare coding rules"
       es: "Siga las reglas de codificación de Medicare"
+    beautify:
+      en: "Ensure documentation meets Medicare standards"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,8 +18,7 @@ This document provides a high‑level overview of the components that make up th
 ### Backend (`backend/`)
 
 - **FastAPI application** (`main.py`): Exposes endpoints to beautify notes (`/beautify`), suggest codes and compliance (`/suggest`), generate patient‑friendly summaries (`/summarize`), record analytics events (`/event`), return aggregated metrics (`/metrics`), stream events (`/events`) and set the OpenAI API key (`/apikey`).  It also initialises a SQLite database in the user's data directory to persist events.
-- **Prompt templates** (`prompts.py`): Contains functions to build chat prompts for beautification, suggestion generation and summarisation.  Each prompt includes system instructions emphasising de‑identification, no hallucination and JSON output formats.
- - **Prompt templates** (`prompts.py`): Contains functions to build chat prompts for beautification, suggestion generation and summarisation.  Each prompt includes system instructions emphasising de‑identification, no hallucination and JSON output formats.  Prompts accept a `lang` parameter (`en` or `es`) and may load overrides from `backend/prompt_templates.json` or `.yaml` keyed by specialty or payer.
+- **Prompt templates** (`prompts.py`): Contains functions to build chat prompts for beautification, suggestion generation and summarisation.  Each prompt includes system instructions emphasising de‑identification, no hallucination and JSON output formats.  Prompts accept a `lang` parameter (`en` or `es`) and may load extra instructions from `backend/prompt_templates.json` or `.yaml` keyed by specialty or payer.
 - **OpenAI client wrapper** (`openai_client.py`): Wraps `openai.ChatCompletion.create` and reads the API key either from the environment or from `openai_key.txt`.  It hides the details of the OpenAI SDK from the rest of the codebase.
 - **Audio processing** (`audio_processing.py`): Provides stubbed functions for diarisation and transcription.  They return empty strings and need to be implemented with real speech‑to‑text libraries (e.g. Whisper, pyannote).  This module demonstrates the expected API and highlights a current gap in functionality.
 
@@ -48,4 +47,4 @@ The current repository is designed for local development.  The `start.sh` script
 
 ## Customising Prompt Templates
 
-Prompt instructions can be tailored per specialty or payer.  Create a `backend/prompt_templates.json` or `backend/prompt_templates.yaml` file with entries under `specialty` or `payer` that map to custom `beautify`, `suggest`, or `summary` instructions.  Each instruction can provide translations via `en` and `es` keys.  When a request supplies matching `specialty` or `payer` values, the custom text overrides the default prompts.
+Prompt instructions can be tailored per specialty or payer.  Create a `backend/prompt_templates.json` or `backend/prompt_templates.yaml` file with entries under `specialty` or `payer` that map to custom `beautify`, `suggest`, or `summary` instructions.  Each instruction can provide translations via `en` and `es` keys.  When a request supplies matching `specialty` or `payer` values, the custom text is appended to the default prompts.

--- a/docs/PROMPT_TEMPLATES.md
+++ b/docs/PROMPT_TEMPLATES.md
@@ -1,0 +1,41 @@
+# Prompt Template Overrides
+
+RevenuePilot's language model prompts can be customised without modifying the
+source code.  Place a `prompt_templates.json` or `prompt_templates.yaml` file in
+the `backend/` directory to add instructions that supplement the built‑in
+prompts.
+
+## File structure
+
+The file contains three optional top‑level sections:
+
+- `default` – instructions applied to all requests.
+- `specialty` – overrides keyed by clinical specialty.
+- `payer` – overrides keyed by payer name.
+
+Each section may define the prompt *category* (`beautify`, `suggest`, or
+`summary`).  The value for a category can be either a single string or a mapping
+of language codes to strings.  When a mapping is used, the English (`en`)
+version acts as a fallback if the requested language is missing.
+
+Example (`prompt_templates.yaml`):
+
+```yaml
+default:
+  beautify:
+    en: "These instructions are always included."
+
+specialty:
+  cardiology:
+    beautify:
+      en: "Use cardiology terminology."
+
+payer:
+  medicare:
+    suggest:
+      en: "Follow Medicare coding rules."
+```
+
+With the above file, a call to `build_suggest_prompt(..., payer="medicare")`
+will append the Medicare instruction to the default prompt.  Multiple matching
+sections are concatenated in the order: `default`, `specialty`, then `payer`.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -99,6 +99,8 @@ function App() {
     enablePublicHealth: true,
     enableDifferentials: true,
     lang: 'en',
+    specialty: '',
+    payer: '',
     // Array of custom clinical rules supplied by the user.  When non‑empty,
     // these rules are appended to the prompt sent to the AI model.  Each
     // entry should be a concise guideline such as “Payer X requires ROS for 99214”.
@@ -215,7 +217,7 @@ function App() {
     // Strip HTML tags before sending the note to the backend.  ReactQuill
     // produces an HTML string; the backend expects plain text.
     const plain = stripHtml(draftText);
-    beautifyNote(plain, settingsState.lang)
+    beautifyNote(plain, settingsState.lang, { specialty: settingsState.specialty, payer: settingsState.payer })
       .then((cleaned) => {
         setBeautified(cleaned);
         setActiveTab('beautified');
@@ -244,6 +246,8 @@ function App() {
       chart: chartText,
       audio: audioTranscript,
       lang: settingsState.lang,
+      specialty: settingsState.specialty,
+      payer: settingsState.payer,
     })
       .then((summary) => {
         setSummaryText(summary);
@@ -404,6 +408,8 @@ function App() {
         rules: settingsState.rules,
         audio: audioTranscript,
         lang: settingsState.lang,
+        specialty: settingsState.specialty,
+        payer: settingsState.payer,
       })
         .then((data) => {
           setSuggestions(data);
@@ -416,7 +422,7 @@ function App() {
     }, 600); // 600ms delay
     // Cleanup function cancels the previous timer if draftText changes again
     return () => clearTimeout(timer);
-  }, [draftText, audioTranscript, age, sex, region]);
+  }, [draftText, audioTranscript, age, sex, region, settingsState.specialty, settingsState.payer]);
 
   // Effect: apply theme colours to CSS variables when the theme changes
   useEffect(() => {

--- a/src/api.js
+++ b/src/api.js
@@ -96,17 +96,20 @@ export async function saveSettings(settings, token) {
  * @param {string} text
  * @returns {Promise<string>}
  */
-export async function beautifyNote(text, lang = 'en') {
+export async function beautifyNote(text, lang = 'en', context = {}) {
   const baseUrl =
     import.meta?.env?.VITE_API_URL ||
     window.__BACKEND_URL__ ||
     window.location.origin;
   // If a backend URL is configured, call the API.  Otherwise, fall back to a stub.
   if (baseUrl) {
+    const payload = { text, lang };
+    if (context.specialty) payload.specialty = context.specialty;
+    if (context.payer) payload.payer = context.payer;
     const resp = await fetch(`${baseUrl}/beautify`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ text, lang }),
+      body: JSON.stringify(payload),
     });
     const data = await resp.json();
     return data.beautified;
@@ -140,6 +143,8 @@ export async function getSuggestions(text, context = {}) {
     if (typeof context.age === 'number') payload.age = context.age;
     if (context.sex) payload.sex = context.sex;
     if (context.region) payload.region = context.region;
+    if (context.specialty) payload.specialty = context.specialty;
+    if (context.payer) payload.payer = context.payer;
     const resp = await fetch(`${baseUrl}/suggest`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -396,6 +401,8 @@ export async function summarizeNote(text, context = {}) {
     const payload = { text, lang: context.lang };
     if (context.chart) payload.chart = context.chart;
     if (context.audio) payload.audio = context.audio;
+    if (context.specialty) payload.specialty = context.specialty;
+    if (context.payer) payload.payer = context.payer;
     try {
       const resp = await fetch(`${baseUrl}/summarize`, {
         method: 'POST',

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -64,6 +64,26 @@ function Settings({ settings, updateSettings }) {
     }
   };
 
+  const handleSpecialtyChange = async (event) => {
+    const updated = { ...settings, specialty: event.target.value };
+    updateSettings(updated);
+    try {
+      await saveSettings(updated);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const handlePayerChange = async (event) => {
+    const updated = { ...settings, payer: event.target.value };
+    updateSettings(updated);
+    try {
+      await saveSettings(updated);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
   return (
     <div className="settings-page" style={{ padding: '1rem', overflowY: 'auto' }}>
       <h2>{t('settings.title')}</h2>
@@ -174,6 +194,22 @@ function Settings({ settings, updateSettings }) {
         <option value="en">{t('settings.english')}</option>
         <option value="es">{t('settings.spanish')}</option>
       </select>
+
+      <h3>{t('settings.specialty')}</h3>
+      <input
+        type="text"
+        value={settings.specialty || ''}
+        onChange={handleSpecialtyChange}
+        style={{ width: '100%', padding: '0.5rem', marginBottom: '0.5rem', border: '1px solid var(--disabled)', borderRadius: '4px' }}
+      />
+
+      <h3>{t('settings.payer')}</h3>
+      <input
+        type="text"
+        value={settings.payer || ''}
+        onChange={handlePayerChange}
+        style={{ width: '100%', padding: '0.5rem', border: '1px solid var(--disabled)', borderRadius: '4px' }}
+      />
 
       <h3>{t('settings.templates')}</h3>
       <ul>

--- a/src/components/__tests__/Settings.test.jsx
+++ b/src/components/__tests__/Settings.test.jsx
@@ -20,6 +20,8 @@ test('saveSettings called when preferences change', async () => {
       enableDifferentials: true,
       rules: [],
       lang: 'en',
+      specialty: '',
+      payer: '',
     };
   const updateSettings = vi.fn();
   const { getByLabelText } = render(

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -98,6 +98,8 @@
     "customRulesHelp": "Enter one rule per line. These rules will be passed to the AI model to customise suggestions based on payer or clinic‑specific requirements.",
     "customRulesPlaceholder": "e.g. Commercial payer X requires three ROS for 99214; Include time spent on counselling for CPT 99406",
     "language": "Language",
+    "specialty": "Specialty",
+    "payer": "Payer",
     "templates": "Templates",
     "noTemplates": "No templates",
     "english": "English",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -98,6 +98,8 @@
     "customRulesHelp": "Introduzca una regla por línea. Estas reglas se pasarán al modelo de IA para personalizar las sugerencias según requisitos del pagador o de la clínica.",
     "customRulesPlaceholder": "p. ej., El pagador comercial X requiere tres ROS para 99214; Incluir tiempo dedicado a asesoría para CPT 99406",
     "language": "Idioma",
+    "specialty": "Especialidad",
+    "payer": "Pagador",
     "templates": "Plantillas",
     "noTemplates": "Sin plantillas",
     "english": "Inglés",

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -59,6 +59,8 @@ def test_login_and_settings(client):
     data = resp.json()
     assert data["theme"] == "modern"
     assert data["lang"] == "en"
+    assert data["specialty"] is None
+    assert data["payer"] is None
 
     new_settings = {
         "theme": "dark",
@@ -70,6 +72,8 @@ def test_login_and_settings(client):
         },
         "rules": ["x"],
         "lang": "es",
+        "specialty": "cardiology",
+        "payer": "medicare",
     }
     resp = client.post(
         "/settings", json=new_settings, headers=auth_header(token)
@@ -82,6 +86,8 @@ def test_login_and_settings(client):
     assert data["categories"]["codes"] is False
     assert data["rules"] == ["x"]
     assert data["lang"] == "es"
+    assert data["specialty"] == "cardiology"
+    assert data["payer"] == "medicare"
 
     resp = client.get("/settings")
     assert resp.status_code in {401, 403}

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -3,13 +3,13 @@ import sqlite3
 from backend.migrations import ensure_settings_table
 
 
-def test_ensure_settings_table_adds_lang():
-    # Start with an old schema lacking the lang column
+def test_ensure_settings_table_adds_columns():
+    # Start with an old schema lacking the new columns
     conn = sqlite3.connect(":memory:")
     conn.execute(
         "CREATE TABLE IF NOT EXISTS settings (user_id INTEGER PRIMARY KEY, theme TEXT NOT NULL, categories TEXT NOT NULL, rules TEXT NOT NULL)"
     )
     ensure_settings_table(conn)
     cols = {row[1] for row in conn.execute("PRAGMA table_info(settings)")}
-    assert {"user_id", "theme", "categories", "rules", "lang"} <= cols
+    assert {"user_id", "theme", "categories", "rules", "lang", "specialty", "payer"} <= cols
     conn.close()

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,4 +1,22 @@
 from backend import prompts
+from pathlib import Path
+import textwrap
+
+from typing import Iterator
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reset_templates() -> Iterator[None]:
+    """Ensure no prompt template overrides leak between tests."""
+    tpl_path = Path(prompts.__file__).with_name("prompt_templates.yaml")
+    if tpl_path.exists():
+        tpl_path.unlink()
+    prompts._load_custom_templates.cache_clear()
+    yield
+    if tpl_path.exists():
+        tpl_path.unlink()
+    prompts._load_custom_templates.cache_clear()
 
 
 def test_beautify_prompt_language():
@@ -20,3 +38,35 @@ def test_summary_prompt_language():
     es = prompts.build_summary_prompt("nota", lang="es")
     assert "clinical communicator" in en[0]["content"]
     assert "comunicador clínico" in es[0]["content"]
+
+
+def test_specialty_and_payer_overrides(tmp_path):
+    tpl_path = Path(prompts.__file__).with_name("prompt_templates.yaml")
+    tpl_path.write_text(
+        textwrap.dedent(
+            """
+            default:
+              beautify:
+                en: "Base addendum"
+            specialty:
+              cardiology:
+                beautify:
+                  en: "Cardio extra"
+            payer:
+              medicare:
+                beautify:
+                  en: "Medicare extra"
+                suggest:
+                  en: "Follow Medicare coding rules"
+            """
+        )
+    )
+    prompts._load_custom_templates.cache_clear()
+    beauty = prompts.build_beautify_prompt("note", lang="en", specialty="cardiology", payer="medicare")
+    content = beauty[0]["content"]
+    assert "clinical documentation specialist" in content
+    assert "Base addendum" in content
+    assert "Cardio extra" in content
+    assert "Medicare extra" in content
+    sugg = prompts.build_suggest_prompt("note", lang="en", payer="medicare")
+    assert "Follow Medicare coding rules" in sugg[0]["content"]


### PR DESCRIPTION
## Summary
- merge default prompt text with specialty- and payer-specific overrides loaded from JSON/YAML templates
- persist specialty and payer in user settings and expose them in the UI
- document prompt template override file format

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68929e9b50808324a853dc9b9f6a9dee