### PR TITLE
chore: document packaging and add CI build

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,10 +7,13 @@ BACKEND_URL=http://localhost:8000
 ICON_PNG_URL=
 ICON_ICO_URL=
 ICON_ICNS_URL=
-UPDATE_SERVER_URL=https://updates.revenuepilot.com
+# Auto-update feed
+UPDATE_SERVER_URL=
+
 # Windows signing
 WIN_CSC_LINK=
 WIN_CSC_KEY_PASSWORD=
+
 # macOS signing
 CSC_LINK=
 CSC_KEY_PASSWORD=

--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -1,0 +1,59 @@
+name: Electron Packaging
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: npm ci
+      - name: Generate dummy certificates
+        run: |
+          openssl req -new -newkey rsa:2048 -nodes -x509 -days 1 -subj "/CN=test" -keyout key.pem -out cert.pem
+          openssl pkcs12 -export -out cert.p12 -inkey key.pem -in cert.pem -passout pass:password
+      - name: Build electron app
+        env:
+          UPDATE_SERVER_URL: http://localhost:8080
+          WIN_CSC_LINK: cert.p12
+          WIN_CSC_KEY_PASSWORD: password
+          CSC_LINK: cert.p12
+          CSC_KEY_PASSWORD: password
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
+        run: npm run electron:build -- -l
+      - uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: dist
+
+  smoke:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: pip install -r backend/requirements.txt pytest pytest-cov
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm ci
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: dist
+      - name: Run update server
+        run: |
+          npm run update-server &
+          sleep 5
+          curl -I http://localhost:8080 || true
+          kill %1
+      - name: Run smoke tests
+        run: pytest tests/test_blockers.py::test_electron_auto_update_and_backend_spawn_present tests/test_blockers.py::test_update_server_serves_files -q

--- a/docs/DESKTOP_BUILD.md
+++ b/docs/DESKTOP_BUILD.md
@@ -25,6 +25,18 @@ The following variables are written to `.env`:
 - `CSC_LINK`, `CSC_KEY_PASSWORD` – macOS Developer ID certificate and
   password.
 
+## Obtaining code-signing certificates
+
+Windows builds require an Authenticode code-signing certificate. These can be
+purchased from certificate authorities such as DigiCert or GlobalSign. Export
+the certificate to a `.p12` file, host it securely and set `WIN_CSC_LINK` to
+its path or URL along with `WIN_CSC_KEY_PASSWORD`.
+
+macOS builds require membership in the Apple Developer Program. Create a
+*Developer ID Application* certificate in the Apple Developer portal, export it
+as a `.p12` file and configure `CSC_LINK` and `CSC_KEY_PASSWORD` with the file
+location and password.
+
 ## 2. Build signed installers
 
 Running the build script bundles the React frontend, the FastAPI backend and

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "electron:build": "npm run build && npm run fetch-icons && npm run backend:prebuild && node -r dotenv/config scripts/check-build-env.js && node -r dotenv/config ./node_modules/.bin/electron-builder -mwl",
     "fetch-icons": "node scripts/fetch-icons.js",
     "backend:prebuild": "node scripts/backend-prebuild.js",
-    "update-server": "node scripts/update-server.js",
+    "update-server": "node -r dotenv/config scripts/update-server.js",
     "setup-env": "node scripts/setup-env.js",
     "test": "vitest run"
   },
@@ -62,13 +62,17 @@
     },
     "mac": {
       "target": "dmg",
-      "category": "public.app-category.productivity"
+      "category": "public.app-category.productivity",
+      "cscLink": "${env.CSC_LINK}",
+      "cscKeyPassword": "${env.CSC_KEY_PASSWORD}"
     },
     "win": {
       "target": "nsis",
       "signingHashAlgorithms": [
         "sha256"
-      ]
+      ],
+      "cscLink": "${env.WIN_CSC_LINK}",
+      "cscKeyPassword": "${env.WIN_CSC_KEY_PASSWORD}"
     },
     "linux": {
       "target": [


### PR DESCRIPTION
## Summary
- add environment example for auto-update and code signing
- wire code signing certificates into electron-builder and document obtaining them
- run electron build & update-server in CI with smoke tests

## Testing
- `pytest tests/test_blockers.py::test_electron_auto_update_and_backend_spawn_present tests/test_blockers.py::test_update_server_serves_files -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892a4ed92b88324b81fc674d5c7d635