### PR TITLE
Expand backend and frontend tests

### DIFF
--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -1,11 +1,34 @@
 /* @vitest-environment jsdom */
-import { render } from '@testing-library/react';
-import { test, expect } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { test, expect, vi, beforeEach } from 'vitest';
 import '../i18n.js';
 import App from '../App.jsx';
 
-test('renders login form when no token', () => {
+vi.mock('../api.js', () => ({
+  getSettings: vi.fn().mockResolvedValue({
+    theme: 'modern',
+    lang: 'en',
+    enableCodes: true,
+    enableCompliance: true,
+    enablePublicHealth: true,
+    enableDifferentials: true,
+    rules: [],
+    region: '',
+  }),
+}));
+
+beforeEach(() => {
   localStorage.clear();
+  vi.clearAllMocks();
+});
+
+test('renders login form when no token', () => {
   const { getByLabelText } = render(<App />);
   expect(getByLabelText(/username/i)).toBeTruthy();
+});
+
+test('renders main app when token present', async () => {
+  localStorage.setItem('token', 'abc');
+  const { getByText } = render(<App />);
+  await waitFor(() => expect(getByText('Beautify')).toBeTruthy());
 });

--- a/src/components/__tests__/Settings.test.jsx
+++ b/src/components/__tests__/Settings.test.jsx
@@ -4,11 +4,12 @@ import { vi, expect, test, beforeEach } from 'vitest';
 import i18n from '../../i18n.js';
 
 vi.mock('../../api.js', () => ({ setApiKey: vi.fn(), saveSettings: vi.fn() }));
-import { saveSettings } from '../../api.js';
+import { saveSettings, setApiKey } from '../../api.js';
 import Settings from '../Settings.jsx';
 
 beforeEach(() => {
   vi.clearAllMocks();
+  i18n.changeLanguage('en');
 });
 
 test('saveSettings called when preferences change', async () => {
@@ -46,4 +47,26 @@ test('renders Spanish translations when lang is es', () => {
   );
   expect(getAllByText('Configuración').length).toBeGreaterThan(0);
   expect(getAllByText('Idioma').length).toBeGreaterThan(0);
+});
+
+test('setApiKey called when saving API key', async () => {
+  const settings = {
+    theme: 'modern',
+    enableCodes: true,
+    enableCompliance: true,
+    enablePublicHealth: true,
+    enableDifferentials: true,
+    rules: [],
+    lang: 'en',
+    region: '',
+  };
+  const { getAllByPlaceholderText, getAllByText } = render(
+    <Settings settings={settings} updateSettings={() => {}} />
+  );
+  const input = getAllByPlaceholderText('sk-... (e.g., sk-proj-...)')[0];
+  fireEvent.change(input, {
+    target: { value: 'sk-' + 'a'.repeat(22) },
+  });
+  fireEvent.click(getAllByText('Save Key')[0]);
+  await waitFor(() => expect(setApiKey).toHaveBeenCalled());
 });

--- a/tests/test_audio_processing.py
+++ b/tests/test_audio_processing.py
@@ -63,8 +63,7 @@ def test_diarize_fallback_when_unavailable(monkeypatch):
     assert result == {"provider": "full text", "patient": ""}
 
 
-@pytest.mark.asyncio
-async def test_transcribe_placeholder_on_failure(monkeypatch):
+def test_transcribe_placeholder_on_failure(monkeypatch):
     class DummyCreate:
         def create(self, model, file):  # noqa: ARG002
             raise RuntimeError("boom")


### PR DESCRIPTION
## Summary
- Convert register flow test to use synchronous TestClient
- Add App test verifying main UI renders with stored token
- Extend Settings tests to cover saving API key
- Simplify audio transcription failure test

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892a503e4f0832497faa74dad788010