### PR TITLE
Persist user settings on server

### DIFF
--- a/backend/migrations.py
+++ b/backend/migrations.py
@@ -13,8 +13,8 @@ def ensure_settings_table(conn: sqlite3.Connection) -> None:
         "CREATE TABLE IF NOT EXISTS settings ("
         "user_id INTEGER PRIMARY KEY,"
         "theme TEXT NOT NULL,"
-        "categories TEXT NOT NULL,"
-        "rules TEXT NOT NULL,"
+        "categories TEXT NOT NULL DEFAULT '{}',"
+        "rules TEXT NOT NULL DEFAULT '[]',"
         "lang TEXT NOT NULL DEFAULT 'en',"
         "specialty TEXT,"
         "payer TEXT,"
@@ -22,7 +22,16 @@ def ensure_settings_table(conn: sqlite3.Connection) -> None:
         "FOREIGN KEY(user_id) REFERENCES users(id)"
         ")"
     )
+
     columns = {row[1] for row in conn.execute("PRAGMA table_info(settings)")}
+    if "categories" not in columns:
+        conn.execute(
+            "ALTER TABLE settings ADD COLUMN categories TEXT NOT NULL DEFAULT '{}'"
+        )
+    if "rules" not in columns:
+        conn.execute(
+            "ALTER TABLE settings ADD COLUMN rules TEXT NOT NULL DEFAULT '[]'"
+        )
     if "lang" not in columns:
         conn.execute("ALTER TABLE settings ADD COLUMN lang TEXT NOT NULL DEFAULT 'en'")
     if "specialty" not in columns:

--- a/src/api.js
+++ b/src/api.js
@@ -60,7 +60,20 @@ export async function getSettings(token) {
     headers: { Authorization: `Bearer ${auth}` },
   });
   if (!resp.ok) throw new Error('Failed to fetch settings');
-  return await resp.json();
+  const data = await resp.json();
+  const categories = data.categories || {};
+  return {
+    theme: data.theme,
+    enableCodes: categories.codes !== false,
+    enableCompliance: categories.compliance !== false,
+    enablePublicHealth: categories.publicHealth !== false,
+    enableDifferentials: categories.differentials !== false,
+    rules: data.rules || [],
+    lang: data.lang || 'en',
+    specialty: data.specialty || '',
+    payer: data.payer || '',
+    region: data.region || '',
+  };
 }
 
 /**
@@ -78,13 +91,27 @@ export async function saveSettings(settings, token) {
   const auth =
     token || (typeof window !== 'undefined' ? localStorage.getItem('token') : null);
   if (!auth) throw new Error('Not authenticated');
+  const payload = {
+    theme: settings.theme,
+    categories: {
+      codes: settings.enableCodes,
+      compliance: settings.enableCompliance,
+      publicHealth: settings.enablePublicHealth,
+      differentials: settings.enableDifferentials,
+    },
+    rules: settings.rules || [],
+    lang: settings.lang || 'en',
+    specialty: settings.specialty || null,
+    payer: settings.payer || null,
+    region: settings.region || '',
+  };
   const resp = await fetch(`${baseUrl}/settings`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${auth}`,
     },
-    body: JSON.stringify(settings),
+    body: JSON.stringify(payload),
   });
   if (!resp.ok) throw new Error('Failed to save settings');
   return await resp.json();

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -4,10 +4,10 @@ from backend.migrations import ensure_settings_table
 
 
 def test_ensure_settings_table_adds_columns():
-    # Start with an old schema lacking the new columns
+    # Start with an old schema lacking all the newer columns
     conn = sqlite3.connect(":memory:")
     conn.execute(
-        "CREATE TABLE IF NOT EXISTS settings (user_id INTEGER PRIMARY KEY, theme TEXT NOT NULL, categories TEXT NOT NULL, rules TEXT NOT NULL)"
+        "CREATE TABLE IF NOT EXISTS settings (user_id INTEGER PRIMARY KEY, theme TEXT NOT NULL)"
     )
     ensure_settings_table(conn)
     cols = {row[1] for row in conn.execute("PRAGMA table_info(settings)")}


### PR DESCRIPTION
## Summary
- normalize settings API to read/write user preferences on the server
- add migration ensuring settings table carries categories, rules, language, and related fields
- test migrations and authenticated settings persistence

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892b2c9272483249c74f6f65044c574