### PR TITLE
Add public health recommendation API integrations

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -34,7 +34,7 @@ from .openai_client import call_openai
 from .key_manager import get_api_key, save_api_key, APP_NAME
 from platformdirs import user_data_dir
 from .audio_processing import simple_transcribe, diarize_and_transcribe
-from .public_health import get_public_health_suggestions
+from . import public_health as public_health_api
 from .migrations import ensure_settings_table
 
 
@@ -1091,7 +1091,9 @@ async def suggest(req: NoteRequest, user=Depends(require_role("user"))) -> Sugge
         public_health = [str(x) for x in public_health_raw]
         diffs = [str(x) for x in data.get("differentials", [])]
         # Augment public health suggestions with external guidelines
-        extra_ph = get_public_health_suggestions(req.age, req.sex, req.region)
+        extra_ph = public_health_api.get_public_health_suggestions(
+            req.age, req.sex, req.region
+        )
         if extra_ph:
             public_health = list(dict.fromkeys(public_health + extra_ph))
         # If all categories are empty, raise an error to fall back to rule-based suggestions.
@@ -1157,7 +1159,9 @@ async def suggest(req: NoteRequest, user=Depends(require_role("user"))) -> Sugge
             public_health.append("Consider influenza vaccine")
         if not diffs:
             diffs.append("Routine follow-up")
-        extra_ph = get_public_health_suggestions(req.age, req.sex, req.region)
+        extra_ph = public_health_api.get_public_health_suggestions(
+            req.age, req.sex, req.region
+        )
         if extra_ph:
             public_health = list(dict.fromkeys(public_health + extra_ph))
         return SuggestionsResponse(

--- a/backend/public_health.py
+++ b/backend/public_health.py
@@ -1,11 +1,13 @@
-"""Fetch public health guidelines based on demographics.
+"""Public health recommendation helpers.
 
-This module retrieves public health recommendations from an external API
-according to patient age, sex and region.  The API base URL can be
-configured via the ``PUBLIC_HEALTH_API_URL`` environment variable.  The
-function returns a list of plain string suggestions.  Network failures or
-unexpected responses result in an empty list so callers can fail gracefully.
+This module provides thin wrappers around external public health APIs to
+retrieve preventative care recommendations.  Two separate endpoints are
+consulted – one for vaccinations and another for screenings.  Each helper
+returns a list of recommendation strings and gracefully falls back to an
+empty list if anything goes wrong.  Environment variables allow the API
+endpoints to be overridden during deployment or tests.
 """
+
 from __future__ import annotations
 
 import os
@@ -13,39 +15,83 @@ from typing import List, Optional
 
 import requests
 
-BASE_URL = os.getenv("PUBLIC_HEALTH_API_URL", "https://public-health.example.com/guidelines")
+# Base URLs for the external services.  These are intentionally configurable so
+# tests can monkeypatch them and real deployments can point to trusted sources.
+VACCINATION_API_URL = os.getenv(
+    "VACCINATION_API_URL", "https://public-health.example.com/vaccinations"
+)
+SCREENING_API_URL = os.getenv(
+    "SCREENING_API_URL", "https://public-health.example.com/screenings"
+)
 
 
-def get_public_health_suggestions(age: Optional[int], sex: Optional[str], region: Optional[str]) -> List[str]:
-    """Return public health suggestions for the given demographics.
+def _extract_items(data: object, key: str) -> List[str]:
+    """Return list of strings from ``data`` using a best‑effort strategy."""
 
-    Args:
-        age: Patient age in years.
-        sex: Patient sex or gender.
-        region: Geographic region or country code.
-    Returns:
-        A list of recommendation strings.  Returns an empty list on error or
-        when insufficient demographics are provided.
-    """
+    items: List[str] = []
+    if isinstance(data, dict):
+        raw = (
+            data.get(key)
+            or data.get("recommendations")
+            or data.get("suggestions")
+            or data.get("results")
+            or data.get("data")
+        )
+        if isinstance(raw, list):
+            items = raw
+    elif isinstance(data, list):
+        items = data
+    return [str(x) for x in items]
+
+
+def fetch_vaccination_recommendations(
+    age: Optional[int], sex: Optional[str], region: Optional[str]
+) -> List[str]:
+    """Return vaccination recommendations for the supplied demographics."""
+
     if age is None or not sex or not region:
         return []
     params = {"age": age, "sex": sex, "region": region}
     try:
-        resp = requests.get(BASE_URL, params=params, timeout=10)
+        resp = requests.get(VACCINATION_API_URL, params=params, timeout=10)
         resp.raise_for_status()
-        data = resp.json()
-        # The API is expected to return a JSON object with a ``suggestions``
-        # field containing a list of strings.  If the structure differs,
-        # fallback to an empty list.
-        items = []
-        if isinstance(data, dict):
-            raw = data.get("suggestions") or data.get("data") or data.get("results")
-            if isinstance(raw, list):
-                items = raw
-        elif isinstance(data, list):
-            items = data
-        return [str(x) for x in items]
+        return _extract_items(resp.json(), "vaccinations")
     except Exception as exc:  # pragma: no cover - best effort logging
-        # Print error so it surfaces in logs but don't crash the caller.
-        print(f"Public health API error: {exc}")
+        print(f"Vaccination API error: {exc}")
         return []
+
+
+def fetch_screening_recommendations(
+    age: Optional[int], sex: Optional[str], region: Optional[str]
+) -> List[str]:
+    """Return screening recommendations for the supplied demographics."""
+
+    if age is None or not sex or not region:
+        return []
+    params = {"age": age, "sex": sex, "region": region}
+    try:
+        resp = requests.get(SCREENING_API_URL, params=params, timeout=10)
+        resp.raise_for_status()
+        return _extract_items(resp.json(), "screenings")
+    except Exception as exc:  # pragma: no cover - best effort logging
+        print(f"Screening API error: {exc}")
+        return []
+
+
+def get_public_health_suggestions(
+    age: Optional[int], sex: Optional[str], region: Optional[str]
+) -> List[str]:
+    """Return combined vaccination and screening recommendations."""
+
+    vaccs = fetch_vaccination_recommendations(age, sex, region)
+    screens = fetch_screening_recommendations(age, sex, region)
+    # Use ``dict.fromkeys`` to remove duplicates while preserving order.
+    return list(dict.fromkeys(vaccs + screens))
+
+
+__all__ = [
+    "fetch_vaccination_recommendations",
+    "fetch_screening_recommendations",
+    "get_public_health_suggestions",
+]
+

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -328,7 +328,9 @@ def test_suggest_includes_public_health_from_api(client, monkeypatch):
         assert region == "US"
         return ["Shingles vaccine"]
 
-    monkeypatch.setattr(main, "get_public_health_suggestions", fake_ph)
+    monkeypatch.setattr(
+        main.public_health_api, "get_public_health_suggestions", fake_ph
+    )
 
     token_d = main.create_token("u", "user")
     resp = client.post(

--- a/tests/test_public_health.py
+++ b/tests/test_public_health.py
@@ -13,20 +13,48 @@ class DummyResp:
         return self._data
 
 
-def test_get_public_health_suggestions(monkeypatch):
+def test_fetch_vaccination_recommendations(monkeypatch):
     def fake_get(url, params=None, timeout=10):
+        assert url == public_health.VACCINATION_API_URL
         assert params == {"age": 40, "sex": "male", "region": "US"}
-        return DummyResp({"suggestions": ["Flu shot", "BP check"]})
+        return DummyResp({"vaccinations": ["Flu shot"]})
 
     monkeypatch.setattr(public_health.requests, "get", fake_get)
+    result = public_health.fetch_vaccination_recommendations(40, "male", "US")
+    assert result == ["Flu shot"]
+
+
+def test_fetch_screening_recommendations(monkeypatch):
+    def fake_get(url, params=None, timeout=10):
+        assert url == public_health.SCREENING_API_URL
+        assert params == {"age": 40, "sex": "male", "region": "US"}
+        return DummyResp({"screenings": ["BP check"]})
+
+    monkeypatch.setattr(public_health.requests, "get", fake_get)
+    result = public_health.fetch_screening_recommendations(40, "male", "US")
+    assert result == ["BP check"]
+
+
+def test_get_public_health_suggestions_combines(monkeypatch):
+    monkeypatch.setattr(
+        public_health,
+        "fetch_vaccination_recommendations",
+        lambda *args, **kwargs: ["Flu shot"],
+    )
+    monkeypatch.setattr(
+        public_health,
+        "fetch_screening_recommendations",
+        lambda *args, **kwargs: ["Flu shot", "BP check"],
+    )
     result = public_health.get_public_health_suggestions(40, "male", "US")
     assert result == ["Flu shot", "BP check"]
 
 
-def test_get_public_health_suggestions_error(monkeypatch):
+def test_fetch_vaccination_recommendations_error(monkeypatch):
     def fake_get(*args, **kwargs):
         raise requests.RequestException("boom")
 
     monkeypatch.setattr(public_health.requests, "get", fake_get)
-    result = public_health.get_public_health_suggestions(40, "male", "US")
+    result = public_health.fetch_vaccination_recommendations(40, "male", "US")
     assert result == []
+


### PR DESCRIPTION
## Summary
- add `public_health` module with vaccination and screening fetchers from configurable APIs
- augment `/suggest` to merge external vaccination and screening guidance
- test public health helpers and suggestion integration with mocked APIs

## Testing
- `pytest` *(fails: tests/test_blockers.py::test_audio_transcription_returns_text - KeyError: 'provider')*

------
https://chatgpt.com/codex/tasks/task_e_6892c1d486008324895b1335dd2486b0