### PR TITLE
feat: surface audio transcript and diarisation in editor

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -959,6 +959,18 @@ async def transcribe(
     last_transcript.update(result)
     return result
 
+
+@app.get("/transcribe")
+async def get_last_transcript(user=Depends(require_role("user"))) -> Dict[str, str]:
+    """Return the most recent audio transcript.
+
+    This endpoint allows the frontend to retrieve the last transcript
+    produced by :func:`transcribe` without uploading the audio again.
+    The transcript is stored in-memory and reset when the server restarts.
+    """
+
+    return last_transcript
+
 # Endpoint: set the OpenAI API key.  Accepts a JSON body with a single
 # field "key" and stores it in a local file.  Also updates the
 # environment variable OPENAI_API_KEY so future requests in this

--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -15,6 +15,7 @@ vi.mock('../api.js', () => ({
     rules: [],
     region: '',
   }),
+  fetchLastTranscript: vi.fn().mockResolvedValue({ provider: '', patient: '' }),
 }));
 
 // Mock fetch for loading default templates and reset state before each test

--- a/src/__tests__/NoteEditor.test.jsx
+++ b/src/__tests__/NoteEditor.test.jsx
@@ -1,0 +1,43 @@
+/* @vitest-environment jsdom */
+import { render, cleanup } from '@testing-library/react';
+import { test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../api.js', () => ({
+  fetchLastTranscript: vi.fn(),
+}));
+
+import { fetchLastTranscript } from '../api.js';
+import '../i18n.js';
+import NoteEditor from '../components/NoteEditor.jsx';
+
+beforeEach(() => {
+  fetchLastTranscript.mockResolvedValue({ provider: 'hello', patient: 'world' });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+test('transcript persists across reloads', async () => {
+  const { findByText, unmount } = render(
+    <NoteEditor id="n1" value="" onChange={() => {}} />
+  );
+  await findByText(/Provider:/);
+  expect(fetchLastTranscript).toHaveBeenCalledTimes(2);
+  unmount();
+  const { findByText: findByText2 } = render(
+    <NoteEditor id="n1" value="" onChange={() => {}} />
+  );
+  await findByText2(/Provider:/);
+  expect(fetchLastTranscript).toHaveBeenCalledTimes(4);
+});
+
+test('shows diarised output when available', async () => {
+  fetchLastTranscript.mockResolvedValue({ provider: 'Doc', patient: 'Pat' });
+  const { findByText } = render(
+    <NoteEditor id="n2" value="" onChange={() => {}} />
+  );
+  await findByText(/Provider:/);
+  await findByText(/Patient:/);
+});

--- a/src/api.js
+++ b/src/api.js
@@ -258,6 +258,32 @@ export async function transcribeAudio(blob, diarise = false) {
 }
 
 /**
+ * Retrieve the most recent audio transcript from the backend.
+ * @returns {Promise<{provider: string, patient: string}>}
+ */
+export async function fetchLastTranscript() {
+  const baseUrl =
+    import.meta?.env?.VITE_API_URL ||
+    window.__BACKEND_URL__ ||
+    window.location.origin;
+  if (baseUrl) {
+    try {
+      const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+      const headers = token ? { Authorization: `Bearer ${token}` } : {};
+      const resp = await fetch(`${baseUrl}/transcribe`, { headers });
+      if (resp.status === 401 || resp.status === 403) {
+        throw new Error('Unauthorized');
+      }
+      const data = await resp.json();
+      return { provider: data.provider || '', patient: data.patient || '' };
+    } catch (err) {
+      console.error('fetchLastTranscript error', err);
+    }
+  }
+  return { provider: '', patient: '' };
+}
+
+/**
  * Log an analytics event.  Sends the event type and optional details to the
  * backend.  If no backend is configured, the call is a no-op.
  * @param {string} eventType

--- a/src/components/__tests__/NoteEditor.test.jsx
+++ b/src/components/__tests__/NoteEditor.test.jsx
@@ -1,6 +1,11 @@
 /* @vitest-environment jsdom */
 import { render, cleanup, fireEvent } from '@testing-library/react';
 import { vi, expect, test, afterEach } from 'vitest';
+
+vi.mock('../../api.js', () => ({
+  fetchLastTranscript: vi.fn().mockResolvedValue({ provider: '', patient: '' }),
+}));
+
 import '../../i18n.js';
 import NoteEditor from '../NoteEditor.jsx';
 


### PR DESCRIPTION
## Summary
- expose GET `/transcribe` for retrieving last transcript
- show provider/patient transcript with recording status in `NoteEditor`
- load last transcript from backend and handle recording/transcribing errors
- add tests for transcript persistence, diarised output and API endpoint

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892c6e597988324aa65c5536f962d17