### PR TITLE
Add end-to-end success path tests and frontend coverage

### DIFF
--- a/src/components/__tests__/Dashboard.test.jsx
+++ b/src/components/__tests__/Dashboard.test.jsx
@@ -107,3 +107,17 @@ test('denies access when user not admin', () => {
   render(<Dashboard />);
   expect(alertSpy).toHaveBeenCalled();
 });
+
+test('applies clinician filter', async () => {
+  const { getByLabelText, getByText } = render(<Dashboard />);
+  await waitFor(() => document.querySelector('[data-testid="daily-line"]'));
+  const clinicianInput = getByLabelText('Clinician');
+  fireEvent.change(clinicianInput, { target: { value: 'alice' } });
+  getByText('Apply').click();
+  await waitFor(() => expect(getMetrics).toHaveBeenCalledTimes(2));
+  expect(getMetrics).toHaveBeenLastCalledWith({
+    start: '',
+    end: '',
+    clinician: 'alice',
+  });
+});

--- a/src/components/__tests__/Settings.test.jsx
+++ b/src/components/__tests__/Settings.test.jsx
@@ -131,3 +131,25 @@ test('setApiKey called when saving API key', async () => {
   fireEvent.click(getAllByText('Save Key')[0]);
   await waitFor(() => expect(setApiKey).toHaveBeenCalled());
 });
+
+test('changing theme triggers saveSettings', async () => {
+  const settings = {
+    theme: 'modern',
+    enableCodes: true,
+    enableCompliance: true,
+    enablePublicHealth: true,
+    enableDifferentials: true,
+    rules: [],
+    lang: 'en',
+    region: '',
+  };
+  const updateSettings = vi.fn();
+  const { getByLabelText } = render(
+    <Settings settings={settings} updateSettings={updateSettings} />
+  );
+  await fireEvent.click(getByLabelText('Dark Elegance'));
+  await waitFor(() => expect(saveSettings).toHaveBeenCalled());
+  expect(updateSettings).toHaveBeenCalledWith(
+    expect.objectContaining({ theme: 'dark' })
+  );
+});

--- a/tests/test_blockers.py
+++ b/tests/test_blockers.py
@@ -1,9 +1,9 @@
-"""Failing tests for open blockers.
+"""Regression tests for previously blocked features.
 
-These tests highlight missing or incomplete functionality described in
-`docs/ROADMAP.md`.  They are intentionally written to fail or be marked as
-`xfail` so that subsequent development can drive them to green.  When
-implementing these features, update or remove the `xfail` markers.
+The project roadmap once marked these behaviours as incomplete and some tests
+used ``xfail`` to document the gaps.  Those features have since been
+implemented, so the ``xfail`` markers have been removed and the tests now run
+as part of the standard suite.
 """
 
 import os

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -14,6 +14,16 @@ def setup_module(module):
         "CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT, eventType TEXT, timestamp REAL, details TEXT)"
     )
 
+
+def test_metrics_empty_returns_zeros():
+    """When no events are logged metrics should return zeros and empty dicts."""
+    client = TestClient(main.app)
+    token = main.create_token('admin', 'admin')
+    resp = client.get('/metrics', headers={'Authorization': f'Bearer {token}'})
+    data = resp.json()
+    assert data['total_notes'] == 0
+    assert data['coding_distribution'] == {}
+
 def test_metrics_aggregation():
     client = TestClient(main.app)
     events = [

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -68,3 +68,13 @@ def test_specialty_and_payer_overrides():
     texts = [m["content"] for m in summary]
     assert "Example summary note" in texts
 
+
+def test_guideline_tips_added(monkeypatch):
+    """Public health guideline tips should be appended to the user content."""
+    monkeypatch.setattr(
+        prompts, "get_guidelines", lambda age, sex, region: {"vaccinations": ["Flu"], "screenings": ["BP"]}
+    )
+    msgs = prompts.build_suggest_prompt("note", age=30, sex="male", region="US")
+    user_msg = msgs[-1]["content"]
+    assert "Flu" in user_msg and "BP" in user_msg
+

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -34,10 +34,13 @@ def test_register_endpoint(monkeypatch):
     )
     assert resp.status_code == 200
 
-    # New user can log in
+    # New user can log in and receives a token with the correct role
     resp = client.post("/login", json={"username": "bob", "password": "pw"})
     assert resp.status_code == 200
-    assert "access_token" in resp.json()
+    token_resp = resp.json()["access_token"]
+    assert token_resp
+    payload = main.jwt.decode(token_resp, main.JWT_SECRET, algorithms=[main.JWT_ALGORITHM])
+    assert payload["role"] == "user"
 
     # Non-admin should be rejected
     user_token = main.create_token("bob", "user")

--- a/tests/test_settings_persistence.py
+++ b/tests/test_settings_persistence.py
@@ -1,0 +1,61 @@
+import hashlib
+import sqlite3
+
+from fastapi.testclient import TestClient
+
+from backend import main, migrations
+
+
+def _setup_db(monkeypatch):
+    """Create an in-memory database with users and settings tables."""
+    db = sqlite3.connect(":memory:", check_same_thread=False)
+    db.row_factory = sqlite3.Row
+    db.execute(
+        "CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password_hash TEXT, role TEXT)"
+    )
+    migrations.ensure_settings_table(db)
+    pwd = hashlib.sha256(b"pw").hexdigest()
+    db.execute(
+        "INSERT INTO users (username, password_hash, role) VALUES (?,?,?)",
+        ("alice", pwd, "user"),
+    )
+    db.commit()
+    monkeypatch.setattr(main, "db_conn", db)
+    return db
+
+
+def test_settings_roundtrip(monkeypatch):
+    """Saving settings should persist and be returned on subsequent fetches."""
+    _setup_db(monkeypatch)
+    client = TestClient(main.app)
+    token = main.create_token("alice", "user")
+
+    prefs = {
+        "theme": "dark",
+        "categories": {
+            "codes": True,
+            "compliance": False,
+            "publicHealth": True,
+            "differentials": True,
+        },
+        "rules": ["r1"],
+        "lang": "es",
+        "specialty": "cardiology",
+        "payer": "medicare",
+        "region": "us",
+    }
+
+    resp = client.post(
+        "/settings", json=prefs, headers={"Authorization": f"Bearer {token}"}
+    )
+    assert resp.status_code == 200
+
+    resp = client.get("/settings", headers={"Authorization": f"Bearer {token}"})
+    data = resp.json()
+    assert data["theme"] == "dark"
+    assert data["categories"]["compliance"] is False
+    assert data["lang"] == "es"
+    assert data["specialty"] == "cardiology"
+    assert data["payer"] == "medicare"
+    assert data["region"] == "us"
+


### PR DESCRIPTION
## Summary
- remove old xfail references now that blocker tests pass
- add registration/login assertions on returned role token
- verify settings save and load roundtrip
- expand prompt generation, metrics and frontend tests

## Testing
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892c72a49cc8324acb5a167b02b67ff