### PR TITLE
Allow users to manage personal templates

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -35,7 +35,7 @@ from .key_manager import get_api_key, save_api_key, APP_NAME
 from platformdirs import user_data_dir
 from .audio_processing import simple_transcribe, diarize_and_transcribe
 from . import public_health as public_health_api
-from .migrations import ensure_settings_table
+from .migrations import ensure_settings_table, ensure_templates_table
 
 
 import json
@@ -172,6 +172,9 @@ db_conn.commit()
 # Persisted user preferences for theme, enabled categories and custom rules.
 # Ensure the table exists and contains the latest schema (including ``lang``).
 ensure_settings_table(db_conn)
+
+# Table storing user and clinic specific note templates.
+ensure_templates_table(db_conn)
 
 # Configure the database connection to return rows as dictionaries.  This
 # makes it easier to access columns by name when querying events for
@@ -658,7 +661,7 @@ async def log_event(event: EventModel, user=Depends(require_role("user"))) -> Di
 
 
 @app.get("/templates", response_model=List[TemplateModel])
-def get_templates(user=Depends(require_role("admin"))) -> List[TemplateModel]:
+def get_templates(user=Depends(require_role("user"))) -> List[TemplateModel]:
     """Return custom templates for the current user and clinic."""
 
     clinic = user.get("clinic")
@@ -671,7 +674,7 @@ def get_templates(user=Depends(require_role("admin"))) -> List[TemplateModel]:
 
 
 @app.post("/templates", response_model=TemplateModel)
-def create_template(tpl: TemplateModel, user=Depends(require_role("admin"))) -> TemplateModel:
+def create_template(tpl: TemplateModel, user=Depends(require_role("user"))) -> TemplateModel:
     """Create a new custom template for the user."""
 
     clinic = user.get("clinic")
@@ -686,7 +689,7 @@ def create_template(tpl: TemplateModel, user=Depends(require_role("admin"))) -> 
 
 
 @app.put("/templates/{template_id}", response_model=TemplateModel)
-def update_template(template_id: int, tpl: TemplateModel, user=Depends(require_role("admin"))) -> TemplateModel:
+def update_template(template_id: int, tpl: TemplateModel, user=Depends(require_role("user"))) -> TemplateModel:
     """Update an existing custom template owned by the current user."""
 
     cursor = db_conn.cursor()
@@ -701,7 +704,7 @@ def update_template(template_id: int, tpl: TemplateModel, user=Depends(require_r
 
 
 @app.delete("/templates/{template_id}")
-def delete_template(template_id: int, user=Depends(require_role("admin"))) -> Dict[str, str]:
+def delete_template(template_id: int, user=Depends(require_role("user"))) -> Dict[str, str]:
     """Delete a custom template owned by the current user."""
 
     cursor = db_conn.cursor()

--- a/backend/migrations.py
+++ b/backend/migrations.py
@@ -41,3 +41,16 @@ def ensure_settings_table(conn: sqlite3.Connection) -> None:
     if "region" not in columns:
         conn.execute("ALTER TABLE settings ADD COLUMN region TEXT")
     conn.commit()
+
+def ensure_templates_table(conn: sqlite3.Connection) -> None:
+    """Ensure the templates table exists for storing note templates."""
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS templates ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT," 
+        "user TEXT,"
+        "clinic TEXT,"
+        "name TEXT,"
+        "content TEXT"
+        ")"
+    )
+    conn.commit()

--- a/src/components/TemplatesModal.jsx
+++ b/src/components/TemplatesModal.jsx
@@ -10,6 +10,18 @@ function TemplatesModal({ baseTemplates, onSelect, onClose }) {
   const [editingId, setEditingId] = useState(null);
   const [error, setError] = useState(null);
 
+  let isAdmin = false;
+  if (typeof window !== 'undefined') {
+    const token = localStorage.getItem('token');
+    if (token) {
+      try {
+        isAdmin = JSON.parse(atob(token.split('.')[1])).role === 'admin';
+      } catch {
+        isAdmin = false;
+      }
+    }
+  }
+
   useEffect(() => {
     getTemplates()
       .then((data) => setTemplates([...baseTemplates, ...data]))
@@ -83,14 +95,16 @@ function TemplatesModal({ baseTemplates, onSelect, onClose }) {
                 >
                   {tpl.name}
                 </button>
-                {tpl.id && (
+                {(tpl.id || isAdmin) && (
                   <>
                     <button onClick={() => handleEdit(tpl)} style={{ marginLeft: '0.25rem' }}>
                       {t('templatesModal.edit')}
                     </button>
-                    <button onClick={() => handleDelete(tpl.id)} style={{ marginLeft: '0.25rem' }}>
-                      {t('templatesModal.delete')}
-                    </button>
+                    {tpl.id && (
+                      <button onClick={() => handleDelete(tpl.id)} style={{ marginLeft: '0.25rem' }}>
+                        {t('templatesModal.delete')}
+                      </button>
+                    )}
                   </>
                 )}
               </li>

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -16,7 +16,7 @@ def setup_module(module):
 
 def test_create_update_and_list_templates():
     client = TestClient(main.app)
-    token = main.create_token('alice', 'admin', clinic='clinic1')
+    token = main.create_token('alice', 'user', clinic='clinic1')
     resp = client.post(
         '/templates',
         json={'name': 'Custom', 'content': 'Note'},
@@ -39,7 +39,7 @@ def test_create_update_and_list_templates():
 
 def test_delete_template():
     client = TestClient(main.app)
-    token = main.create_token('alice', 'admin', clinic='clinic1')
+    token = main.create_token('alice', 'user', clinic='clinic1')
     resp = client.post(
         '/templates',
         json={'name': 'Temp', 'content': 'X'},
@@ -54,14 +54,14 @@ def test_delete_template():
 
 def test_template_scoped_by_clinic():
     client = TestClient(main.app)
-    token_a = main.create_token('alice', 'admin', clinic='clinicA')
+    token_a = main.create_token('alice', 'user', clinic='clinicA')
     resp = client.post(
         '/templates',
         json={'name': 'Scoped', 'content': 'S'},
         headers={'Authorization': f'Bearer {token_a}'},
     )
     tpl_id = resp.json()['id']
-    token_b = main.create_token('alice', 'admin', clinic='clinicB')
+    token_b = main.create_token('alice', 'user', clinic='clinicB')
     resp = client.get('/templates', headers={'Authorization': f'Bearer {token_b}'})
     assert all(t['id'] != tpl_id for t in resp.json())
 
@@ -72,11 +72,11 @@ def test_templates_require_auth():
     assert resp.status_code in {401, 403}
 
 
-def test_templates_require_admin_role():
+def test_templates_allow_user_role():
     client = TestClient(main.app)
     token = main.create_token('alice', 'user', clinic='clinic1')
     resp = client.get('/templates', headers={'Authorization': f'Bearer {token}'})
-    assert resp.status_code == 403
+    assert resp.status_code == 200
 
 
 def test_templates_reject_invalid_token():


### PR DESCRIPTION
## Summary
- enable template management for regular users by lowering /templates role requirement
- persist templates reliably by creating templates table on startup
- decode JWT role in TemplatesModal so admins can edit global templates

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892d18c5b1c8324973044f2fd3b9507