### PR TITLE
Add offline model mode for deterministic API responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ app into an Electron shell for desktop deployment.
 
    If you prefer not to use the UI, you can manually create the file `backend/openai_key.txt` containing your secret key and restart the server.
 
+### Offline model mode (experimental)
+
+Set the environment variable `USE_OFFLINE_MODEL=true` before starting the backend to bypass calls to external AI services. In this mode the `/beautify`, `/suggest` and `/summarize` endpoints return deterministic placeholder data so the app can run without network access or an API key.
+
 ### Advanced PHI de-identification
 
 The backend can optionally use machine-learning based scrubbers to remove names, dates, addresses, Social Security numbers and phone numbers from notes.

--- a/backend/main.py
+++ b/backend/main.py
@@ -42,6 +42,11 @@ import json
 import sqlite3
 import hashlib
 
+# When ``USE_OFFLINE_MODEL`` is set, endpoints will return deterministic
+# placeholder responses without calling external AI services.  This is useful
+# for running the API in environments without network access.
+USE_OFFLINE_MODEL = os.getenv("USE_OFFLINE_MODEL", "false").lower() in {"1", "true", "yes"}
+
 try:
     import scrubadub
     _SCRUBBER_AVAILABLE = True
@@ -988,19 +993,24 @@ async def summarize(req: NoteRequest, user=Depends(require_role("user"))) -> Dic
     if req.audio:
         combined += "\n\n" + str(req.audio)
     cleaned = deidentify(combined)
-    try:
-        messages = build_summary_prompt(cleaned, req.lang, req.specialty, req.payer)
-        response_content = call_openai(messages)
-        summary = response_content.strip()
-    except Exception as exc:
-        # If the LLM call fails, fall back to a simple truncation of the
-        # cleaned text.  Take the first 200 characters and append ellipsis
-        # if the text is longer.  This ensures the endpoint still returns
-        # something useful without crashing.
-        print(f"Error during summary LLM call: {exc}")
-        summary = cleaned[:200]
-        if len(cleaned) > 200:
-            summary += "..."
+    if USE_OFFLINE_MODEL:
+        from .offline_model import summarize as offline_summarize
+
+        summary = offline_summarize(cleaned, req.lang, req.specialty, req.payer)
+    else:
+        try:
+            messages = build_summary_prompt(cleaned, req.lang, req.specialty, req.payer)
+            response_content = call_openai(messages)
+            summary = response_content.strip()
+        except Exception as exc:
+            # If the LLM call fails, fall back to a simple truncation of the
+            # cleaned text.  Take the first 200 characters and append ellipsis
+            # if the text is longer.  This ensures the endpoint still returns
+            # something useful without crashing.
+            print(f"Error during summary LLM call: {exc}")
+            summary = cleaned[:200]
+            if len(cleaned) > 200:
+                summary += "..."
     return {"summary": summary}
 
 
@@ -1096,6 +1106,11 @@ async def beautify_note(req: NoteRequest, user=Depends(require_role("user"))) ->
         A dictionary with the beautified note as a string.
     """
     cleaned = deidentify(req.text)
+    if USE_OFFLINE_MODEL:
+        from .offline_model import beautify as offline_beautify
+
+        beautified = offline_beautify(cleaned, req.lang, req.specialty, req.payer)
+        return {"beautified": beautified}
     # Attempt to call the LLM to beautify the note.  If the call
     # fails for any reason (e.g., missing API key, network error), fall
     # back to a simple uppercase transformation so the endpoint still
@@ -1143,6 +1158,24 @@ async def suggest(req: NoteRequest, user=Depends(require_role("user"))) -> Sugge
         cleaned_for_prompt = cleaned + rules_section
     else:
         cleaned_for_prompt = cleaned
+    if USE_OFFLINE_MODEL:
+        from .offline_model import suggest as offline_suggest
+
+        data = offline_suggest(
+            cleaned_for_prompt,
+            req.lang,
+            req.specialty,
+            req.payer,
+            req.age,
+            req.sex,
+            req.region,
+        )
+        return SuggestionsResponse(
+            codes=[CodeSuggestion(**c) for c in data["codes"]],
+            compliance=data["compliance"],
+            publicHealth=data["publicHealth"],
+            differentials=data["differentials"],
+        )
     # Try to call the LLM to generate structured suggestions.  The prompt
     # instructs the model to return JSON with keys codes, compliance,
     # public_health and differentials.  We parse the JSON into the

--- a/backend/offline_model.py
+++ b/backend/offline_model.py
@@ -1,0 +1,38 @@
+"""Offline deterministic placeholders for API endpoints.
+
+This module provides simple functions that return fixed data structures for
+``/beautify``, ``/suggest`` and ``/summarize`` when the environment variable
+``USE_OFFLINE_MODEL`` is enabled.  It allows the backend to operate without
+network access or an API key by returning predictable strings and lists.
+"""
+
+from typing import Dict, List, Optional
+
+
+def beautify(text: str, lang: str = "en", specialty: Optional[str] = None, payer: Optional[str] = None) -> str:
+    """Return a deterministic beautified note for offline testing."""
+    return f"Beautified (offline): {text.strip()}"
+
+
+def summarize(text: str, lang: str = "en", specialty: Optional[str] = None, payer: Optional[str] = None) -> str:
+    """Return a deterministic summary for offline testing."""
+    snippet = text.strip()[:50]
+    return f"Summary (offline): {snippet}"
+
+
+def suggest(
+    text: str,
+    lang: str = "en",
+    specialty: Optional[str] = None,
+    payer: Optional[str] = None,
+    age: Optional[int] = None,
+    sex: Optional[str] = None,
+    region: Optional[str] = None,
+) -> Dict[str, List]:
+    """Return deterministic suggestion payload for offline testing."""
+    return {
+        "codes": [{"code": "00000", "rationale": "offline"}],
+        "compliance": ["offline compliance"],
+        "publicHealth": ["offline public health"],
+        "differentials": ["offline differential"],
+    }

--- a/tests/test_offline_mode.py
+++ b/tests/test_offline_mode.py
@@ -1,0 +1,67 @@
+import json
+import sqlite3
+import hashlib
+import importlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def auth_header(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def offline_client(monkeypatch):
+    """Return a TestClient with offline model mode enabled."""
+    monkeypatch.setenv("USE_OFFLINE_MODEL", "true")
+    from backend import main as main_module
+    importlib.reload(main_module)
+
+    db = sqlite3.connect(":memory:", check_same_thread=False)
+    db.row_factory = sqlite3.Row
+    db.execute(
+        "CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT, eventType TEXT NOT NULL, timestamp REAL NOT NULL, details TEXT)"
+    )
+    db.execute(
+        "CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE NOT NULL, password_hash TEXT NOT NULL, role TEXT NOT NULL)"
+    )
+    pwd = hashlib.sha256(b"pw").hexdigest()
+    db.execute(
+        "INSERT INTO users (username, password_hash, role) VALUES (?, ?, ?)",
+        ("u", pwd, "user"),
+    )
+    db.commit()
+    monkeypatch.setattr(main_module, "db_conn", db)
+    monkeypatch.setattr(main_module, "events", [])
+    client = TestClient(main_module.app)
+    yield client, main_module
+    monkeypatch.delenv("USE_OFFLINE_MODEL", raising=False)
+    importlib.reload(main_module)
+
+
+def test_offline_beautify(offline_client):
+    client, main_module = offline_client
+    token = main_module.create_token("u", "user")
+    resp = client.post("/beautify", json={"text": "hello"}, headers=auth_header(token))
+    assert resp.status_code == 200
+    assert resp.json()["beautified"]
+
+
+def test_offline_suggest(offline_client):
+    client, main_module = offline_client
+    token = main_module.create_token("u", "user")
+    resp = client.post("/suggest", json={"text": "note"}, headers=auth_header(token))
+    data = resp.json()
+    assert data["codes"]
+    assert data["compliance"]
+    assert data["publicHealth"]
+    assert data["differentials"]
+
+
+def test_offline_summarize(offline_client):
+    client, main_module = offline_client
+    token = main_module.create_token("u", "user")
+    resp = client.post("/summarize", json={"text": "hello"}, headers=auth_header(token))
+    assert resp.status_code == 200
+    assert resp.json()["summary"]


### PR DESCRIPTION
## Summary
- Add `USE_OFFLINE_MODEL` flag to serve deterministic placeholders without calling external AI services
- Provide `backend/offline_model.py` implementing offline beautify, suggest, and summarize helpers
- Document experimental offline mode in README and cover it with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892d1cce7608324a71b8a75d6ad737c