### PR TITLE
feat: improve note editor toolbar and accessibility

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -510,9 +510,12 @@ function App() {
                 onChange={(e) => setPatientID(e.target.value)}
                 className="patient-input"
               />
-              <button onClick={() => setShowTemplatesModal(true)}>
-                {t('app.templates')}
-              </button>
+                <button
+                  onClick={() => setShowTemplatesModal(true)}
+                  aria-label={t('app.templates')}
+                >
+                  {t('app.templates')}
+                </button>
               <button
                 disabled={loadingBeautify || !draftText.trim()}
                 onClick={handleBeautify}

--- a/src/__tests__/i18nSwitch.test.jsx
+++ b/src/__tests__/i18nSwitch.test.jsx
@@ -21,6 +21,7 @@ vi.mock('../api.js', () => ({
   createTemplate: vi.fn(),
   updateTemplate: vi.fn(),
   deleteTemplate: vi.fn(),
+  getPromptTemplates: vi.fn().mockResolvedValue({}),
   saveSettings: vi.fn(),
 }));
 

--- a/src/components/NoteEditor.jsx
+++ b/src/components/NoteEditor.jsx
@@ -25,6 +25,31 @@ try {
   ReactQuill = null;
 }
 
+// Formats allowed in the editor.  These correspond to the buttons rendered in
+// ``QuillToolbar`` below.
+const quillFormats = ['header', 'bold', 'italic', 'underline', 'list', 'bullet'];
+
+// Custom toolbar markup so we can provide accessible labels for the icons.
+// Quill will hook into this container via the ``modules.toolbar`` option.
+function QuillToolbar({ toolbarId }) {
+  return (
+    <div id={toolbarId} className="ql-toolbar ql-snow">
+      <span className="ql-formats">
+        <select className="ql-header" defaultValue="" aria-label="Heading">
+          <option value="1">H1</option>
+          <option value="2">H2</option>
+          <option value="">Normal</option>
+        </select>
+        <button className="ql-bold" aria-label="Bold" />
+        <button className="ql-italic" aria-label="Italic" />
+        <button className="ql-underline" aria-label="Underline" />
+        <button className="ql-list" value="ordered" aria-label="Ordered List" />
+        <button className="ql-list" value="bullet" aria-label="Bullet List" />
+      </span>
+    </div>
+  );
+}
+
 function NoteEditor({
   id,
   value,
@@ -86,10 +111,14 @@ function NoteEditor({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [transcribing]);
 
-  const toolbar = (
+  const audioControls = (
     <div style={{ marginBottom: '0.5rem' }}>
       {onRecord && (
-        <button type="button" onClick={onRecord}>
+        <button
+          type="button"
+          onClick={onRecord}
+          aria-label={recording ? t('noteEditor.stopRecording') : t('noteEditor.recordAudio')}
+        >
           {recording ? t('noteEditor.stopRecording') : t('noteEditor.recordAudio')}
         </button>
       )}
@@ -100,13 +129,18 @@ function NoteEditor({
 
   // Render the rich text editor if available; otherwise render a textarea.
   if (ReactQuill) {
+    const toolbarId = `${id || 'editor'}-toolbar`;
+    const modules = { toolbar: { container: `#${toolbarId}` } };
     return (
       <div style={{ height: '100%', width: '100%' }}>
-        {toolbar}
+        {audioControls}
+        <QuillToolbar toolbarId={toolbarId} />
         <ReactQuill
           id={id}
           theme="snow"
           value={value}
+          modules={modules}
+          formats={quillFormats}
           // ReactQuill's onChange passes the new HTML string as the first
           // argument.  We ignore the other args (delta, source, editor) and
           // forward the HTML string to the parent onChange.
@@ -137,7 +171,7 @@ function NoteEditor({
   }
   return (
     <div style={{ width: '100%', height: '100%' }}>
-      {toolbar}
+      {audioControls}
       <textarea
         id={id}
         value={localValue}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4,6 +4,16 @@ body {
   background: var(--bg);
   color: var(--text);
   font-family: Inter, Roboto, sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+button:focus,
+input:focus,
+select:focus,
+textarea:focus {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
 }
 
 /* Layout */
@@ -80,6 +90,7 @@ body {
   padding: 0.4rem 0.8rem;
   border-radius: 3px;
   cursor: pointer;
+  font-size: 1rem;
 }
 
 .toolbar button:disabled {


### PR DESCRIPTION
## Summary
- add custom ReactQuill toolbar with heading and list formatting options
- expose accessible template button and editor controls
- improve global typography and focus outlines for better accessibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892de7ac9748324a207dd9a3fc0d345