### PR TITLE
feat: extend suggestion schema with upgrade and scoring

### DIFF
--- a/backend/offline_model.py
+++ b/backend/offline_model.py
@@ -31,8 +31,12 @@ def suggest(
 ) -> Dict[str, List]:
     """Return deterministic suggestion payload for offline testing."""
     return {
-        "codes": [{"code": "00000", "rationale": "offline"}],
+        "codes": [{"code": "00000", "rationale": "offline", "upgrade_to": "00001"}],
         "compliance": ["offline compliance"],
-        "publicHealth": ["offline public health"],
-        "differentials": ["offline differential"],
+        "publicHealth": [
+            {"recommendation": "offline public health", "reason": "offline reason"}
+        ],
+        "differentials": [
+            {"diagnosis": "offline differential", "score": 50}
+        ],
     }

--- a/backend/prompts.py
+++ b/backend/prompts.py
@@ -166,19 +166,19 @@ def build_suggest_prompt(
         "en": (
             "You are an expert medical coder, compliance officer and clinical decision support assistant. "
             "Analyse the following de‑identified clinical note and return a JSON object with four keys:\n"
-            "- codes: an array of objects with two fields: code (string) and rationale (string). Include only the most relevant CPT and ICD‑10 codes based solely on the information provided. Do not guess codes that are not supported by the note. Limit to a maximum of five codes.\n"
+            "- codes: an array of objects with fields code (string), rationale (string) and upgrade_to (string, optional). Include only the most relevant CPT and ICD‑10 codes supported by the note. When the documentation would justify a higher‑level code, set upgrade_to to that code. Limit to a maximum of five entries.\n"
             "- compliance: an array of succinct strings highlighting missing documentation elements, audit risks or compliance tips (e.g., incomplete history, missing ROS, insufficient exam). Focus on areas that could cause downcoding or denials.\n"
-            "- public_health: an array of preventative measures, vaccinations or screenings that may apply given the patient’s context. Suggest generic recommendations (e.g., influenza vaccine, smoking cessation) without assuming personal details.\n"
-            "- differentials: an array of plausible differential diagnoses suggested by the note. Limit to a maximum of five differentials and ensure they are consistent with the symptoms described.\n"
+            "- public_health: an array of objects with fields recommendation (string) and reason (string) for preventative measures, vaccinations or screenings that may apply given the patient’s context. Suggest generic recommendations without assuming personal details.\n"
+            "- differentials: an array of objects with fields diagnosis (string) and score (number). Estimate the likelihood of each differential based on the note and provide the score as a percentage from 0 to 100. Limit to a maximum of five entries.\n"
             "Return only valid JSON without any surrounding Markdown. Do not fabricate information beyond the note. If no suggestions apply to a category, return an empty array for that key."
         ),
         "es": (
             "Usted es un experto codificador médico, responsable de cumplimiento y asistente de apoyo a la decisión clínica. "
             "Analice la siguiente nota clínica desidentificada y devuelva un objeto JSON con cuatro claves:\n"
-            "- codes: una matriz de objetos con dos campos: code (cadena) y rationale (cadena). Incluya solo los códigos CPT e ICD‑10 más relevantes basados únicamente en la información proporcionada. No suponga códigos que no estén respaldados por la nota. Limítese a un máximo de cinco códigos.\n"
+            "- codes: una matriz de objetos con los campos code (cadena), rationale (cadena) y upgrade_to (cadena, opcional). Incluya solo los códigos CPT e ICD‑10 más relevantes basados en la información proporcionada. Cuando la documentación justifique un código de mayor nivel, establezca upgrade_to con ese código. Límite a un máximo de cinco entradas.\n"
             "- compliance: una matriz de cadenas breves que resalten elementos faltantes de documentación, riesgos de auditoría o consejos de cumplimiento (por ejemplo, historial incompleto, ROS faltante, examen insuficiente). Concéntrese en áreas que podrían causar reducción de códigos o denegaciones.\n"
-            "- public_health: una matriz de medidas preventivas, vacunaciones o cribados que puedan aplicar según el contexto del paciente. Sugiera recomendaciones genéricas (por ejemplo, vacuna contra la gripe, dejar de fumar) sin asumir detalles personales.\n"
-            "- differentials: una matriz de diagnósticos diferenciales plausibles sugeridos por la nota. Limítese a un máximo de cinco diferenciales y asegúrese de que sean coherentes con los síntomas descritos.\n"
+            "- public_health: una matriz de objetos con los campos recommendation (cadena) y reason (cadena) para medidas preventivas, vacunaciones o cribados que puedan aplicar según el contexto del paciente. Sugiera recomendaciones genéricas sin asumir detalles personales.\n"
+            "- differentials: una matriz de objetos con los campos diagnosis (cadena) y score (número). Estime la probabilidad de cada diagnóstico diferencial según la nota y exprese score como un porcentaje de 0 a 100. Limítese a un máximo de cinco entradas.\n"
             "Devuelva solo JSON válido sin ningún Markdown adicional. No fabrique información más allá de la nota. Si no hay sugerencias para una categoría, devuelva un array vacío para esa clave. Todas las cadenas devueltas deben estar en español."
         ),
     }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -141,7 +141,8 @@
     "loading": "Loading suggestions...",
     "none": "No suggestions yet",
     "followUp": "Follow-Up",
-    "addToCalendar": "Add to calendar"
+    "addToCalendar": "Add to calendar",
+    "upgradeTo": "Upgrade to"
   },
   "templatesModal": {
     "title": "Templates",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -141,7 +141,8 @@
     "loading": "Cargando sugerencias...",
     "none": "Sin sugerencias aún",
     "followUp": "Seguimiento",
-    "addToCalendar": "Agregar al calendario"
+    "addToCalendar": "Agregar al calendario",
+    "upgradeTo": "Mejorar a"
   },
   "templatesModal": {
     "title": "Plantillas",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -615,16 +615,10 @@ function App() {
                 </div>
               </div>
               {(() => {
-                const filtered = {
-                  codes: settingsState.enableCodes ? suggestions.codes : [],
-                  compliance: settingsState.enableCompliance ? suggestions.compliance : [],
-                  publicHealth: settingsState.enablePublicHealth ? suggestions.publicHealth : [],
-                  differentials: settingsState.enableDifferentials ? suggestions.differentials : [],
-                  followUp: suggestions.followUp,
-                };
                 return (
                   <SuggestionPanel
-                    suggestions={filtered}
+                    suggestions={suggestions}
+                    settingsState={settingsState}
                     loading={loadingSuggestions}
                     className={showSuggestions ? '' : 'collapsed'}
                     onInsert={handleInsertSuggestion}

--- a/src/__tests__/i18nSwitch.test.jsx
+++ b/src/__tests__/i18nSwitch.test.jsx
@@ -22,6 +22,7 @@ vi.mock('../api.js', () => ({
   updateTemplate: vi.fn(),
   deleteTemplate: vi.fn(),
   saveSettings: vi.fn(),
+  getPromptTemplates: vi.fn().mockResolvedValue({}),
 }));
 
 vi.mock('react-chartjs-2', () => ({

--- a/src/api.js
+++ b/src/api.js
@@ -182,7 +182,7 @@ export async function beautifyNote(text, lang = 'en', context = {}) {
  * Get coding and clinical suggestions based on the draft note.
  * The returned object has arrays for different suggestion types.
  * @param {string} text
- * @returns {Promise<{codes: string[], compliance: string[], publicHealth: string[], differentials: string[], followUp?: string}>}
+ * @returns {Promise<{codes: {code:string,rationale?:string,upgrade_to?:string}[], compliance: string[], publicHealth: {recommendation:string, reason?:string}[], differentials: {diagnosis:string, score?:number}[], followUp?: string}>}
 */
 export async function getSuggestions(text, context = {}) {
   const baseUrl =
@@ -229,14 +229,20 @@ export async function getSuggestions(text, context = {}) {
     };
   }
   // In stub mode, we ignore additional context and return sample suggestions
-    return {
+  return {
     codes: [
-      { code: '99213', rationale: 'Established patient, low complexity' },
+      { code: '99213', rationale: 'Established patient, low complexity', upgrade_to: '99214' },
       { code: '99395', rationale: 'Annual preventive visit' },
     ],
     compliance: ['Include duration of symptoms', 'Add ROS for cardiovascular system'],
-    publicHealth: ['Consider flu vaccine', 'Screen for depression'],
-    differentials: ['Influenza', 'Acute sinusitis'],
+    publicHealth: [
+      { recommendation: 'Consider flu vaccine', reason: 'Seasonal influenza prevention' },
+      { recommendation: 'Screen for depression', reason: 'Common in adults' },
+    ],
+    differentials: [
+      { diagnosis: 'Influenza', score: 60 },
+      { diagnosis: 'Acute sinusitis', score: 40 },
+    ],
     followUp: '3 months',
   };
 }

--- a/src/components/SuggestionPanel.jsx
+++ b/src/components/SuggestionPanel.jsx
@@ -5,19 +5,27 @@ import { useTranslation } from 'react-i18next';
 
   function SuggestionPanel({
     suggestions,
+    settingsState,
     loading,
     className = '',
     onInsert,
   }) {
     const { t } = useTranslation();
     // suggestions: { codes: [], compliance: [], publicHealth: [], differentials: [], followUp: string }
-    const cards = [
-      { type: 'codes', key: 'codes', title: t('suggestion.codes'), items: suggestions?.codes || [] },
-      { type: 'compliance', key: 'compliance', title: t('suggestion.compliance'), items: suggestions?.compliance || [] },
-      { type: 'public-health', key: 'publicHealth', title: t('suggestion.publicHealth'), items: suggestions?.publicHealth || [] },
-      { type: 'differentials', key: 'differentials', title: t('suggestion.differentials'), items: suggestions?.differentials || [] },
-      { type: 'follow-up', key: 'followUp', title: t('suggestion.followUp'), items: suggestions?.followUp ? [suggestions.followUp] : [] },
-    ];
+    const cards = [];
+    if (!settingsState || settingsState.enableCodes) {
+      cards.push({ type: 'codes', key: 'codes', title: t('suggestion.codes'), items: suggestions?.codes || [] });
+    }
+    if (!settingsState || settingsState.enableCompliance) {
+      cards.push({ type: 'compliance', key: 'compliance', title: t('suggestion.compliance'), items: suggestions?.compliance || [] });
+    }
+    if (!settingsState || settingsState.enablePublicHealth) {
+      cards.push({ type: 'public-health', key: 'publicHealth', title: t('suggestion.publicHealth'), items: suggestions?.publicHealth || [] });
+    }
+    if (!settingsState || settingsState.enableDifferentials) {
+      cards.push({ type: 'differentials', key: 'differentials', title: t('suggestion.differentials'), items: suggestions?.differentials || [] });
+    }
+    cards.push({ type: 'follow-up', key: 'followUp', title: t('suggestion.followUp'), items: suggestions?.followUp ? [suggestions.followUp] : [] });
 
   const [openState, setOpenState] = useState({
     codes: true,
@@ -47,20 +55,47 @@ import { useTranslation } from 'react-i18next';
         );
       }
     return items.map((item, idx) => {
-      if (typeof item === 'object' && item !== null && 'code' in item) {
-        const text = item.rationale
-          ? `${item.code} — ${item.rationale}`
-          : item.code;
-        const tooltip = item.rationale || '';
+      if (type === 'codes' && typeof item === 'object' && item !== null) {
+        const text = item.rationale ? `${item.code} — ${item.rationale}` : item.code;
         return (
           <li
             key={idx}
-            title={tooltip}
+            title={item.rationale || ''}
             style={{ cursor: 'pointer' }}
             onClick={() => onInsert && onInsert(text)}
           >
             <strong>{item.code}</strong>
             {item.rationale ? ` — ${item.rationale}` : ''}
+            {item.upgrade_to && (
+              <span style={{ marginLeft: '0.5em', fontSize: '0.85em', color: '#555' }}>
+                {t('suggestion.upgradeTo')} {item.upgrade_to}
+              </span>
+            )}
+          </li>
+        );
+      }
+      if (type === 'public-health' && typeof item === 'object' && item !== null) {
+        return (
+          <li
+            key={idx}
+            title={item.reason || ''}
+            style={{ cursor: 'pointer' }}
+            onClick={() => onInsert && onInsert(item.recommendation)}
+          >
+            {item.recommendation}
+          </li>
+        );
+      }
+      if (type === 'differentials' && typeof item === 'object' && item !== null) {
+        const score = item.score !== undefined && item.score !== null ? ` — ${item.score}%` : '';
+        return (
+          <li
+            key={idx}
+            title={score ? `${item.diagnosis}${score}` : item.diagnosis}
+            style={{ cursor: 'pointer' }}
+            onClick={() => onInsert && onInsert(item.diagnosis)}
+          >
+            {item.diagnosis}{score}
           </li>
         );
       }

--- a/src/components/__tests__/SuggestionPanel.test.jsx
+++ b/src/components/__tests__/SuggestionPanel.test.jsx
@@ -8,15 +8,24 @@ afterEach(() => cleanup());
 
 test('renders suggestions and handles click', () => {
   const onInsert = vi.fn();
-  const { getByText } = render(
-    <SuggestionPanel suggestions={{ codes: ['A'], compliance: [], publicHealth: [], differentials: [] }} onInsert={onInsert} />
+  const { getAllByText } = render(
+    <SuggestionPanel
+      suggestions={{ codes: [{ code: 'A', rationale: 'reason' }], compliance: [], publicHealth: [], differentials: [] }}
+      settingsState={{ enableCodes: true, enableCompliance: true, enablePublicHealth: true, enableDifferentials: true }}
+      onInsert={onInsert}
+    />
   );
-  fireEvent.click(getByText('A'));
-  expect(onInsert).toHaveBeenCalledWith('A');
+  const el = getAllByText((_, el) => el.textContent === 'A — reason').find(
+    (node) => node.tagName === 'LI'
+  );
+  fireEvent.click(el);
+  expect(onInsert).toHaveBeenCalledWith('A — reason');
 });
 
 test('shows loading and toggles sections', () => {
-  const { getByText, getAllByText } = render(<SuggestionPanel loading />);
+  const { getByText, getAllByText } = render(
+    <SuggestionPanel loading settingsState={{ enableCodes: true, enableCompliance: true, enablePublicHealth: true, enableDifferentials: true }} />
+  );
   expect(getAllByText('Loading suggestions...').length).toBeGreaterThan(0);
   const header = getByText('Codes & Rationale');
   fireEvent.click(header);
@@ -25,7 +34,10 @@ test('shows loading and toggles sections', () => {
 
 test('renders follow-up with calendar link', () => {
   const { getByText } = render(
-    <SuggestionPanel suggestions={{ codes: [], compliance: [], publicHealth: [], differentials: [], followUp: '3 months' }} />
+    <SuggestionPanel
+      suggestions={{ codes: [], compliance: [], publicHealth: [], differentials: [], followUp: '3 months' }}
+      settingsState={{ enableCodes: true, enableCompliance: true, enablePublicHealth: true, enableDifferentials: true }}
+    />
   );
   expect(getByText('3 months')).toBeTruthy();
   const href = getByText('Add to calendar').getAttribute('href');

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -141,7 +141,8 @@
     "loading": "Loading suggestions...",
     "none": "No suggestions yet",
     "followUp": "Follow-Up",
-    "addToCalendar": "Add to calendar"
+    "addToCalendar": "Add to calendar",
+    "upgradeTo": "Upgrade to"
   },
   "templatesModal": {
     "title": "Templates",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -141,7 +141,8 @@
     "loading": "Cargando sugerencias...",
     "none": "Sin sugerencias aún",
     "followUp": "Seguimiento",
-    "addToCalendar": "Agregar al calendario"
+    "addToCalendar": "Agregar al calendario",
+    "upgradeTo": "Mejorar a"
   },
   "templatesModal": {
     "title": "Plantillas",


### PR DESCRIPTION
## Summary
- expand suggestion prompt to include upgrade_to, differential scores, and public health reasoning
- parse new suggestion schema in backend and surface upgrade/score info
- enhance suggestion panel UI with upgrade tags, differential percentages, and public health reasoning with settings-based visibility

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892deb7d96c832491434110a3bae8cb