### PR TITLE
feat: add audio recording hook

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,7 +11,6 @@ import {
   beautifyNote,
   getSuggestions,
   logEvent,
-  transcribeAudio,
   summarizeNote,
   getSettings,
 } from './api.js';
@@ -68,12 +67,6 @@ function App() {
     provider: '',
     patient: '',
   });
-  const [recording, setRecording] = useState(false);
-  const [transcribing, setTranscribing] = useState(false);
-  const [transcriptionError, setTranscriptionError] = useState('');
-  // References for MediaRecorder and audio chunks
-  const mediaRecorderRef = useRef(null);
-  const audioChunksRef = useRef([]);
   // Track whether the sidebar is collapsed
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
@@ -329,57 +322,6 @@ function App() {
     reader.readAsText(file);
   };
 
-  /**
-   * Start or stop audio recording.  Uses the browser's MediaRecorder API to
-   * capture audio from the user's microphone.  When recording stops the
-   * resulting ``Blob`` is uploaded to the backend ``/transcribe`` endpoint
-   * and the returned transcript stored in ``audioTranscript``.  The raw
-   * audio is never persisted locally.
-   */
-  const handleRecordAudio = async () => {
-    if (!recording) {
-      try {
-        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-        const mediaRecorder = new MediaRecorder(stream);
-        mediaRecorderRef.current = mediaRecorder;
-        audioChunksRef.current = [];
-        mediaRecorder.ondataavailable = (e) => {
-          if (e.data.size > 0) audioChunksRef.current.push(e.data);
-        };
-        mediaRecorder.onstop = async () => {
-          const blob = new Blob(audioChunksRef.current, { type: 'audio/webm' });
-          setTranscribing(true);
-          try {
-            await transcribeAudio(blob, true);
-            setTranscriptionError('');
-          } catch (err) {
-            if (err.message === 'Unauthorized') {
-              handleUnauthorized();
-            } else {
-              console.error('Transcription failed', err);
-              setTranscriptionError('Transcription failed');
-            }
-          } finally {
-            setTranscribing(false);
-          }
-          if (patientID) {
-            logEvent('audio_recorded', { patientID, size: blob.size }).catch(() => {});
-          }
-        };
-        mediaRecorder.start();
-        setRecording(true);
-      } catch (err) {
-        console.error('Error accessing microphone', err);
-        setTranscriptionError('Error accessing microphone');
-      }
-    } else {
-      const recorder = mediaRecorderRef.current;
-      if (recorder && recorder.state !== 'inactive') {
-        recorder.stop();
-      }
-      setRecording(false);
-    }
-  };
 
   const handleTranscriptChange = (data) => {
     setAudioTranscript({
@@ -636,11 +578,7 @@ function App() {
                       id="draft-input"
                       value={draftText}
                       onChange={handleDraftChange}
-                      onRecord={handleRecordAudio}
-                      recording={recording}
-                      transcribing={transcribing}
                       onTranscriptChange={handleTranscriptChange}
-                      error={transcriptionError}
                     />
                   ) : (
                     activeTab === 'beautified' ? (

--- a/src/__tests__/NoteEditor.test.jsx
+++ b/src/__tests__/NoteEditor.test.jsx
@@ -4,6 +4,7 @@ import { test, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('../api.js', () => ({
   fetchLastTranscript: vi.fn(),
+  transcribeAudio: vi.fn(),
 }));
 
 import { fetchLastTranscript } from '../api.js';
@@ -24,13 +25,13 @@ test('transcript persists across reloads', async () => {
     <NoteEditor id="n1" value="" onChange={() => {}} />
   );
   await findByText(/Provider:/);
-  expect(fetchLastTranscript).toHaveBeenCalledTimes(2);
+  expect(fetchLastTranscript).toHaveBeenCalledTimes(1);
   unmount();
   const { findByText: findByText2 } = render(
     <NoteEditor id="n1" value="" onChange={() => {}} />
   );
   await findByText2(/Provider:/);
-  expect(fetchLastTranscript).toHaveBeenCalledTimes(4);
+  expect(fetchLastTranscript).toHaveBeenCalledTimes(2);
 });
 
 test('shows diarised output when available', async () => {

--- a/src/components/ClipboardExportButtons.jsx
+++ b/src/components/ClipboardExportButtons.jsx
@@ -70,11 +70,12 @@ function ClipboardExportButtons({ beautified, summary, patientID, suggestions = 
   };
 
 
-  const calcRevenue = (codes = []) => {
-    const map = { '99212': 50, '99213': 75, '99214': 110, '99215': 160 };
-    return (codes || []).reduce((sum, c) => sum + (map[c.code || c] || 0), 0);
+    const calcRevenue = (codes = []) => {
+      const map = { '99212': 50, '99213': 75, '99214': 110, '99215': 160 };
+      return (codes || []).reduce((sum, c) => sum + (map[c.code || c] || 0), 0);
+    };
 
-  const exportRtf = async () => {
+    const exportRtf = async () => {
     try {
       const ipcRenderer = window.require
         ? window.require('electron').ipcRenderer

--- a/src/components/__tests__/NoteEditor.test.jsx
+++ b/src/components/__tests__/NoteEditor.test.jsx
@@ -4,25 +4,43 @@ import { vi, expect, test, afterEach } from 'vitest';
 
 vi.mock('../../api.js', () => ({
   fetchLastTranscript: vi.fn().mockResolvedValue({ provider: '', patient: '' }),
+  transcribeAudio: vi.fn().mockResolvedValue({ provider: '', patient: '' }),
 }));
 
 import '../../i18n.js';
 import NoteEditor from '../NoteEditor.jsx';
 
-afterEach(() => cleanup());
-
-test('calls onRecord when record button clicked', () => {
-  const onRecord = vi.fn();
-  const { getByText } = render(
-    <NoteEditor id="n" value="" onChange={() => {}} onRecord={onRecord} />
-  );
-  fireEvent.click(getByText('Record Audio'));
-  expect(onRecord).toHaveBeenCalled();
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
 });
 
-test('shows record button when recording', () => {
-  const { getByText } = render(
-    <NoteEditor id="a" value="" onChange={() => {}} onRecord={() => {}} recording />
+test('record button toggles recording state', async () => {
+  class MockRecorder {
+    constructor() {
+      this.stream = { getTracks: () => [] };
+      this.ondataavailable = null;
+      this.onstop = null;
+      this.state = 'inactive';
+    }
+    start() {
+      this.state = 'recording';
+    }
+    stop() {
+      this.state = 'inactive';
+      if (this.ondataavailable) this.ondataavailable({ data: new Blob(['a']) });
+      if (this.onstop) this.onstop();
+    }
+  }
+  vi.stubGlobal('MediaRecorder', MockRecorder);
+  // eslint-disable-next-line no-undef
+  navigator.mediaDevices = { getUserMedia: vi.fn().mockResolvedValue({}) };
+
+  const { getByText, findByText } = render(
+    <NoteEditor id="n" value="" onChange={() => {}} />
   );
-  expect(getByText('Stop Recording')).toBeTruthy();
+  fireEvent.click(getByText('Record Audio'));
+  await findByText('Stop Recording');
+  fireEvent.click(getByText('Stop Recording'));
+  await findByText('Record Audio');
 });


### PR DESCRIPTION
## Summary
- add `useAudioRecorder` hook using MediaRecorder to capture microphone input and transcribe on stop
- integrate recording controls into `NoteEditor` and remove old recording logic from `App`
- fix ClipboardExportButtons syntax and update tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892e651edac8324b3a9861af7ad84cc