### PR TITLE
feat: add template chooser to note editor

### DIFF
--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -16,6 +16,7 @@ vi.mock('../api.js', () => ({
     region: '',
   }),
   fetchLastTranscript: vi.fn().mockResolvedValue({ provider: '', patient: '' }),
+  getTemplates: vi.fn().mockResolvedValue([]),
 }));
 
 // Mock fetch for loading default templates and reset state before each test

--- a/src/__tests__/NoteEditor.test.jsx
+++ b/src/__tests__/NoteEditor.test.jsx
@@ -4,6 +4,7 @@ import { test, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('../api.js', () => ({
   fetchLastTranscript: vi.fn(),
+  getTemplates: vi.fn().mockResolvedValue([]),
 }));
 
 import { fetchLastTranscript } from '../api.js';

--- a/src/components/ClipboardExportButtons.jsx
+++ b/src/components/ClipboardExportButtons.jsx
@@ -73,6 +73,7 @@ function ClipboardExportButtons({ beautified, summary, patientID, suggestions = 
   const calcRevenue = (codes = []) => {
     const map = { '99212': 50, '99213': 75, '99214': 110, '99215': 160 };
     return (codes || []).reduce((sum, c) => sum + (map[c.code || c] || 0), 0);
+  };
 
   const exportRtf = async () => {
     try {
@@ -93,7 +94,6 @@ function ClipboardExportButtons({ beautified, summary, patientID, suggestions = 
     } catch {
       setFeedback(t('clipboard.exportFailed'));
     }
-
   };
 
   return (

--- a/src/components/__tests__/NoteEditor.test.jsx
+++ b/src/components/__tests__/NoteEditor.test.jsx
@@ -1,9 +1,11 @@
 /* @vitest-environment jsdom */
-import { render, cleanup, fireEvent } from '@testing-library/react';
+import { render, cleanup, fireEvent, waitFor } from '@testing-library/react';
 import { vi, expect, test, afterEach } from 'vitest';
+import { useState } from 'react';
 
 vi.mock('../../api.js', () => ({
   fetchLastTranscript: vi.fn().mockResolvedValue({ provider: '', patient: '' }),
+  getTemplates: vi.fn().mockResolvedValue([{ id: 1, name: 'Tpl', content: 'Hello' }]),
 }));
 
 import '../../i18n.js';
@@ -25,4 +27,16 @@ test('shows record button when recording', () => {
     <NoteEditor id="a" value="" onChange={() => {}} onRecord={() => {}} recording />
   );
   expect(getByText('Stop Recording')).toBeTruthy();
+});
+
+test('selecting template inserts content', async () => {
+  function Wrapper() {
+    const [val, setVal] = useState('');
+    return <NoteEditor id="t" value={val} onChange={setVal} />;
+  }
+  const { findByLabelText, container } = render(<Wrapper />);
+  const select = await findByLabelText('Templates');
+  fireEvent.change(select, { target: { value: '1' } });
+  const editor = container.querySelector('.ql-editor');
+  await waitFor(() => expect(editor.innerHTML).toContain('Hello'));
 });


### PR DESCRIPTION
## Summary
- fetch user templates and expose a dropdown above the note editor
- allow inserting a selected template at the cursor position
- add test coverage for template insertion and mock template API
- fix missing brace in ClipboardExportButtons

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892e667f76883248b2ba40332622254