### PR TITLE
feat: show differential likelihoods

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -19,7 +19,7 @@ from fastapi import FastAPI, Depends, HTTPException, status, UploadFile, File
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from pydantic import BaseModel
+from pydantic import BaseModel, confloat
 
 import jwt
 
@@ -456,7 +456,7 @@ class PublicHealthSuggestion(BaseModel):
 class DifferentialSuggestion(BaseModel):
     """Potential differential diagnosis with likelihood score."""
     diagnosis: str
-    score: Optional[float] = None
+    score: Optional[confloat(ge=0, le=1)] = None
 
 
 class SuggestionsResponse(BaseModel):
@@ -1347,13 +1347,21 @@ async def suggest(req: NoteRequest, user=Depends(require_role("user"))) -> Sugge
         for item in data.get("differentials", []):
             if isinstance(item, dict):
                 diag = item.get("diagnosis") or item.get("Diagnosis") or ""
-                score = item.get("score")
+                raw_score = item.get("score")
                 score_val: Optional[float] = None
-                if isinstance(score, (int, float)):
-                    score_val = float(score)
-                elif isinstance(score, str):
+                if isinstance(raw_score, (int, float)):
+                    score_val = float(raw_score)
+                    if score_val > 1:
+                        score_val /= 100.0
+                    if not 0 <= score_val <= 1:
+                        score_val = None
+                elif isinstance(raw_score, str):
                     try:
-                        score_val = float(score.strip().rstrip("%"))
+                        score_val = float(raw_score.strip().rstrip("%"))
+                        if score_val > 1:
+                            score_val /= 100.0
+                        if not 0 <= score_val <= 1:
+                            score_val = None
                     except Exception:
                         score_val = None
                 if diag:

--- a/backend/offline_model.py
+++ b/backend/offline_model.py
@@ -37,6 +37,6 @@ def suggest(
             {"recommendation": "offline public health", "reason": "offline reason"}
         ],
         "differentials": [
-            {"diagnosis": "offline differential", "score": 50}
+            {"diagnosis": "offline differential", "score": 0.5}
         ],
     }

--- a/backend/prompts.py
+++ b/backend/prompts.py
@@ -168,7 +168,7 @@ def build_suggest_prompt(
             "- codes: an array of objects with fields code (string), rationale (string) and upgrade_to (string, optional). Include only the most relevant CPT and ICD‑10 codes supported by the note. When the documentation would justify a higher‑level code, set upgrade_to to that code. Limit to a maximum of five entries.\n"
             "- compliance: an array of succinct strings highlighting missing documentation elements, audit risks or compliance tips (e.g., incomplete history, missing ROS, insufficient exam). Focus on areas that could cause downcoding or denials.\n"
             "- public_health: an array of objects with fields recommendation (string) and reason (string) for preventative measures, vaccinations or screenings that may apply given the patient’s context. Suggest generic recommendations without assuming personal details.\n"
-            "- differentials: an array of objects with fields diagnosis (string) and score (number). Estimate the likelihood of each differential based on the note and provide the score as a percentage from 0 to 100. Limit to a maximum of five entries.\n"
+            "- differentials: an array of objects with fields diagnosis (string) and score (number between 0 and 1). Estimate the likelihood of each differential based on the note and provide the score as a decimal between 0 and 1. Limit to a maximum of five entries.\n"
             "Return only valid JSON without any surrounding Markdown. Do not fabricate information beyond the note. If no suggestions apply to a category, return an empty array for that key."
         ),
         "es": (
@@ -177,7 +177,7 @@ def build_suggest_prompt(
             "- codes: una matriz de objetos con los campos code (cadena), rationale (cadena) y upgrade_to (cadena, opcional). Incluya solo los códigos CPT e ICD‑10 más relevantes basados en la información proporcionada. Cuando la documentación justifique un código de mayor nivel, establezca upgrade_to con ese código. Límite a un máximo de cinco entradas.\n"
             "- compliance: una matriz de cadenas breves que resalten elementos faltantes de documentación, riesgos de auditoría o consejos de cumplimiento (por ejemplo, historial incompleto, ROS faltante, examen insuficiente). Concéntrese en áreas que podrían causar reducción de códigos o denegaciones.\n"
             "- public_health: una matriz de objetos con los campos recommendation (cadena) y reason (cadena) para medidas preventivas, vacunaciones o cribados que puedan aplicar según el contexto del paciente. Sugiera recomendaciones genéricas sin asumir detalles personales.\n"
-            "- differentials: una matriz de objetos con los campos diagnosis (cadena) y score (número). Estime la probabilidad de cada diagnóstico diferencial según la nota y exprese score como un porcentaje de 0 a 100. Limítese a un máximo de cinco entradas.\n"
+            "- differentials: una matriz de objetos con los campos diagnosis (cadena) y score (número entre 0 y 1). Estime la probabilidad de cada diagnóstico diferencial según la nota y exprese score como un decimal entre 0 y 1. Limítese a un máximo de cinco entradas.\n"
             "Devuelva solo JSON válido sin ningún Markdown adicional. No fabrique información más allá de la nota. Si no hay sugerencias para una categoría, devuelva un array vacío para esa clave. Todas las cadenas devueltas deben estar en español."
         ),
     }

--- a/src/api.js
+++ b/src/api.js
@@ -182,7 +182,7 @@ export async function beautifyNote(text, lang = 'en', context = {}) {
  * Get coding and clinical suggestions based on the draft note.
  * The returned object has arrays for different suggestion types.
  * @param {string} text
- * @returns {Promise<{codes: {code:string,rationale?:string,upgrade_to?:string}[], compliance: string[], publicHealth: {recommendation:string, reason?:string}[], differentials: {diagnosis:string, score?:number}[], followUp?: string}>}
+ * @returns {Promise<{codes: {code:string,rationale?:string,upgrade_to?:string}[], compliance: string[], publicHealth: {recommendation:string, reason?:string}[], differentials: {diagnosis:string, score?:number}[], followUp?: string}>}  The differential score is a number between 0 and 1.
 */
 export async function getSuggestions(text, context = {}) {
   const baseUrl =
@@ -240,8 +240,8 @@ export async function getSuggestions(text, context = {}) {
       { recommendation: 'Screen for depression', reason: 'Common in adults' },
     ],
     differentials: [
-      { diagnosis: 'Influenza', score: 60 },
-      { diagnosis: 'Acute sinusitis', score: 40 },
+      { diagnosis: 'Influenza', score: 0.6 },
+      { diagnosis: 'Acute sinusitis', score: 0.4 },
     ],
     followUp: '3 months',
   };

--- a/src/components/ClipboardExportButtons.jsx
+++ b/src/components/ClipboardExportButtons.jsx
@@ -73,7 +73,7 @@ function ClipboardExportButtons({ beautified, summary, patientID, suggestions = 
   const calcRevenue = (codes = []) => {
     const map = { '99212': 50, '99213': 75, '99214': 110, '99215': 160 };
     return (codes || []).reduce((sum, c) => sum + (map[c.code || c] || 0), 0);
-
+  };
   const exportRtf = async () => {
     try {
       const ipcRenderer = window.require

--- a/src/components/SuggestionPanel.jsx
+++ b/src/components/SuggestionPanel.jsx
@@ -87,15 +87,22 @@ import { useTranslation } from 'react-i18next';
         );
       }
       if (type === 'differentials' && typeof item === 'object' && item !== null) {
-        const score = item.score !== undefined && item.score !== null ? ` — ${item.score}%` : '';
+        const isValidScore =
+          typeof item.score === 'number' &&
+          !Number.isNaN(item.score) &&
+          item.score >= 0 &&
+          item.score <= 1;
+        const pct = isValidScore ? Math.round(item.score * 100) : null;
+        const scoreText = pct !== null ? ` — ${pct}%` : '';
         return (
           <li
             key={idx}
-            title={score ? `${item.diagnosis}${score}` : item.diagnosis}
+            title={pct !== null ? `${item.diagnosis} — ${pct}%` : item.diagnosis}
             style={{ cursor: 'pointer' }}
             onClick={() => onInsert && onInsert(item.diagnosis)}
           >
-            {item.diagnosis}{score}
+            {item.diagnosis}
+            {scoreText}
           </li>
         );
       }

--- a/src/components/__tests__/SuggestionPanel.test.jsx
+++ b/src/components/__tests__/SuggestionPanel.test.jsx
@@ -43,3 +43,42 @@ test('renders follow-up with calendar link', () => {
   const href = getByText('Add to calendar').getAttribute('href');
   expect(href).toContain('text/calendar');
 });
+
+test('renders differential scores as percentages', () => {
+  const { getByText } = render(
+    <SuggestionPanel
+      suggestions={{
+        codes: [],
+        compliance: [],
+        publicHealth: [],
+        differentials: [{ diagnosis: 'Flu', score: 0.42 }],
+      }}
+      settingsState={{ enableDifferentials: true }}
+    />
+  );
+  expect(getByText('Flu — 42%')).toBeTruthy();
+});
+
+test('handles missing or invalid differential scores gracefully', () => {
+  const { getByText, queryByText } = render(
+    <SuggestionPanel
+      suggestions={{
+        codes: [],
+        compliance: [],
+        publicHealth: [],
+        differentials: [
+          { diagnosis: 'NoScore' },
+          { diagnosis: 'BadScore', score: 'oops' },
+          { diagnosis: 'TooHigh', score: 2 },
+        ],
+      }}
+      settingsState={{ enableDifferentials: true }}
+    />
+  );
+  expect(getByText('NoScore')).toBeTruthy();
+  expect(getByText('BadScore')).toBeTruthy();
+  expect(getByText('TooHigh')).toBeTruthy();
+  expect(queryByText(/NoScore\s+—/)).toBeNull();
+  expect(queryByText(/BadScore\s+—/)).toBeNull();
+  expect(queryByText(/TooHigh\s+—/)).toBeNull();
+});

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -324,7 +324,7 @@ def test_suggest_and_fallback(client, monkeypatch):
                 "codes": [{"code": "A1"}],
                 "compliance": ["c"],
                 "publicHealth": [{"recommendation": "p", "reason": "r"}],
-                "differentials": [{"diagnosis": "d", "score": 10}],
+                "differentials": [{"diagnosis": "d", "score": 0.1}],
             }
         ),
     )


### PR DESCRIPTION
## Summary
- require differential diagnoses to return numeric likelihoods between 0 and 1
- normalize and validate differential scores before serializing to the UI
- display differential likelihoods as percentages in the suggestion panel and add tests for missing or invalid scores
- adjust stubs and offline responses to use normalized scores
- fix missing brace in `ClipboardExportButtons.jsx` to keep tests passing

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892e67f121c8324af201fd979a242d9