### PR TITLE
feat: debounce suggestions and insert at cursor

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,6 @@ import Help from './components/Help.jsx';
 import Settings from './components/Settings.jsx';
 import {
   beautifyNote,
-  getSuggestions,
   logEvent,
   transcribeAudio,
   summarizeNote,
@@ -74,6 +73,7 @@ function App() {
   // References for MediaRecorder and audio chunks
   const mediaRecorderRef = useRef(null);
   const audioChunksRef = useRef([]);
+  const editorRef = useRef(null);
   // Track whether the sidebar is collapsed
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
@@ -81,6 +81,7 @@ function App() {
   const [showSuggestions, setShowSuggestions] = useState(true);
   const [showTemplatesModal, setShowTemplatesModal] = useState(false);
   const [baseTemplates, setBaseTemplates] = useState([]);
+  const [templateContext, setTemplateContext] = useState('');
 
   // Track the current patient ID for draft saving
   const [patientID, setPatientID] = useState('');
@@ -131,6 +132,18 @@ function App() {
       localStorage.removeItem('token');
       window.location.href = '/';
     }
+  };
+
+  const suggestionContext = {
+    chart: chartText,
+    rules: settingsState.rules,
+    audio: `${audioTranscript.provider} ${audioTranscript.patient}`.trim(),
+    lang: settingsState.lang,
+    specialty: settingsState.specialty,
+    payer: settingsState.payer,
+    age: age ? parseInt(age, 10) : undefined,
+    sex,
+    region: settingsState.region,
   };
 
   useEffect(() => {
@@ -289,23 +302,35 @@ function App() {
   // Insert template into the draft
   const insertTemplate = (content) => {
     setDraftText(content);
+    setTemplateContext(content);
     setActiveTab('draft');
   };
 
-  // Insert a suggestion into the draft note.  Appends the text to the
-  // current draft and focuses the draft tab so the user can continue
-  // editing after inserting a suggestion.
+  // Insert a suggestion into the draft note at the current cursor position
+  // and focus the draft tab so the user can continue editing.
   const handleInsertSuggestion = (text) => {
-    setDraftText((prev) => {
-      const usesHtml = /<[^>]+>/.test(prev);
-      if (usesHtml) {
-        // Append as a new paragraph in the HTML string
-        return `${prev}<p>${text}</p>`;
-      }
-      const prefix = prev && !prev.endsWith('\n') ? '\n' : '';
-      return `${prev}${prefix}${text}`;
-    });
+    if (editorRef.current && typeof editorRef.current.insertAtCursor === 'function') {
+      editorRef.current.insertAtCursor(text);
+    } else {
+      setDraftText((prev) => `${prev}${prev && !prev.endsWith('\n') ? '\n' : ''}${text}`);
+    }
     setActiveTab('draft');
+  };
+
+  const handleSuggestions = (data) => {
+    setSuggestions(data);
+    if (patientID) {
+      const codes = data.codes.map((c) => c.code);
+      const revenue = calcRevenue(codes);
+      logEvent('suggest', {
+        patientID,
+        length: draftText.length,
+        codes,
+        revenue,
+        compliance: data.compliance,
+        publicHealth: data.publicHealth.length > 0,
+      }).catch(() => {});
+    }
   };
 
   /**
@@ -410,75 +435,6 @@ function App() {
     }
     prevDraftRef.current = draftText;
   }, [draftText, patientID]);
-
-  /*
-   * Debounce the suggestion API calls.  When the draft text changes, wait
-   * a short delay before fetching new suggestions.  This prevents making
-   * a network request on every keystroke and improves responsiveness.  If
-   * the user continues typing, the timer resets.  When the timer completes,
-   * call the API and update the suggestions.
-   */
-  useEffect(() => {
-    // If the draft is empty, clear suggestions and skip API call
-    if (!draftText.trim()) {
-      setSuggestions({ codes: [], compliance: [], publicHealth: [], differentials: [], followUp: null });
-      return;
-    }
-    // Set loading state and start a timeout to call the API
-    setLoadingSuggestions(true);
-    const timer = setTimeout(() => {
-      // Strip HTML tags before sending to the backend for suggestions.
-      const plain = stripHtml(draftText);
-      getSuggestions(plain, {
-        chart: chartText,
-        rules: settingsState.rules,
-        audio: `${audioTranscript.provider} ${audioTranscript.patient}`.trim(),
-        lang: settingsState.lang,
-        specialty: settingsState.specialty,
-        payer: settingsState.payer,
-        age: age ? parseInt(age, 10) : undefined,
-        sex,
-        region: settingsState.region,
-      })
-        .then((data) => {
-          setSuggestions(data);
-          // Log a suggest event once suggestions are fetched
-          if (patientID) {
-            const codes = data.codes.map((c) => c.code);
-            const revenue = calcRevenue(codes);
-            logEvent('suggest', {
-              patientID,
-              length: draftText.length,
-              codes,
-              revenue,
-              compliance: data.compliance,
-              publicHealth: data.publicHealth.length > 0,
-            }).catch(() => {});
-          }
-        })
-        .catch((e) => {
-          if (e.message === 'Unauthorized') {
-            handleUnauthorized();
-          } else {
-            console.error('Suggestions failed', e);
-          }
-        })
-        .finally(() => setLoadingSuggestions(false));
-    }, 600); // 600ms delay
-    // Cleanup function cancels the previous timer if draftText changes again
-    return () => clearTimeout(timer);
-  }, [
-    draftText,
-    audioTranscript,
-    age,
-    sex,
-    settingsState.region,
-    settingsState.specialty,
-    settingsState.payer,
-    settingsState.lang,
-  ]);
-
-
 
   // Effect: apply theme colours to CSS variables when the theme changes
   useEffect(() => {
@@ -633,6 +589,7 @@ function App() {
                 <div className="editor-area card">
                   {activeTab === 'draft' ? (
                     <NoteEditor
+                      ref={editorRef}
                       id="draft-input"
                       value={draftText}
                       onChange={handleDraftChange}
@@ -641,6 +598,10 @@ function App() {
                       transcribing={transcribing}
                       onTranscriptChange={handleTranscriptChange}
                       error={transcriptionError}
+                      templateContext={templateContext}
+                      suggestionContext={suggestionContext}
+                      onSuggestions={handleSuggestions}
+                      onSuggestionsLoading={setLoadingSuggestions}
                     />
                   ) : (
                     activeTab === 'beautified' ? (

--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -16,6 +16,9 @@ vi.mock('../api.js', () => ({
     region: '',
   }),
   fetchLastTranscript: vi.fn().mockResolvedValue({ provider: '', patient: '' }),
+  getSuggestions: vi
+    .fn()
+    .mockResolvedValue({ codes: [], compliance: [], publicHealth: [], differentials: [], followUp: null }),
 }));
 
 // Mock fetch for loading default templates and reset state before each test

--- a/src/__tests__/NoteEditor.test.jsx
+++ b/src/__tests__/NoteEditor.test.jsx
@@ -4,6 +4,9 @@ import { test, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('../api.js', () => ({
   fetchLastTranscript: vi.fn(),
+  getSuggestions: vi
+    .fn()
+    .mockResolvedValue({ codes: [], compliance: [], publicHealth: [], differentials: [], followUp: null }),
 }));
 
 import { fetchLastTranscript } from '../api.js';

--- a/src/api.js
+++ b/src/api.js
@@ -204,6 +204,7 @@ export async function getSuggestions(text, context = {}) {
     if (context.region) payload.region = context.region;
     if (context.specialty) payload.specialty = context.specialty;
     if (context.payer) payload.payer = context.payer;
+    if (context.template) payload.template = context.template;
     const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
     const headers = token
       ? { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` }

--- a/src/components/ClipboardExportButtons.jsx
+++ b/src/components/ClipboardExportButtons.jsx
@@ -73,6 +73,7 @@ function ClipboardExportButtons({ beautified, summary, patientID, suggestions = 
   const calcRevenue = (codes = []) => {
     const map = { '99212': 50, '99213': 75, '99214': 110, '99215': 160 };
     return (codes || []).reduce((sum, c) => sum + (map[c.code || c] || 0), 0);
+  };
 
   const exportRtf = async () => {
     try {

--- a/src/components/__tests__/NoteEditor.test.jsx
+++ b/src/components/__tests__/NoteEditor.test.jsx
@@ -4,6 +4,9 @@ import { vi, expect, test, afterEach } from 'vitest';
 
 vi.mock('../../api.js', () => ({
   fetchLastTranscript: vi.fn().mockResolvedValue({ provider: '', patient: '' }),
+  getSuggestions: vi
+    .fn()
+    .mockResolvedValue({ codes: [], compliance: [], publicHealth: [], differentials: [], followUp: null }),
 }));
 
 import '../../i18n.js';


### PR DESCRIPTION
## Summary
- debounce /suggest calls in NoteEditor and include template context
- insert suggestions at cursor via editor ref
- fix ClipboardExportButtons calcRevenue block

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892e6917e108324bcb2ae93dc34cead