### PR TITLE
Add detailed metrics time series charts

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -920,7 +920,9 @@ async def get_metrics(
             SUM(CASE WHEN eventType='audio_recorded' THEN 1 ELSE 0 END) AS audio,
             AVG(CAST(json_extract(CASE WHEN json_valid(details) THEN details ELSE '{{}}' END, '$.length')      AS REAL)) AS avg_note_length,
             AVG(revenue) AS revenue_per_visit,
-            AVG(CAST(json_extract(CASE WHEN json_valid(details) THEN details ELSE '{{}}' END, '$.timeToClose') AS REAL)) AS avg_close_time
+            AVG(CAST(json_extract(CASE WHEN json_valid(details) THEN details ELSE '{{}}' END, '$.timeToClose') AS REAL)) AS avg_close_time,
+            SUM(CASE WHEN json_extract(CASE WHEN json_valid(details) THEN details ELSE '{{}}' END, '$.denial') = 1 THEN 1 ELSE 0 END) AS denials,
+            SUM(CASE WHEN json_extract(CASE WHEN json_valid(details) THEN details ELSE '{{}}' END, '$.deficiency') = 1 THEN 1 ELSE 0 END) AS deficiencies
         FROM events {where_clause}
         GROUP BY date
         ORDER BY date
@@ -939,7 +941,9 @@ async def get_metrics(
             SUM(CASE WHEN eventType='audio_recorded' THEN 1 ELSE 0 END) AS audio,
             AVG(CAST(json_extract(CASE WHEN json_valid(details) THEN details ELSE '{{}}' END, '$.length')      AS REAL)) AS avg_note_length,
             AVG(revenue) AS revenue_per_visit,
-            AVG(CAST(json_extract(CASE WHEN json_valid(details) THEN details ELSE '{{}}' END, '$.timeToClose') AS REAL)) AS avg_close_time
+            AVG(CAST(json_extract(CASE WHEN json_valid(details) THEN details ELSE '{{}}' END, '$.timeToClose') AS REAL)) AS avg_close_time,
+            SUM(CASE WHEN json_extract(CASE WHEN json_valid(details) THEN details ELSE '{{}}' END, '$.denial') = 1 THEN 1 ELSE 0 END) AS denials,
+            SUM(CASE WHEN json_extract(CASE WHEN json_valid(details) THEN details ELSE '{{}}' END, '$.deficiency') = 1 THEN 1 ELSE 0 END) AS deficiencies
         FROM events {where_clause}
         GROUP BY week
         ORDER BY week

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -274,6 +274,18 @@ ChartJS.register(
         backgroundColor: 'rgba(0,0,0,0.2)',
       },
       {
+        label: t('dashboard.denials'),
+        data: metrics.timeseries?.daily?.map((d) => d.denials || 0) || [],
+        borderColor: 'rgba(255,0,0,1)',
+        backgroundColor: 'rgba(255,0,0,0.2)',
+      },
+      {
+        label: t('dashboard.deficiencies'),
+        data: metrics.timeseries?.daily?.map((d) => d.deficiencies || 0) || [],
+        borderColor: 'rgba(0,128,0,1)',
+        backgroundColor: 'rgba(0,128,0,0.2)',
+      },
+      {
         label: t('dashboard.cards.avgNoteLength'),
         data: metrics.timeseries?.daily?.map((d) => d.avg_note_length || 0) || [],
         borderColor: 'rgba(99,255,132,1)',
@@ -305,6 +317,7 @@ ChartJS.register(
   };
 
   const dailyOptions = {
+    plugins: { tooltip: { enabled: true }, legend: { display: true } },
     scales: {
       y: { beginAtZero: true },
       y1: {
@@ -356,6 +369,18 @@ ChartJS.register(
         backgroundColor: 'rgba(0,0,0,0.2)',
       },
       {
+        label: t('dashboard.denials'),
+        data: metrics.timeseries?.weekly?.map((w) => w.denials || 0) || [],
+        borderColor: 'rgba(255,0,0,1)',
+        backgroundColor: 'rgba(255,0,0,0.2)',
+      },
+      {
+        label: t('dashboard.deficiencies'),
+        data: metrics.timeseries?.weekly?.map((w) => w.deficiencies || 0) || [],
+        borderColor: 'rgba(0,128,0,1)',
+        backgroundColor: 'rgba(0,128,0,0.2)',
+      },
+      {
         label: t('dashboard.cards.avgNoteLength'),
         data: metrics.timeseries?.weekly?.map((w) => w.avg_note_length || 0) || [],
         borderColor: 'rgba(99,255,132,1)',
@@ -387,6 +412,7 @@ ChartJS.register(
   };
 
   const weeklyOptions = {
+    plugins: { tooltip: { enabled: true }, legend: { display: true } },
     scales: {
       y: { beginAtZero: true },
       y1: {
@@ -409,26 +435,27 @@ ChartJS.register(
       },
     ],
   };
+  const revenueLineOptions = {
+    plugins: { tooltip: { enabled: true }, legend: { display: true } },
+    scales: { y: { beginAtZero: true } },
+  };
 
   const emCodes = ['99212', '99213', '99214', '99215'];
   const totalCodes = emCodes.reduce(
     (sum, c) => sum + (metrics.coding_distribution?.[c] || 0),
     0
   );
-  const codeBarData = {
-    labels: ['E/M'],
-    datasets: emCodes.map((c, idx) => ({
-      label: c,
-      data: [
-        totalCodes
-          ? ((metrics.coding_distribution?.[c] || 0) / totalCodes) * 100
-          : 0,
-      ],
-      backgroundColor: ['#FF6384', '#36A2EB', '#FFCE56', '#4BC0C0'][idx],
-    })),
+  const codePieData = {
+    labels: emCodes,
+    datasets: [
+      {
+        data: emCodes.map((c) => metrics.coding_distribution?.[c] || 0),
+        backgroundColor: ['#FF6384', '#36A2EB', '#FFCE56', '#4BC0C0'],
+      },
+    ],
   };
-  const codeBarOptions = {
-    scales: { x: { stacked: true, max: 100 }, y: { stacked: true, beginAtZero: true } },
+  const codePieOptions = {
+    plugins: { tooltip: { enabled: true }, legend: { display: true } },
   };
   const denialDefData = {
     labels: [t('dashboard.cards.denialRate'), t('dashboard.cards.deficiencyRate')],
@@ -443,7 +470,10 @@ ChartJS.register(
       },
     ],
   };
-  const rateOptions = { scales: { y: { beginAtZero: true, max: 100 } } };
+  const rateOptions = {
+    plugins: { tooltip: { enabled: true }, legend: { display: true } },
+    scales: { y: { beginAtZero: true, max: 100 } },
+  };
 
   const denialData = {
     labels: Object.keys(metrics.denial_rates || {}),
@@ -454,6 +484,10 @@ ChartJS.register(
         backgroundColor: 'rgba(255, 159, 64, 0.6)',
       },
     ],
+  };
+  const denialOptions = {
+    plugins: { tooltip: { enabled: true }, legend: { display: true } },
+    scales: { y: { beginAtZero: true, max: 100 } },
   };
   return (
       <div className="dashboard">
@@ -553,7 +587,7 @@ ChartJS.register(
           <h3>{t('dashboard.revenueOverTime')}</h3>
           <Line
             data={revenueLineData}
-            options={{ scales: { y: { beginAtZero: true } } }}
+            options={revenueLineOptions}
             data-testid="revenue-line"
           />
         </div>
@@ -575,10 +609,10 @@ ChartJS.register(
         Object.keys(metrics.coding_distribution).length > 0 && (
           <div style={{ marginTop: '1rem' }}>
             <h3>{t('dashboard.codeDistribution')}</h3>
-            <Bar
-              data={codeBarData}
-              options={codeBarOptions}
-              data-testid="codes-bar"
+            <Pie
+              data={codePieData}
+              options={codePieOptions}
+              data-testid="codes-pie"
             />
           </div>
         )}
@@ -587,7 +621,7 @@ ChartJS.register(
         Object.keys(metrics.denial_rates).length > 0 && (
           <div style={{ marginTop: '1rem' }}>
               <h3>{t('dashboard.denialRates')}</h3>
-              <Bar data={denialData} data-testid="denial-bar" />
+              <Bar data={denialData} options={denialOptions} data-testid="denial-bar" />
           </div>
         )}
     </div>

--- a/src/components/__tests__/Dashboard.test.jsx
+++ b/src/components/__tests__/Dashboard.test.jsx
@@ -79,7 +79,7 @@ test('renders charts and calls API', async () => {
   expect(getMetrics).toHaveBeenCalled();
   expect(document.querySelector('[data-testid="daily-line"]')).toBeTruthy();
   expect(document.querySelector('[data-testid="weekly-line"]')).toBeTruthy();
-  expect(document.querySelector('[data-testid="codes-bar"]')).toBeTruthy();
+  expect(document.querySelector('[data-testid="codes-pie"]')).toBeTruthy();
   expect(document.querySelector('[data-testid="denial-bar"]')).toBeTruthy();
   expect(document.querySelector('[data-testid="denial-def-bar"]')).toBeTruthy();
   expect(document.querySelector('[data-testid="revenue-line"]')).toBeTruthy();

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -35,6 +35,8 @@
     "denialDefRates": "Denial and Deficiency Rates",
     "denialRateLabel": "Denial Rate (%)",
     "deficiencyRateLabel": "Deficiency Rate (%)",
+    "denials": "Denials",
+    "deficiencies": "Deficiencies",
     "allClinicians": "All Clinicians",
     "range": "Range",
     "customRange": "Custom",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -35,6 +35,8 @@
     "denialDefRates": "Tasas de denegación y deficiencia",
     "denialRateLabel": "Tasa de denegación (%)",
     "deficiencyRateLabel": "Tasa de deficiencia (%)",
+    "denials": "Denegaciones",
+    "deficiencies": "Deficiencias",
     "allClinicians": "Todos los clínicos",
     "range": "Rango",
     "customRange": "Personalizado",

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -87,6 +87,7 @@ def test_metrics_timeseries_and_range():
         {"eventType": "chart_upload", "timestamp": ts1 + 240, "details": json.dumps({})},
         {"eventType": "audio_recorded", "timestamp": ts1 + 300, "details": json.dumps({})},
         {"eventType": "note_started", "timestamp": ts2, "details": json.dumps({"patientID": "p2", "length": 150})},
+        {"eventType": "note_closed", "timestamp": ts1 + 360, "details": json.dumps({"denial": True, "deficiency": True})},
     ]
     for ev in events:
         main.db_conn.execute(
@@ -103,6 +104,8 @@ def test_metrics_timeseries_and_range():
     assert daily['2024-01-01']['notes'] == 1
     assert daily['2024-01-01']['beautify'] == 1
     assert daily['2024-01-01']['suggest'] == 1
+    assert daily['2024-01-01']['denials'] == 1
+    assert daily['2024-01-01']['deficiencies'] == 1
     assert daily['2024-01-08']['notes'] == 1
     # range filter
     resp = client.get('/metrics', params={'start': datetime.utcfromtimestamp(ts2).isoformat()}, headers={'Authorization': f'Bearer {token}'})


### PR DESCRIPTION
## Summary
- Extend `/metrics` time-series to include daily/weekly denial and deficiency counts
- Plot new metrics and a code-distribution pie chart in Dashboard with Chart.js tooltips and legends
- Localize new labels and update tests

## Testing
- `pytest -q`
- `npm test` *(fails: Transform failed with duplicate symbol declarations in NoteEditor.jsx)*
- `npx vitest run src/components/__tests__/Dashboard.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_6892efa45a208324bd14f4dd3ad5930f