### PR TITLE
Implement audit log and login lockout

### DIFF
--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -19,6 +19,9 @@ def client(monkeypatch, tmp_path):
     db.execute(
         "CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE NOT NULL, password_hash TEXT NOT NULL, role TEXT NOT NULL)"
     )
+    db.execute(
+        "CREATE TABLE audit_log (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp REAL, username TEXT, action TEXT, details TEXT)"
+    )
     migrations.ensure_settings_table(db)
     pwd = hashlib.sha256(b"pw").hexdigest()
     db.execute(

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -13,6 +13,13 @@ def setup_module(module):
     main.db_conn.execute(
         "CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT, eventType TEXT, timestamp REAL, details TEXT, revenue REAL, codes TEXT, compliance_flags TEXT, public_health INTEGER, satisfaction INTEGER)"
     )
+    main.db_conn.execute(
+        "CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password_hash TEXT, role TEXT)"
+    )
+    main.db_conn.execute(
+        "CREATE TABLE audit_log (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp REAL, username TEXT, action TEXT, details TEXT)"
+    )
+    main.db_conn.commit()
 
 
 def test_metrics_empty_returns_zeros():

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -13,6 +13,9 @@ def test_register_endpoint(monkeypatch):
     db.execute(
         "CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE NOT NULL, password_hash TEXT NOT NULL, role TEXT NOT NULL)"
     )
+    db.execute(
+        "CREATE TABLE audit_log (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp REAL, username TEXT, action TEXT, details TEXT)"
+    )
     db.commit()
     monkeypatch.setattr(main, "db_conn", db)
 


### PR DESCRIPTION
## Summary
- track failed logins and admin actions in new `audit_log` table
- lock accounts for 15 minutes after 5 failed login attempts
- add admin-only `/audit` endpoint and tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892f0374f788324932735ecac2eb771