### PR TITLE
fix: clean up NoteEditor state handling

### DIFF
--- a/src/components/NoteEditor.jsx
+++ b/src/components/NoteEditor.jsx
@@ -117,10 +117,8 @@ const NoteEditor = forwardRef(function NoteEditor(
   const [segments, setSegments] = useState([]);
   const [audioUrl, setAudioUrl] = useState('');
   const [currentSpeaker, setCurrentSpeaker] = useState('');
-  const [templates, setTemplates] = useState([]);
   const [loadingTranscript, setLoadingTranscript] = useState(false);
   const [fetchError, setFetchError] = useState('');
-  const [transcribing, setTranscribing] = useState(false);
 
   const quillRef = useRef(null);
   const textAreaRef = useRef(null);
@@ -145,6 +143,7 @@ const NoteEditor = forwardRef(function NoteEditor(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value, mode]);
 
+  let mounted = true;
   useEffect(() => {
     getTemplates()
       .then((tpls) => mounted && setTemplates(tpls))
@@ -152,7 +151,6 @@ const NoteEditor = forwardRef(function NoteEditor(
     return () => {
       mounted = false;
     };
-
   }, []);
 
   const loadTranscript = async () => {


### PR DESCRIPTION
## Summary
- remove duplicate templates/transcribing state declarations
- add mounted guard for template fetch
- use recorder hook's transcribing flag consistently

## Testing
- `npm test` *(fails: Transform failed with 1 error: Dashboard.jsx:509:8: ERROR: Expected ":" but found "denialOptions")*

------
https://chatgpt.com/codex/tasks/task_e_6893619f42148324930427e2ca1da8b9