### PR TITLE
Enhance transcription fallbacks and UI handling

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -306,17 +306,23 @@ export async function transcribeAudio(blob, diarise = false) {
           provider: data.provider || '',
           patient: data.patient || '',
           segments: data.segments || [],
+          error: data.error || '',
         };
       }
       if (data.transcript) {
-        return { provider: data.transcript, patient: '', segments: data.segments || [] };
+        return {
+          provider: data.transcript,
+          patient: '',
+          segments: data.segments || [],
+          error: data.error || '',
+        };
       }
     } catch (err) {
       console.error('Transcription error', err);
     }
   }
   // Fallback placeholder when no backend is available
-  return { provider: `[transcribed ${blob.size} bytes]`, patient: '', segments: [] };
+  return { provider: `[transcribed ${blob.size} bytes]`, patient: '', segments: [], error: '' };
 }
 
 /**
@@ -341,12 +347,13 @@ export async function fetchLastTranscript() {
         provider: data.provider || '',
         patient: data.patient || '',
         segments: data.segments || [],
+        error: data.error || '',
       };
     } catch (err) {
       console.error('fetchLastTranscript error', err);
     }
   }
-  return { provider: '', patient: '', segments: [] };
+  return { provider: '', patient: '', segments: [], error: '' };
 }
 
 /**

--- a/src/components/NoteEditor.jsx
+++ b/src/components/NoteEditor.jsx
@@ -51,6 +51,8 @@ function useAudioRecorder(onTranscribed) {
         setTranscribing(true);
         try {
           const data = await transcribeAudio(blob, true);
+          if (data.error) setError(data.error);
+          else setError('');
           if (onTranscribed) onTranscribed(data, blob);
         } catch (err) {
           console.error('Transcription failed', err);
@@ -142,6 +144,7 @@ const NoteEditor = forwardRef(function NoteEditor(
       });
       if (onTranscriptChange) onTranscriptChange(data);
       setSegments(data.segments || []);
+      setFetchError(data.error || '');
     } catch (err) {
       setFetchError('Failed to load transcript');
     } finally {


### PR DESCRIPTION
## Summary
- report diarisation failures with a clear `error` field and fall back to single-speaker segments
- surface transcript errors to the frontend and reset cached transcripts to avoid stale data
- handle transcript fetch/recording errors in the note editor UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68936c6f75e4832491bf2fb879ffee15