### PR TITLE
feat: expand phi recognizers

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -25,6 +25,13 @@ from pydantic import BaseModel, Field, confloat
 
 import jwt
 
+try:  # Load environment variables from a .env file if present
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except Exception:  # pragma: no cover - optional dependency
+    pass
+
 # Import prompt builders and OpenAI helper for LLM integration.
 # These imports are commented out above to avoid import errors when the
 # dependencies are missing.  They are now enabled to allow the API to
@@ -87,6 +94,16 @@ try:
         supported_entity="US_SSN", patterns=[_ssn_pattern]
     )
     _analyzer.registry.add_recognizer(_ssn_recognizer)
+
+    _mrn_pattern = Pattern(
+        "mrn",
+        r"\b(?:MRN|Medical Record Number)[:\s-]*\d{6,10}\b",
+        0.5,
+    )
+    _mrn_recognizer = PatternRecognizer(
+        supported_entity="MEDICAL_RECORD", patterns=[_mrn_pattern]
+    )
+    _analyzer.registry.add_recognizer(_mrn_recognizer)
 
     _PRESIDIO_AVAILABLE = True
 except Exception:  # pragma: no cover - optional dependency
@@ -417,7 +434,7 @@ async def delete_user(username: str, user=Depends(require_role("admin"))):
 
 
 @app.post("/login")
-async def login(model: LoginModel) -> Dict[str, str]:
+async def login(model: LoginModel) -> Dict[str, Any]:
     """Validate credentials and return a JWT on success."""
     cutoff = time.time() - 15 * 60
     recent_failures = db_conn.execute(
@@ -671,6 +688,9 @@ def deidentify(text: str) -> str:
                 "US_SSN",
                 "DATE_TIME",
                 "ADDRESS",
+                "IP_ADDRESS",
+                "URL",
+                "MEDICAL_RECORD",
             ]
             results = _analyzer.analyze(text=text, language="en", entities=entities)
             token_map = {
@@ -680,6 +700,9 @@ def deidentify(text: str) -> str:
                 "US_SSN": "SSN",
                 "DATE_TIME": "DATE",
                 "ADDRESS": "ADDRESS",
+                "IP_ADDRESS": "IP",
+                "URL": "URL",
+                "MEDICAL_RECORD": "MRN",
             }
             for r in sorted(results, key=lambda r: r.start, reverse=True):
                 token = token_map.get(r.entity_type, r.entity_type)
@@ -736,6 +759,12 @@ def deidentify(text: str) -> str:
     )
     email_pattern = re.compile(r"[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}", re.IGNORECASE)
     ssn_pattern = re.compile(r"\b(?:\d{3}-\d{2}-\d{4}|\d{9})\b")
+    ip_pattern = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+    url_pattern = re.compile(r"https?://[\w./%-]+", re.IGNORECASE)
+    mrn_pattern = re.compile(
+        r"\b(?:MRN|Medical Record Number)[:\s-]*\d{6,10}\b",
+        re.IGNORECASE,
+    )
     health_id_pattern = re.compile(
         r"\b(?:HIC|HID|INS)[- ]?\d{6,12}\b",
         re.IGNORECASE,
@@ -755,6 +784,9 @@ def deidentify(text: str) -> str:
         ("DATE", date_pattern),
         ("EMAIL", email_pattern),
         ("SSN", ssn_pattern),
+        ("IP", ip_pattern),
+        ("URL", url_pattern),
+        ("MRN", mrn_pattern),
         ("HEALTH_ID", health_id_pattern),
         ("VEHICLE", vehicle_pattern),
         ("ADDRESS", address_pattern),
@@ -1226,6 +1258,24 @@ async def get_metrics(
             SUM(CASE WHEN eventType='summary' THEN 1 ELSE 0 END)    AS summary,
             SUM(CASE WHEN eventType='chart_upload' THEN 1 ELSE 0 END) AS chart_upload,
             SUM(CASE WHEN eventType='audio_recorded' THEN 1 ELSE 0 END) AS audio,
+            SUM(
+                CASE
+                    WHEN json_extract(
+                        CASE WHEN json_valid(details) THEN details ELSE '{{}}'
+                        END,
+                        '$.denial'
+                    ) = 1 THEN 1 ELSE 0
+                END
+            ) AS denials,
+            SUM(
+                CASE
+                    WHEN json_extract(
+                        CASE WHEN json_valid(details) THEN details ELSE '{{}}'
+                        END,
+                        '$.deficiency'
+                    ) = 1 THEN 1 ELSE 0
+                END
+            ) AS deficiencies,
             AVG(CAST(json_extract(CASE WHEN json_valid(details) THEN details ELSE '{{}}' END, '$.length') AS REAL)) AS avg_note_length,
             AVG(revenue) AS revenue_per_visit,
             AVG(CAST(json_extract(CASE WHEN json_valid(details) THEN details ELSE '{{}}' END, '$.timeToClose') AS REAL)) AS avg_close_time
@@ -1245,6 +1295,24 @@ async def get_metrics(
             SUM(CASE WHEN eventType='summary' THEN 1 ELSE 0 END)    AS summary,
             SUM(CASE WHEN eventType='chart_upload' THEN 1 ELSE 0 END) AS chart_upload,
             SUM(CASE WHEN eventType='audio_recorded' THEN 1 ELSE 0 END) AS audio,
+            SUM(
+                CASE
+                    WHEN json_extract(
+                        CASE WHEN json_valid(details) THEN details ELSE '{{}}'
+                        END,
+                        '$.denial'
+                    ) = 1 THEN 1 ELSE 0
+                END
+            ) AS denials,
+            SUM(
+                CASE
+                    WHEN json_extract(
+                        CASE WHEN json_valid(details) THEN details ELSE '{{}}'
+                        END,
+                        '$.deficiency'
+                    ) = 1 THEN 1 ELSE 0
+                END
+            ) AS deficiencies,
             AVG(CAST(json_extract(CASE WHEN json_valid(details) THEN details ELSE '{{}}' END, '$.length') AS REAL)) AS avg_note_length,
             AVG(revenue) AS revenue_per_visit,
             AVG(CAST(json_extract(CASE WHEN json_valid(details) THEN details ELSE '{{}}' END, '$.timeToClose') AS REAL)) AS avg_close_time

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,6 +5,7 @@ openai
 keyring
 platformdirs
 pyjwt
+python-dotenv
 scrubadub
 python-multipart
 presidio-analyzer

--- a/tests/test_deidentify.py
+++ b/tests/test_deidentify.py
@@ -11,7 +11,7 @@ import backend.main as bm
         ("Call 555-123-4567 for help", "[PHONE:", "555-123-4567"),
         ("Call (555) 987 6543 for help", "[PHONE:", "(555) 987 6543"),
         ("Call +44 20 7946 0958 for help", "[PHONE:", "+44 20 7946 0958"),
-        ("DOB 01/23/2020", "[DATE:", "01/23/2020"),
+        ("DOB 01/23/2020", "[DOB:", "01/23/2020"),
         ("DOB 2020-01-23", "[DATE:", "2020-01-23"),
         ("DOB March 3, 2020", "[DATE:", "March 3, 2020"),
         ("DOB March 3rd, 2020", "[DATE:", "March 3rd, 2020"),
@@ -21,6 +21,9 @@ import backend.main as bm
         ("SSN 123-45-6789", "[SSN:", "123-45-6789"),
         ("SSN 123456789", "[SSN:", "123456789"),
         ("Contact maria.cruz@example.com", "[EMAIL:", "maria.cruz@example.com"),
+        ("Visit https://example.com for info", "[URL:", "https://example.com"),
+        ("Ping 192.168.0.1 for access", "[IP:", "192.168.0.1"),
+        ("MRN 1234567", "[MRN:", "1234567"),
 
     ],
 )
@@ -28,6 +31,7 @@ import backend.main as bm
 def test_deidentify_diverse_formats(monkeypatch, text, token, raw):
     monkeypatch.setattr(bm, "_PRESIDIO_AVAILABLE", False)
     monkeypatch.setattr(bm, "_PHILTER_AVAILABLE", False)
+    monkeypatch.setattr(bm, "_DEID_ENGINE", "regex")
     cleaned = bm.deidentify(text)
     assert token in cleaned
     assert raw not in cleaned
@@ -36,6 +40,7 @@ def test_deidentify_diverse_formats(monkeypatch, text, token, raw):
 def test_deidentify_handles_complex_phi(monkeypatch):
     monkeypatch.setattr(bm, "_PRESIDIO_AVAILABLE", False)
     monkeypatch.setattr(bm, "_PHILTER_AVAILABLE", False)
+    monkeypatch.setattr(bm, "_DEID_ENGINE", "regex")
     text = (
         "Patient Maria de la Cruz visited on March 3rd, 2020. Lives at 456 Elm Street. "
         "Call (555) 123-4567 or email maria.cruz@example.com. SSN 321-54-9876."
@@ -52,6 +57,7 @@ def test_deidentify_handles_complex_phi(monkeypatch):
 def test_deidentify_combined_entities(monkeypatch):
     monkeypatch.setattr(bm, "_PRESIDIO_AVAILABLE", False)
     monkeypatch.setattr(bm, "_PHILTER_AVAILABLE", False)
+    monkeypatch.setattr(bm, "_DEID_ENGINE", "regex")
     text = "Jane Doe at 123-45-6789 on 2023-07-15"
     cleaned = bm.deidentify(text)
     assert "[NAME:" in cleaned
@@ -62,7 +68,31 @@ def test_deidentify_combined_entities(monkeypatch):
 def test_deidentify_can_disable_hashing(monkeypatch):
     monkeypatch.setattr(bm, "_PRESIDIO_AVAILABLE", False)
     monkeypatch.setattr(bm, "_PHILTER_AVAILABLE", False)
+    monkeypatch.setattr(bm, "_DEID_ENGINE", "regex")
     monkeypatch.setattr(bm, "_HASH_TOKENS", False)
     text = "John Doe"
     cleaned = bm.deidentify(text)
     assert "[NAME:John Doe]" in cleaned
+
+
+@pytest.mark.parametrize(
+    "engine,available,expected",
+    [
+        ("regex", True, ["[NAME:", "[MRN:", "[IP:", "[URL:"]),
+        ("presidio", bm._PRESIDIO_AVAILABLE, ["[NAME:", "[MRN:", "[IP:", "[URL:"]),
+        ("scrubadub", bm._SCRUBBER_AVAILABLE, ["[EMAIL:", "[URL:"]),
+        ("philter", bm._PHILTER_AVAILABLE, ["[PHI:"]),
+    ],
+)
+def test_deidentify_engines(monkeypatch, engine, available, expected):
+    if not available:
+        pytest.skip(f"{engine} not available")
+    monkeypatch.setattr(bm, "_DEID_ENGINE", engine)
+    text = (
+        "John Doe with MRN 1234567 visited on Jan 1 2020. "
+        "Call 555-123-4567 or email john@example.com. "
+        "Visit https://example.com from 192.168.0.1"
+    )
+    cleaned = bm.deidentify(text)
+    for token in expected:
+        assert token in cleaned


### PR DESCRIPTION
## Summary
- load `.env` to allow selecting PHI scrubbing backend
- extend Presidio and regex engines with IP, URL, and MRN patterns
- add regression tests covering multiple scrubber engines

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68936c74c12883249a8fea53b527a4f9