### PR TITLE
feat: add auto-update hooks and linux signing

### DIFF
--- a/docs/DESKTOP_BUILD.md
+++ b/docs/DESKTOP_BUILD.md
@@ -24,6 +24,8 @@ The following variables are written to `.env`:
   and password.
 - `CSC_LINK`, `CSC_KEY_PASSWORD` – macOS Developer ID certificate and
   password.
+- `LINUX_CSC_LINK`, `LINUX_CSC_KEY_PASSWORD` – optional Linux code-signing
+  certificate and password.
 
 ## Obtaining code-signing certificates
 
@@ -36,6 +38,9 @@ macOS builds require membership in the Apple Developer Program. Create a
 *Developer ID Application* certificate in the Apple Developer portal, export it
 as a `.p12` file and configure `CSC_LINK` and `CSC_KEY_PASSWORD` with the file
 location and password.
+
+Linux builds can also be signed. Export a suitable code-signing certificate to a
+`.p12` file and set `LINUX_CSC_LINK` and `LINUX_CSC_KEY_PASSWORD`.
 
 ## 2. Build signed installers
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -150,6 +150,15 @@ app.on('window-all-closed', () => {
   }
 });
 
+autoUpdater.on('update-available', () => {
+  console.log('Update available');
+});
+
+autoUpdater.on('update-downloaded', () => {
+  console.log('Update downloaded; installing');
+  autoUpdater.quitAndInstall();
+});
+
 autoUpdater.on('error', (err) => {
   console.error('Auto-update error:', err);
 });

--- a/package.json
+++ b/package.json
@@ -88,7 +88,9 @@
         "AppImage",
         "deb"
       ],
-      "category": "Utility"
+      "category": "Utility",
+      "cscLink": "${env.LINUX_CSC_LINK}",
+      "cscKeyPassword": "${env.LINUX_CSC_KEY_PASSWORD}"
     },
     "publish": [
       {

--- a/scripts/check-build-env.js
+++ b/scripts/check-build-env.js
@@ -8,6 +8,8 @@ const required = [
   'WIN_CSC_KEY_PASSWORD',
   'CSC_LINK',
   'CSC_KEY_PASSWORD',
+  'LINUX_CSC_LINK',
+  'LINUX_CSC_KEY_PASSWORD',
 ];
 
 const missing = required.filter((name) => !process.env[name]);

--- a/tests/test_blockers.py
+++ b/tests/test_blockers.py
@@ -135,6 +135,11 @@ def test_electron_packaging_configuration_present():
 
     build = pkg.get("build") or {}
     assert build.get("appId"), "electron-builder config missing"
+    linux_cfg = build.get("linux") or {}
+    assert linux_cfg.get("cscLink"), "linux code signing link missing"
+    assert linux_cfg.get("cscKeyPassword"), "linux code signing password missing"
+    publish = build.get("publish") or []
+    assert any(p.get("url") == "${env.UPDATE_SERVER_URL}" for p in publish), "update server URL missing"
 
 
 def test_electron_auto_update_and_backend_spawn_present():
@@ -145,6 +150,8 @@ def test_electron_auto_update_and_backend_spawn_present():
 
     assert "autoUpdater" in content, "auto-updater not referenced"
     assert "checkForUpdatesAndNotify" in content, "auto-update not triggered"
+    assert "setFeedURL" in content, "update feed not configured"
+    assert "update-downloaded" in content, "update download handler missing"
     assert "spawn(" in content and "uvicorn" in content, "backend spawn missing"
 
 


### PR DESCRIPTION
## Summary
- hook auto-updater to update server and install downloaded releases
- sign Linux builds and require signing env vars across platforms
- document build env vars and extend smoke tests for update wiring

## Testing
- `npm test` (fails: Dashboard.test.jsx renders charts and calls API)
- `pytest` (fails: 10 tests including ResponseValidationError, KeyError)


------
https://chatgpt.com/codex/tasks/task_e_68936c796ba08324941234e66040ca60