### PR TITLE
feat: add metrics aggregation filters

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -462,6 +462,10 @@ function Dashboard() {
     },
   };
 
+  const hasDaily = (metrics.timeseries?.daily?.length || 0) > 0;
+  const hasWeekly = (metrics.timeseries?.weekly?.length || 0) > 0;
+  const noDataLabel = t('dashboard.noData', { defaultValue: 'No data' });
+
   const revenueLineData = {
     labels: dailyLabels,
     datasets: [
@@ -637,21 +641,29 @@ function Dashboard() {
       {metrics.timeseries && (
         <div className="timeseries" style={{ marginTop: '1rem' }}>
           <h3>{t('dashboard.dailyEvents')}</h3>
-          <Line
-            data={dailyData}
-            options={dailyOptions}
-            data-testid="daily-line"
-          />
+          {hasDaily ? (
+            <Line
+              data={dailyData}
+              options={dailyOptions}
+              data-testid="daily-line"
+            />
+          ) : (
+            <p data-testid="no-daily-data">{noDataLabel}</p>
+          )}
           <h3 style={{ marginTop: '1rem' }}>{t('dashboard.weeklyEvents')}</h3>
-          <Line
-            data={weeklyData}
-            options={weeklyOptions}
-            data-testid="weekly-line"
-          />
+          {hasWeekly ? (
+            <Line
+              data={weeklyData}
+              options={weeklyOptions}
+              data-testid="weekly-line"
+            />
+          ) : (
+            <p data-testid="no-weekly-data">{noDataLabel}</p>
+          )}
         </div>
       )}
 
-      {metrics.timeseries && (
+      {metrics.timeseries && hasDaily && (
         <div style={{ marginTop: '1rem' }}>
           <h3>{t('dashboard.revenueOverTime')}</h3>
           <Line

--- a/src/components/__tests__/Dashboard.test.jsx
+++ b/src/components/__tests__/Dashboard.test.jsx
@@ -46,6 +46,7 @@ vi.mock('../../api.js', () => ({
     coding_distribution: { '99213': 2 },
     denial_rates: { '99213': 0.1 },
     compliance_counts: {},
+    top_compliance: [{ gap: 'Missing ROS', count: 1 }],
     avg_satisfaction: 0,
     public_health_rate: 0,
     clinicians: ['alice', 'bob'],
@@ -146,4 +147,24 @@ test('applies clinician filter', async () => {
     end: '',
     clinician: 'alice',
   });
+});
+
+test('shows message when timeseries empty', async () => {
+  getMetrics.mockResolvedValueOnce({
+    baseline: {},
+    current: {},
+    improvement: {},
+    coding_distribution: {},
+    denial_rates: {},
+    compliance_counts: {},
+    avg_satisfaction: 0,
+    public_health_rate: 0,
+    clinicians: [],
+    timeseries: { daily: [], weekly: [] },
+  });
+  render(<Dashboard />);
+  await waitFor(() => document.querySelector('[data-testid="no-daily-data"]'));
+  expect(document.querySelector('[data-testid="daily-line"]')).toBeNull();
+  expect(document.querySelector('[data-testid="weekly-line"]')).toBeNull();
+  expect(document.querySelector('[data-testid="revenue-line"]')).toBeNull();
 });

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -160,6 +160,23 @@ def test_timeseries_always_present():
     assert isinstance(data['timeseries']['weekly'], list)
 
 
+def test_metrics_query_params_daily_weekly():
+    client = TestClient(main.app)
+    main.db_conn.execute('DELETE FROM events')
+    main.db_conn.commit()
+    token = main.create_token('tester', 'admin')
+
+    resp = client.get('/metrics', params={'weekly': 'false'}, headers={'Authorization': f'Bearer {token}'})
+    data = resp.json()
+    assert 'weekly' not in data['timeseries']
+    assert 'daily' in data['timeseries']
+
+    resp = client.get('/metrics', params={'daily': 'false'}, headers={'Authorization': f'Bearer {token}'})
+    data = resp.json()
+    assert 'daily' not in data['timeseries']
+    assert 'weekly' in data['timeseries']
+
+
 def test_survey_endpoint_and_avg_rating():
     client = TestClient(main.app)
     main.db_conn.execute('DELETE FROM events')


### PR DESCRIPTION
## Summary
- add optional `daily` and `weekly` query params to `/metrics`
- display placeholder text when dashboard charts have no data
- test metrics aggregation filters and dashboard empty-state rendering

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68936c799d3083249db2f03fb4a61134