### PR TITLE
Add FHIR export endpoint and client

### DIFF
--- a/backend/ehr_integration.py
+++ b/backend/ehr_integration.py
@@ -1,0 +1,73 @@
+"""Lightweight FHIR client used by the EHR export endpoint.
+
+This module provides a helper :func:`post_note_and_codes` which submits
+clinical notes and associated billing codes to a FHIR server using a
+transaction bundle.  The function intentionally performs only the minimal
+request construction required for tests; it can be expanded later to cover
+additional resource types or authentication mechanisms.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import List, Dict, Any
+
+import requests
+
+FHIR_SERVER_URL = os.getenv("FHIR_SERVER_URL", "https://fhir.example.com")
+
+
+def _build_bundle(note: str, codes: List[str]) -> Dict[str, Any]:
+    """Return a FHIR transaction bundle for ``note`` and ``codes``.
+
+    ``note`` is wrapped in an ``Observation`` resource while each code is
+    represented as a ``Condition`` with a single coding entry.  The bundle is
+    intentionally simple and omits many optional fields so the tests can focus
+    on verifying the HTTP interaction rather than full FHIR compliance.
+    """
+
+    bundle: Dict[str, Any] = {
+        "resourceType": "Bundle",
+        "type": "transaction",
+        "entry": [
+            {
+                "request": {"method": "POST", "url": "Observation"},
+                "resource": {
+                    "resourceType": "Observation",
+                    "status": "final",
+                    "code": {"text": "Clinical Note"},
+                    "valueString": note,
+                },
+            }
+        ],
+    }
+    for code in codes:
+        bundle["entry"].append(
+            {
+                "request": {"method": "POST", "url": "Condition"},
+                "resource": {
+                    "resourceType": "Condition",
+                    "code": {"coding": [{"code": code}]},
+                },
+            }
+        )
+    return bundle
+
+
+def post_note_and_codes(note: str, codes: List[str]) -> Dict[str, Any]:
+    """Send ``note`` and ``codes`` to the configured FHIR server.
+
+    A transaction bundle is POSTed to ``FHIR_SERVER_URL`` (or the value of the
+    environment variable of the same name).  The server's JSON response is
+    returned.  ``requests`` exceptions are allowed to propagate so callers can
+    surface an appropriate error to clients.
+    """
+
+    url = f"{FHIR_SERVER_URL.rstrip('/')}/Bundle"
+    payload = _build_bundle(note, codes)
+    resp = requests.post(url, json=payload, timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+
+
+__all__ = ["post_note_and_codes"]

--- a/src/api.js
+++ b/src/api.js
@@ -747,7 +747,20 @@ export async function setApiKey(key) {
  * @param {string} note
  * @param {string} [token]
  */
-export async function exportToEhr(note, token) {
+export async function exportToEhr(
+  note,
+  codes = [],
+  direct = false,
+  token
+) {
+  // ``direct`` acts as a frontend toggle. When false the function resolves
+  // immediately without contacting the backend so the caller can simply copy
+  // the note manually. This keeps the UI logic straightforward while allowing
+  // opt‑in EHR submission.
+  if (!direct) {
+    return { status: 'skipped' };
+  }
+
   const baseUrl =
     import.meta?.env?.VITE_API_URL ||
     window.__BACKEND_URL__ ||
@@ -761,7 +774,7 @@ export async function exportToEhr(note, token) {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${auth}`,
     },
-    body: JSON.stringify({ note }),
+    body: JSON.stringify({ note, codes }),
   });
   if (!resp.ok) throw new Error('Export failed');
   return await resp.json();

--- a/tests/test_ehr_integration.py
+++ b/tests/test_ehr_integration.py
@@ -1,0 +1,71 @@
+import hashlib
+import sqlite3
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend import main, migrations, ehr_integration
+
+
+class DummyResp:
+    def __init__(self, data):
+        self._data = data
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._data
+
+
+@pytest.fixture
+def client(monkeypatch):
+    db = sqlite3.connect(":memory:", check_same_thread=False)
+    db.row_factory = sqlite3.Row
+    db.execute(
+        "CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT, eventType TEXT NOT NULL, timestamp REAL NOT NULL, details TEXT, revenue REAL, codes TEXT, compliance_flags TEXT, public_health INTEGER, satisfaction INTEGER)"
+    )
+    db.execute(
+        "CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE NOT NULL, password_hash TEXT NOT NULL, role TEXT NOT NULL)"
+    )
+    db.execute(
+        "CREATE TABLE audit_log (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp REAL, username TEXT, action TEXT, details TEXT)"
+    )
+    migrations.ensure_settings_table(db)
+    pwd = hashlib.sha256(b"pw").hexdigest()
+    db.execute(
+        "INSERT INTO users (username, password_hash, role) VALUES (?, ?, ?)",
+        ("admin", pwd, "admin"),
+    )
+    db.commit()
+    monkeypatch.setattr(main, "db_conn", db)
+    monkeypatch.setattr(main, "events", [])
+    return TestClient(main.app)
+
+
+def auth_header(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_posts_bundle_to_fhir(monkeypatch, client):
+    token = client.post("/login", json={"username": "admin", "password": "pw"}).json()["access_token"]
+
+    calls = []
+
+    def fake_post(url, json=None, timeout=10):
+        calls.append({"url": url, "json": json})
+        return DummyResp({"id": "bundle1"})
+
+    monkeypatch.setattr(ehr_integration.requests, "post", fake_post)
+    monkeypatch.setattr(ehr_integration, "FHIR_SERVER_URL", "http://fhir.test")
+
+    resp = client.post(
+        "/export_to_ehr",
+        json={"note": "Example note", "codes": ["A1"]},
+        headers=auth_header(token),
+    )
+    assert resp.status_code == 200
+    assert calls and calls[0]["url"] == "http://fhir.test/Bundle"
+    bundle = calls[0]["json"]
+    assert bundle["entry"][0]["resource"]["valueString"] == "Example note"
+    assert bundle["entry"][1]["resource"]["code"]["coding"][0]["code"] == "A1"


### PR DESCRIPTION
## Summary
- add lightweight FHIR client module and hook export endpoint to it
- support codes and optional direct flag in frontend EHR export helper
- test FHIR export using mocked server and update auth tests

## Testing
- `pytest tests/test_api_endpoints.py::test_export_to_ehr_requires_admin tests/test_ehr_integration.py -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68937390c9508324a1ffc6cffedbfe84