### PR TITLE
Validate and sync user settings

### DIFF
--- a/src/__tests__/i18nSwitch.test.jsx
+++ b/src/__tests__/i18nSwitch.test.jsx
@@ -22,9 +22,7 @@ vi.mock('../api.js', () => ({
   createTemplate: vi.fn(),
   updateTemplate: vi.fn(),
   deleteTemplate: vi.fn(),
-  getPromptTemplates: vi.fn().mockResolvedValue({}),
-  saveSettings: vi.fn(),
-  getPromptTemplates: vi.fn().mockResolvedValue({}),
+  saveSettings: vi.fn(async (s) => s),
 }));
 
 vi.mock('react-chartjs-2', () => ({

--- a/src/api.js
+++ b/src/api.js
@@ -210,7 +210,20 @@ export async function saveSettings(settings, token) {
     body: JSON.stringify(payload),
   });
   if (!resp.ok) throw new Error('Failed to save settings');
-  return await resp.json();
+  const data = await resp.json();
+  const categories = data.categories || {};
+  return {
+    theme: data.theme,
+    enableCodes: categories.codes !== false,
+    enableCompliance: categories.compliance !== false,
+    enablePublicHealth: categories.publicHealth !== false,
+    enableDifferentials: categories.differentials !== false,
+    rules: data.rules || [],
+    lang: data.lang || 'en',
+    specialty: data.specialty || '',
+    payer: data.payer || '',
+    region: data.region || '',
+  };
 }
 
 /**

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -96,18 +96,18 @@ function Settings({ settings, updateSettings }) {
   };
   const handleToggle = async (key) => {
     const updated = { ...settings, [key]: !settings[key] };
-    updateSettings(updated);
     try {
-      await saveSettings(updated);
+      const saved = await saveSettings(updated);
+      updateSettings(saved);
     } catch (e) {
       console.error(e);
     }
   };
   const handleThemeChange = async (event) => {
     const updated = { ...settings, theme: event.target.value };
-    updateSettings(updated);
     try {
-      await saveSettings(updated);
+      const saved = await saveSettings(updated);
+      updateSettings(saved);
     } catch (e) {
       console.error(e);
     }
@@ -135,10 +135,10 @@ function Settings({ settings, updateSettings }) {
     const newLang = event.target.value;
     if (newLang === settings.lang) return;
     const updated = { ...settings, lang: newLang };
-    updateSettings(updated);
     i18n.changeLanguage(newLang);
     try {
-      await saveSettings(updated);
+      const saved = await saveSettings(updated);
+      updateSettings(saved);
     } catch (e) {
       console.error(e);
     }
@@ -146,9 +146,9 @@ function Settings({ settings, updateSettings }) {
 
   const handleSpecialtyChange = async (event) => {
     const updated = { ...settings, specialty: event.target.value };
-    updateSettings(updated);
     try {
-      await saveSettings(updated);
+      const saved = await saveSettings(updated);
+      updateSettings(saved);
     } catch (e) {
       console.error(e);
     }
@@ -156,9 +156,9 @@ function Settings({ settings, updateSettings }) {
 
   const handlePayerChange = async (event) => {
     const updated = { ...settings, payer: event.target.value };
-    updateSettings(updated);
     try {
-      await saveSettings(updated);
+      const saved = await saveSettings(updated);
+      updateSettings(saved);
     } catch (e) {
       console.error(e);
     }
@@ -166,9 +166,9 @@ function Settings({ settings, updateSettings }) {
 
   const handleRegionChange = async (event) => {
     const updated = { ...settings, region: event.target.value };
-    updateSettings(updated);
     try {
-      await saveSettings(updated);
+      const saved = await saveSettings(updated);
+      updateSettings(saved);
     } catch (e) {
       console.error(e);
     }
@@ -286,9 +286,9 @@ function Settings({ settings, updateSettings }) {
             .map((line) => line.trim())
             .filter(Boolean);
           const updated = { ...settings, rules: lines };
-          updateSettings(updated);
           try {
-            await saveSettings(updated);
+            const saved = await saveSettings(updated);
+            updateSettings(saved);
           } catch (err) {
             console.error(err);
           }

--- a/src/components/__tests__/Settings.test.jsx
+++ b/src/components/__tests__/Settings.test.jsx
@@ -5,7 +5,7 @@ import i18n from '../../i18n.js';
 
 vi.mock('../../api.js', () => ({
   setApiKey: vi.fn(),
-  saveSettings: vi.fn(),
+  saveSettings: vi.fn(async (s) => s),
   getTemplates: vi.fn().mockResolvedValue([]),
   createTemplate: vi.fn(),
   updateTemplate: vi.fn(),


### PR DESCRIPTION
## Summary
- enforce strict validation on user settings including allowed themes, boolean categories, and cleaned rules
- sync settings state with backend responses and expose canonical data from `saveSettings`
- verify persistence and validation of settings in round-trip tests

## Testing
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_689373915e488324b39195bc6e3ab549