### PR TITLE
feat: add specialty/payer prompt modifiers

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -780,7 +780,7 @@ def deidentify(text: str) -> str:
 
     patterns = [
         ("PHONE", phone_pattern),
-        ("DATE", dob_pattern),
+        ("DOB", dob_pattern),
         ("DATE", date_pattern),
         ("EMAIL", email_pattern),
         ("SSN", ssn_pattern),

--- a/backend/prompt_templates.json
+++ b/backend/prompt_templates.json
@@ -34,6 +34,20 @@
       ]
     }
   },
+  "specialty_modifiers": {
+      "cardiology": {
+        "en": "Remember to include cardiac-specific terminology.",
+        "es": "Recuerda incluir terminología cardiaca."
+      },
+    "paediatrics": {
+      "en": "Adjust tone for pediatric cases."
+    }
+  },
+  "payer_modifiers": {
+    "medicare": {
+      "en": "Apply Medicare reimbursement guidelines."
+    }
+  },
   "specialty": {
     "cardiology": {
       "beautify": {

--- a/backend/prompts.py
+++ b/backend/prompts.py
@@ -77,9 +77,23 @@ def _get_custom_instruction(
     parts = []
     parts.append(extract(templates.get("default", {})))
     if specialty:
-        parts.append(extract(templates.get("specialty", {}).get(specialty, {})))
+        specialty_key = specialty.lower()
+        parts.append(
+            _resolve_lang(
+                templates.get("specialty_modifiers", {}).get(specialty_key, {}), lang
+            )
+        )
+        parts.append(
+            extract(templates.get("specialty", {}).get(specialty_key, {}))
+        )
     if payer:
-        parts.append(extract(templates.get("payer", {}).get(payer, {})))
+        payer_key = payer.lower()
+        parts.append(
+            _resolve_lang(
+                templates.get("payer_modifiers", {}).get(payer_key, {}), lang
+            )
+        )
+        parts.append(extract(templates.get("payer", {}).get(payer_key, {})))
     return " ".join(p for p in parts if p)
 
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -48,6 +48,8 @@ def test_specialty_and_payer_overrides():
     assert "Base instruction applied to all notes." in content
     assert "Cardiology specific beautify instruction." in content
     assert "Ensure documentation meets Medicare standards." in content
+    assert "cardiac-specific terminology" in content
+    assert "Medicare reimbursement guidelines" in content
     # Default and specialty examples should be included
     texts = [m["content"] for m in beauty]
     assert any("chief complaint: cough for 3 days" in t for t in texts)
@@ -71,6 +73,15 @@ def test_specialty_and_payer_overrides():
     assert "Follow Medicare summary requirements." in sc
     texts = [m["content"] for m in summary]
     assert "Example summary note" in texts
+
+
+def test_specialty_payer_modifiers_spanish():
+    msgs = prompts.build_beautify_prompt(
+        "nota", lang="es", specialty="cardiology", payer="medicare"
+    )
+    content = msgs[0]["content"]
+    assert "terminología cardiaca" in content
+    assert "Medicare reimbursement guidelines" in content
 
 
 def test_guideline_tips_added(monkeypatch):


### PR DESCRIPTION
## Summary
- load global specialty and payer modifiers into prompt builders
- expand prompt template JSON with new modifier sections and translations
- exercise modifier logic with new tests and Spanish coverage
- tag DOB fields explicitly during de-identification

## Testing
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68937394ac588324939cb77ed49f0905