### PR TITLE
feat: add local model evaluation with fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,27 @@ app into an Electron shell for desktop deployment.
 
 ### Offline model mode (experimental)
 
-Set the environment variable `USE_OFFLINE_MODEL=true` before starting the backend to bypass calls to external AI services. In this mode the `/beautify`, `/suggest` and `/summarize` endpoints return deterministic placeholder data so the app can run without network access or an API key.
+Set the environment variable `USE_OFFLINE_MODEL=true` before starting the
+backend to bypass calls to external AI services. In this mode the
+`/beautify`, `/suggest` and `/summarize` endpoints return deterministic
+placeholder data so the app can run without network access or an API key.
+
+To evaluate lightweight local models instead of the fixed placeholders, set
+`USE_LOCAL_MODELS=true` and provide model names for any of the endpoints you
+wish to test:
+
+```bash
+export USE_OFFLINE_MODEL=true
+export USE_LOCAL_MODELS=true
+export LOCAL_BEAUTIFY_MODEL=hf-internal-testing/tiny-random-t5
+export LOCAL_SUMMARIZE_MODEL=sshleifer/tiny-bart-large-cnn
+export LOCAL_SUGGEST_MODEL=hf-internal-testing/tiny-random-gpt2
+```
+
+Models are loaded with the `transformers` pipeline and must therefore be
+available locally or downloadable from the Hugging Face Hub. If a model fails
+to load or does not return the expected structure, the deterministic offline
+placeholders are used as a fallback so the API always responds.
 
 ### Local Whisper transcription
 

--- a/backend/offline_model.py
+++ b/backend/offline_model.py
@@ -1,21 +1,73 @@
-"""Offline deterministic placeholders for API endpoints.
+"""Offline placeholders and optional local model evaluation for API endpoints.
 
-This module provides simple functions that return fixed data structures for
-``/beautify``, ``/suggest`` and ``/summarize`` when the environment variable
-``USE_OFFLINE_MODEL`` is enabled.  It allows the backend to operate without
-network access or an API key by returning predictable strings and lists.
+This module backs the ``/beautify``, ``/suggest`` and ``/summarize``
+endpoints when the environment variable ``USE_OFFLINE_MODEL`` is enabled.
+By default it returns deterministic strings and lists so the backend can run
+without network access.  If ``USE_LOCAL_MODELS`` is set, lightweight
+``transformers`` pipelines can be used to evaluate local models instead.  Any
+error loading or running the model results in the deterministic placeholder so
+the caller always receives a response.
 """
 
+from __future__ import annotations
+
+import json
+import os
 from typing import Dict, List, Optional
 
 
+_PIPELINES = {}
+
+
+def _get_pipeline(task: str, model: str):
+    """Lazy-load and cache a ``transformers`` pipeline.
+
+    Parameters
+    ----------
+    task:
+        The pipeline task, e.g. ``"summarization"``.
+    model:
+        Model identifier to pass to :func:`transformers.pipeline`.
+    """
+
+    key = (task, model)
+    if key not in _PIPELINES:
+        from transformers import pipeline  # Imported lazily for performance
+
+        _PIPELINES[key] = pipeline(task, model=model)
+    return _PIPELINES[key]
+
+
+def _use_local() -> bool:
+    return os.getenv("USE_LOCAL_MODELS", "").lower() in {"1", "true", "yes"}
+
+
 def beautify(text: str, lang: str = "en", specialty: Optional[str] = None, payer: Optional[str] = None) -> str:
-    """Return a deterministic beautified note for offline testing."""
+    """Beautify ``text`` using a local model or deterministic placeholder."""
+
+    if _use_local():
+        model = os.getenv("LOCAL_BEAUTIFY_MODEL")
+        if model:
+            try:
+                pipe = _get_pipeline("text2text-generation", model)
+                return pipe(text)[0]["generated_text"].strip()
+            except Exception:
+                pass
     return f"Beautified (offline): {text.strip()}"
 
 
 def summarize(text: str, lang: str = "en", specialty: Optional[str] = None, payer: Optional[str] = None) -> str:
-    """Return a deterministic summary for offline testing."""
+    """Summarise ``text`` with a local model or deterministic placeholder."""
+
+    if _use_local():
+        model = os.getenv("LOCAL_SUMMARIZE_MODEL")
+        if model:
+            try:
+                pipe = _get_pipeline("summarization", model)
+                result = pipe(text)[0]
+                return result.get("summary_text", "").strip() or result.get("generated_text", "").strip()
+            except Exception:
+                pass
     snippet = text.strip()[:50]
     return f"Summary (offline): {snippet}"
 
@@ -29,7 +81,20 @@ def suggest(
     sex: Optional[str] = None,
     region: Optional[str] = None,
 ) -> Dict[str, List]:
-    """Return deterministic suggestion payload for offline testing."""
+    """Return suggestions via a local model or deterministic placeholder."""
+
+    if _use_local():
+        model = os.getenv("LOCAL_SUGGEST_MODEL")
+        if model:
+            try:
+                pipe = _get_pipeline("text-generation", model)
+                raw = pipe(text, max_new_tokens=256)[0]["generated_text"]
+                data = json.loads(raw)
+                if all(k in data for k in ("codes", "compliance", "publicHealth", "differentials")):
+                    return data
+            except Exception:
+                pass
+
     return {
         "codes": [
             {

--- a/tests/test_local_models.py
+++ b/tests/test_local_models.py
@@ -1,0 +1,82 @@
+import json
+
+from backend import offline_model as om
+
+
+def test_local_beautify(monkeypatch):
+    monkeypatch.setenv("USE_LOCAL_MODELS", "true")
+    monkeypatch.setenv("LOCAL_BEAUTIFY_MODEL", "dummy")
+
+    class Pipe:
+        def __call__(self, text):
+            return [{"generated_text": "beautified"}]
+
+    monkeypatch.setattr(om, "_get_pipeline", lambda task, model: Pipe())
+    assert om.beautify("note") == "beautified"
+
+
+def test_local_beautify_fallback(monkeypatch):
+    monkeypatch.setenv("USE_LOCAL_MODELS", "true")
+    monkeypatch.setenv("LOCAL_BEAUTIFY_MODEL", "dummy")
+
+    def raiser(task, model):
+        raise RuntimeError("no model")
+
+    monkeypatch.setattr(om, "_get_pipeline", raiser)
+    assert om.beautify("note").startswith("Beautified (offline):")
+
+
+def test_local_summarize(monkeypatch):
+    monkeypatch.setenv("USE_LOCAL_MODELS", "true")
+    monkeypatch.setenv("LOCAL_SUMMARIZE_MODEL", "dummy")
+
+    class Pipe:
+        def __call__(self, text):
+            return [{"summary_text": "short"}]
+
+    monkeypatch.setattr(om, "_get_pipeline", lambda task, model: Pipe())
+    assert om.summarize("long note") == "short"
+
+
+def test_local_summarize_fallback(monkeypatch):
+    monkeypatch.setenv("USE_LOCAL_MODELS", "true")
+    monkeypatch.setenv("LOCAL_SUMMARIZE_MODEL", "dummy")
+
+    def raiser(task, model):
+        raise RuntimeError("no model")
+
+    monkeypatch.setattr(om, "_get_pipeline", raiser)
+    assert om.summarize("note").startswith("Summary (offline):")
+
+
+def test_local_suggest(monkeypatch):
+    monkeypatch.setenv("USE_LOCAL_MODELS", "true")
+    monkeypatch.setenv("LOCAL_SUGGEST_MODEL", "dummy")
+
+    sample = {
+        "codes": [{"code": "12345"}],
+        "compliance": ["ok"],
+        "publicHealth": [{"recommendation": "do"}],
+        "differentials": [{"diagnosis": "dx", "score": 0.1}],
+    }
+
+    class Pipe:
+        def __call__(self, text, max_new_tokens=256):
+            return [{"generated_text": json.dumps(sample)}]
+
+    monkeypatch.setattr(om, "_get_pipeline", lambda task, model: Pipe())
+    assert om.suggest("note") == sample
+
+
+def test_local_suggest_fallback(monkeypatch):
+    monkeypatch.setenv("USE_LOCAL_MODELS", "true")
+    monkeypatch.setenv("LOCAL_SUGGEST_MODEL", "dummy")
+
+    class Pipe:
+        def __call__(self, text, max_new_tokens=256):
+            return [{"generated_text": "not json"}]
+
+    monkeypatch.setattr(om, "_get_pipeline", lambda task, model: Pipe())
+    out = om.suggest("note")
+    assert out["codes"][0]["code"] == "00000"
+


### PR DESCRIPTION
## Summary
- support optional local transformer models for beautify, summarize, and suggest endpoints
- document local model toggles
- test local model and fallback behavior

## Testing
- `pytest tests/test_local_models.py tests/test_offline_mode.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68937397e88c8324920fa9a6a2bff2f9