### PR TITLE
Improve diarization tests and NoteEditor audio handling

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -97,7 +97,9 @@
     "transcript": "Transcript:",
     "placeholder": "Type your clinical note here...",
     "undo": "Undo",
-    "redo": "Redo"
+    "redo": "Redo",
+    "audioUnsupported": "Audio recording not supported",
+    "segments": "Segments"
   },
   "settings": {
     "title": "Settings",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -95,7 +95,9 @@
     "transcript": "Transcripción:",
     "placeholder": "Escriba aquí su nota clínica...",
     "undo": "Deshacer",
-    "redo": "Rehacer"
+    "redo": "Rehacer",
+    "audioUnsupported": "Grabación de audio no compatible",
+    "segments": "Segmentos"
   },
   "settings": {
     "title": "Configuración",

--- a/src/components/NoteEditor.jsx
+++ b/src/components/NoteEditor.jsx
@@ -261,7 +261,13 @@ const NoteEditor = forwardRef(function NoteEditor(
     </select>
   );
 
-  const audioControls = (
+  const recordingSupported =
+    typeof window !== 'undefined' &&
+    typeof navigator !== 'undefined' &&
+    navigator.mediaDevices &&
+    window.MediaRecorder;
+
+  const audioControls = recordingSupported ? (
     <div style={{ marginBottom: '0.5rem' }}>
       <button
         type="button"
@@ -287,6 +293,10 @@ const NoteEditor = forwardRef(function NoteEditor(
         </span>
       )}
     </div>
+  ) : (
+    <p style={{ marginBottom: '0.5rem' }}>
+      {t('noteEditor.audioUnsupported')}
+    </p>
   );
 
   const transcriptControls = (transcript.provider || transcript.patient) && (
@@ -336,6 +346,27 @@ const NoteEditor = forwardRef(function NoteEditor(
       )}
     </div>
   );
+
+  const segmentList =
+    segments.length > 0 ? (
+      <div style={{ marginTop: '0.5rem' }}>
+        <strong>{t('noteEditor.segments')}</strong>
+        <ul style={{ paddingLeft: '1.25rem' }}>
+          {segments.map((s, i) => (
+            <li
+              // eslint-disable-next-line react/no-array-index-key
+              key={i}
+              style={{
+                backgroundColor:
+                  currentSpeaker === s.speaker ? '#fff3cd' : undefined,
+              }}
+            >
+              <strong>{s.speaker}:</strong> {s.text}
+            </li>
+          ))}
+        </ul>
+      </div>
+    ) : null;
 
   const handleUndo = () => {
     setHistoryIndex((idx) => {
@@ -404,6 +435,7 @@ const NoteEditor = forwardRef(function NoteEditor(
             style={{ width: '100%', marginTop: '0.5rem' }}
           />
         )}
+        {segmentList}
         {transcriptControls}
         {(recorderError || fetchError) && (
           <p style={{ color: 'red' }}>{recorderError || fetchError}</p>
@@ -434,6 +466,7 @@ const NoteEditor = forwardRef(function NoteEditor(
           style={{ width: '100%', marginTop: '0.5rem' }}
         />
       )}
+      {segmentList}
       {transcriptControls}
       {(recorderError || fetchError) && (
         <p style={{ color: 'red' }}>{recorderError || fetchError}</p>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -126,7 +126,8 @@
     "insert": "Insert",
     "loadingTranscript": "Loading transcript...",
     "recording": "Recording...",
-    "transcribing": "Transcribing..."
+    "transcribing": "Transcribing...",
+    "segments": "Segments"
   },
   "settings": {
     "title": "Settings",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -126,7 +126,8 @@
     "insert": "Insertar",
     "loadingTranscript": "Cargando transcripción...",
     "recording": "Grabando...",
-    "transcribing": "Transcribiendo..."
+    "transcribing": "Transcribiendo...",
+    "segments": "Segmentos"
   },
   "settings": {
     "title": "Configuración",

--- a/tests/test_audio_processing.py
+++ b/tests/test_audio_processing.py
@@ -61,6 +61,53 @@ def test_diarize_and_transcribe(monkeypatch):
     ]
 
 
+def test_diarize_maps_extra_speakers(monkeypatch):
+    transcripts = ["p0 text", "p1 text", "p0 two", "p2 text"]
+
+    def fake_simple(_):
+        return transcripts.pop(0)
+
+    class DummyDiarization:
+        def itertracks(self, yield_label=True):  # noqa: ARG002
+            yield ("turn1", None, "SPEAKER_00")
+            yield ("turn2", None, "SPEAKER_01")
+            yield ("turn3", None, "SPEAKER_00")
+            yield ("turn4", None, "SPEAKER_02")
+
+    class DummyPipeline:
+        @classmethod
+        def from_pretrained(cls, name):  # noqa: ARG002
+            return cls()
+
+        def __call__(self, path):  # noqa: ARG002
+            return DummyDiarization()
+
+    class DummyAudio:
+        def crop(self, path, turn):  # noqa: ARG002
+            return b"wave", 16000
+
+    class DummyTorchaudio:
+        @staticmethod
+        def save(buf, waveform, sr, format):  # noqa: ARG002
+            buf.write(b"audio")
+
+    monkeypatch.setattr(ap, "Pipeline", DummyPipeline)
+    monkeypatch.setattr(ap, "Audio", DummyAudio)
+    monkeypatch.setattr(ap, "torchaudio", DummyTorchaudio)
+    monkeypatch.setattr(ap, "simple_transcribe", fake_simple)
+    monkeypatch.setattr(ap, "_DIARISATION_AVAILABLE", True)
+
+    result = ap.diarize_and_transcribe(b"bytes")
+    assert result["provider"] == "p0 text p0 two"
+    assert result["patient"] == "p1 text"
+    assert result["segments"] == [
+        {"speaker": "provider", "start": 0.0, "end": 0.0, "text": "p0 text"},
+        {"speaker": "patient", "start": 0.0, "end": 0.0, "text": "p1 text"},
+        {"speaker": "provider", "start": 0.0, "end": 0.0, "text": "p0 two"},
+        {"speaker": "SPEAKER_02", "start": 0.0, "end": 0.0, "text": "p2 text"},
+    ]
+
+
 def test_diarize_fallback_when_unavailable(monkeypatch):
     monkeypatch.setattr(ap, "_DIARISATION_AVAILABLE", False)
     monkeypatch.setattr(ap, "simple_transcribe", lambda b: "full text")


### PR DESCRIPTION
## Summary
- add coverage for diarized audio with additional speakers
- handle missing MediaRecorder and render diarized segment speakers in NoteEditor

## Testing
- `pytest tests/test_audio_processing.py -q`
- `npm test`
- `npm run lint` *(fails: Code style issues found in 3 files. Run Prettier with --write to fix.)*


------
https://chatgpt.com/codex/tasks/task_e_689380285e788324b11949bed95edb95