### PR TITLE
Add admin audit log view and role tests

### DIFF
--- a/src/components/AdminUsers.jsx
+++ b/src/components/AdminUsers.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import AuditLog from './AuditLog.jsx';
 
 function AdminUsers({ token }) {
   const { t } = useTranslation();
@@ -123,6 +124,7 @@ function AdminUsers({ token }) {
           ))}
         </tbody>
       </table>
+      <AuditLog token={token} />
     </div>
   );
 }

--- a/src/components/AuditLog.jsx
+++ b/src/components/AuditLog.jsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+function formatTimestamp(ts) {
+  try {
+    return new Date(ts * 1000).toLocaleString();
+  } catch {
+    return ts;
+  }
+}
+
+export default function AuditLog({ token }) {
+  const { t } = useTranslation();
+  const [entries, setEntries] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const baseUrl =
+    import.meta?.env?.VITE_API_URL ||
+    window.__BACKEND_URL__ ||
+    window.location.origin;
+
+  useEffect(() => {
+    async function load() {
+      setLoading(true);
+      try {
+        const resp = await fetch(`${baseUrl}/audit`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!resp.ok) throw new Error('Failed to fetch');
+        const data = await resp.json();
+        setEntries(data);
+        setError(null);
+      } catch (err) {
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    }
+    if (token) load();
+  }, [token]);
+
+  return (
+    <div style={{ marginTop: '2rem' }}>
+      <h3>{t('auditLog.title')}</h3>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      {loading ? (
+        <p>{t('auditLog.loading')}</p>
+      ) : entries.length === 0 ? (
+        <p>{t('auditLog.none')}</p>
+      ) : (
+        <table>
+          <thead>
+            <tr>
+              <th>{t('auditLog.timestamp')}</th>
+              <th>{t('auditLog.username')}</th>
+              <th>{t('auditLog.action')}</th>
+              <th>{t('auditLog.details')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map((e, idx) => (
+              <tr key={idx}>
+                <td>{formatTimestamp(e.timestamp)}</td>
+                <td>{e.username}</td>
+                <td>{e.action}</td>
+                <td>{e.details}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -112,6 +112,15 @@
     "loading": "Loading…",
     "none": "No events recorded yet."
   },
+  "auditLog": {
+    "title": "Audit Log",
+    "timestamp": "Timestamp",
+    "username": "Username",
+    "action": "Action",
+    "details": "Details",
+    "loading": "Loading…",
+    "none": "No audit entries"
+  },
   "noteEditor": {
     "stopRecording": "Stop Recording",
     "recordAudio": "Record Audio",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -112,6 +112,15 @@
     "loading": "Cargando…",
     "none": "No se han registrado eventos."
   },
+  "auditLog": {
+    "title": "Registro de auditoría",
+    "timestamp": "Marca de tiempo",
+    "username": "Usuario",
+    "action": "Acción",
+    "details": "Detalles",
+    "loading": "Cargando…",
+    "none": "Sin entradas de auditoría"
+  },
   "noteEditor": {
     "stopRecording": "Detener grabación",
     "recordAudio": "Grabar audio",

--- a/tests/test_auth_flow.py
+++ b/tests/test_auth_flow.py
@@ -72,3 +72,13 @@ def test_registration_login_refresh_and_roles():
     # Admin token can access admin endpoint
     resp = client.get("/metrics", headers={"Authorization": f"Bearer {admin_token}"})
     assert resp.status_code == 200
+
+    # Regular user cannot view audit log
+    resp = client.get("/audit", headers={"Authorization": f"Bearer {new_access}"})
+    assert resp.status_code == 403
+
+    # Admin can view audit log and see metrics entry
+    resp = client.get("/audit", headers={"Authorization": f"Bearer {admin_token}"})
+    assert resp.status_code == 200
+    logs = resp.json()
+    assert any(log["details"] == "/metrics" for log in logs)


### PR DESCRIPTION
## Summary
- integrate `AuditLog` component into admin user management
- add translations for audit log entries
- test audit log endpoint role restrictions

## Testing
- `npm test`
- `pytest tests/test_auth_flow.py`


------
https://chatgpt.com/codex/tasks/task_e_6893802b77b08324a9cc9c946e4dd3ef