### PR TITLE
feat: add rolling average metrics and dashboard tests

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -54,6 +54,7 @@ from .scheduling import recommend_follow_up
 import json
 import sqlite3
 import hashlib
+from collections import deque
 
 # When ``USE_OFFLINE_MODEL`` is set, endpoints will return deterministic
 # placeholder responses without calling external AI services.  This is useful
@@ -1392,6 +1393,39 @@ async def get_metrics(
         for entry in weekly_list:
             bt = beautify_weekly.get(entry["week"])
             entry["avg_beautify_time"] = bt[0] / bt[1] if bt and bt[1] else 0
+
+    def _add_rolling(records: List[Dict[str, Any]], window: int) -> None:
+        """Attach rolling averages for key metrics."""
+        fields = [
+            "notes",
+            "beautify",
+            "suggest",
+            "summary",
+            "chart_upload",
+            "audio",
+            "avg_note_length",
+            "avg_beautify_time",
+            "avg_close_time",
+            "revenue_per_visit",
+            "denials",
+            "deficiencies",
+        ]
+        sums: Dict[str, float] = {f: 0.0 for f in fields}
+        queues: Dict[str, deque] = {f: deque() for f in fields}
+        for rec in records:
+            for f in fields:
+                val = float(rec.get(f, 0) or 0)
+                q = queues[f]
+                q.append(val)
+                sums[f] += val
+                if len(q) > window:
+                    sums[f] -= q.popleft()
+                rec[f"rolling_{f}"] = sums[f] / len(q) if q else 0
+
+    if daily:
+        _add_rolling(daily_list, 7)
+    if weekly:
+        _add_rolling(weekly_list, 4)
 
     timeseries: Dict[str, List[Dict[str, Any]]] = {}
     if daily:

--- a/src/components/__tests__/Dashboard.test.jsx
+++ b/src/components/__tests__/Dashboard.test.jsx
@@ -7,9 +7,15 @@ import i18n from '../../i18n.js';
 HTMLCanvasElement.prototype.getContext = vi.fn();
 
 vi.mock('react-chartjs-2', () => ({
-  Line: (props) => <canvas {...props} />,
-  Bar: (props) => <canvas {...props} />,
-  Pie: (props) => <canvas {...props} />,
+  Line: ({ data, ...props }) => (
+    <canvas data-chart={JSON.stringify(data)} {...props} />
+  ),
+  Bar: ({ data, ...props }) => (
+    <canvas data-chart={JSON.stringify(data)} {...props} />
+  ),
+  Pie: ({ data, ...props }) => (
+    <canvas data-chart={JSON.stringify(data)} {...props} />
+  ),
 }));
 
 vi.mock('../../api.js', () => ({
@@ -162,4 +168,102 @@ test('applies quick range filter', async () => {
   await waitFor(() => expect(getMetrics).toHaveBeenCalledTimes(2));
   expect(getMetrics).toHaveBeenLastCalledWith({ start, end, clinician: '' });
 
+});
+
+test('updates chart data when metrics change', async () => {
+  const first = {
+    baseline: {
+      total_notes: 0,
+      total_beautify: 0,
+      total_suggest: 0,
+      total_summary: 0,
+      total_chart_upload: 0,
+      total_audio: 0,
+      avg_note_length: 0,
+      avg_beautify_time: 0,
+      avg_close_time: 0,
+      revenue_per_visit: 0,
+      denial_rate: 0,
+      deficiency_rate: 0,
+    },
+    current: {
+      total_notes: 1,
+      total_beautify: 1,
+      total_suggest: 1,
+      total_summary: 1,
+      total_chart_upload: 1,
+      total_audio: 1,
+      avg_note_length: 10,
+      avg_beautify_time: 5,
+      avg_close_time: 90,
+      revenue_per_visit: 100,
+      denial_rate: 0.1,
+      deficiency_rate: 0.2,
+    },
+    improvement: {},
+    coding_distribution: { '99213': 2 },
+    denial_rates: { '99213': 0.1 },
+    compliance_counts: { Missing: 1 },
+    avg_satisfaction: 0,
+    public_health_rate: 0,
+    clinicians: ['alice', 'bob'],
+    timeseries: {
+      daily: [
+        {
+          date: '2024-01-01',
+          notes: 1,
+          beautify: 1,
+          suggest: 0,
+          summary: 0,
+          chart_upload: 0,
+          audio: 0,
+        },
+      ],
+      weekly: [
+        {
+          week: '2024-01',
+          notes: 1,
+          beautify: 1,
+          suggest: 0,
+          summary: 0,
+          chart_upload: 0,
+          audio: 0,
+        },
+      ],
+    },
+  };
+  const second = {
+    ...first,
+    current: { ...first.current, total_notes: 2 },
+    timeseries: {
+      daily: [
+        { date: '2024-01-01', notes: 2, beautify: 1, suggest: 0, summary: 0, chart_upload: 0, audio: 0 },
+      ],
+      weekly: [
+        { week: '2024-01', notes: 2, beautify: 1, suggest: 0, summary: 0, chart_upload: 0, audio: 0 },
+      ],
+    },
+  };
+  getMetrics.mockResolvedValueOnce(first).mockResolvedValueOnce(second);
+  const { getByText, getByLabelText } = render(<Dashboard />);
+  await waitFor(() => document.querySelector('[data-testid="daily-line"]'));
+  let data = JSON.parse(
+    document.querySelector('[data-testid="daily-line"]').getAttribute('data-chart')
+  );
+  expect(data.datasets[0].data[0]).toBe(1);
+  fireEvent.change(getByLabelText('Clinician'), { target: { value: 'alice' } });
+  getByText('Apply').click();
+  await waitFor(() => getMetrics.mock.calls.length === 2);
+  await waitFor(() => {
+    const updated = JSON.parse(
+      document
+        .querySelector('[data-testid="daily-line"]')
+        .getAttribute('data-chart')
+    );
+    return updated.datasets[0].data[0] === 2;
+  });
+  data = JSON.parse(
+    document.querySelector('[data-testid="daily-line"]').getAttribute('data-chart')
+  );
+  expect(data.datasets[0].data[0]).toBe(2);
 });


### PR DESCRIPTION
## Summary
- extend /metrics endpoint with rolling average calculations
- add data attributes to chart mocks and tests for chart updates

## Testing
- `npm run lint` (warn: Code style issues found)
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893802c32f08324803a46fa06c51b46