### PR TITLE
Replace prints with logging in backend modules

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -128,7 +128,10 @@ _DEID_ENGINE = os.getenv("DEID_ENGINE", "regex").lower()
 # hash of the removed content instead of the raw value.
 _HASH_TOKENS = os.getenv("DEID_HASH_TOKENS", "true").lower() in {"1", "true", "yes"}
 
-logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
+logging.basicConfig(
+    level=os.getenv("LOG_LEVEL", "INFO"),
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
 
 app = FastAPI(title="RevenuePilot API")
 
@@ -844,7 +847,7 @@ async def get_events(user=Depends(require_role("admin"))) -> List[Dict[str, Any]
             })
         return result
     except Exception as exc:
-        print(f"Error fetching events: {exc}")
+        logging.error("Error fetching events: %s", exc)
         # Return empty list on error
         return []
 
@@ -901,7 +904,7 @@ async def log_event(event: EventModel, user=Depends(require_role("user"))) -> Di
         )
         db_conn.commit()
     except Exception as exc:
-        print(f"Error inserting event into database: {exc}")
+        logging.error("Error inserting event into database: %s", exc)
     return {"status": "logged"}
 
 
@@ -935,7 +938,7 @@ async def submit_survey(survey: SurveyModel, user=Depends(require_role("user")))
         )
         db_conn.commit()
     except Exception as exc:
-        print(f"Error inserting survey into database: {exc}")
+        logging.error("Error inserting survey into database: %s", exc)
     return {"status": "recorded"}
 
 
@@ -1468,7 +1471,7 @@ async def summarize(req: NoteRequest, user=Depends(require_role("user"))) -> Dic
             # cleaned text.  Take the first 200 characters and append ellipsis
             # if the text is longer.  This ensures the endpoint still returns
             # something useful without crashing.
-            print(f"Error during summary LLM call: {exc}")
+            logging.error("Error during summary LLM call: %s", exc)
             summary = cleaned[:200]
             if len(cleaned) > 200:
                 summary += "..."
@@ -1594,7 +1597,7 @@ async def beautify_note(req: NoteRequest, user=Depends(require_role("user"))) ->
         return {"beautified": beautified}
     except Exception as exc:
         # Log the exception and fall back to a basic transformation.
-        print(f"Error during beautify LLM call: {exc}")
+        logging.error("Error during beautify LLM call: %s", exc)
         sentences = re.split(r"(?<=[.!?])\s+", cleaned.strip())
         beautified = " ".join(s[:1].upper() + s[1:] for s in sentences if s)
         return {"beautified": beautified, "error": str(exc)}
@@ -1752,7 +1755,7 @@ async def suggest(req: NoteRequest, user=Depends(require_role("user"))) -> Sugge
         )
     except Exception as exc:
         # Log error and use rule-based fallback suggestions.
-        print(f"Error during suggest LLM call or parsing JSON: {exc}")
+        logging.error("Error during suggest LLM call or parsing JSON: %s", exc)
         lower = cleaned.lower()
         codes: List[CodeSuggestion] = []
         compliance: List[str] = []

--- a/backend/public_health.py
+++ b/backend/public_health.py
@@ -15,6 +15,8 @@ from functools import lru_cache
 from pathlib import Path
 from typing import List, Optional
 
+import logging
+
 from .guidelines import get_guidelines
 
 
@@ -76,7 +78,7 @@ def fetch_vaccination_recommendations(
         data = get_guidelines(age, sex, region)
         return _to_strings(data.get("vaccinations"), region)
     except Exception as exc:  # pragma: no cover - best effort logging
-        print(f"Vaccination API error: {exc}")
+        logging.warning("Vaccination API error: %s", exc)
         return []
 
 
@@ -92,7 +94,7 @@ def fetch_screening_recommendations(
         data = get_guidelines(age, sex, region)
         return _to_strings(data.get("screenings"), region)
     except Exception as exc:  # pragma: no cover - best effort logging
-        print(f"Screening API error: {exc}")
+        logging.warning("Screening API error: %s", exc)
         return []
 
 

--- a/tests/test_public_health.py
+++ b/tests/test_public_health.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 from backend import public_health
 
@@ -46,13 +47,15 @@ def test_get_public_health_suggestions_combines(monkeypatch):
     assert result == ["Flu shot", "BP check"]
 
 
-def test_fetch_vaccination_recommendations_error(monkeypatch):
+def test_fetch_vaccination_recommendations_error(monkeypatch, caplog):
     def fake_guidelines(*args, **kwargs):
         raise Exception("boom")
 
     monkeypatch.setattr(public_health, "get_guidelines", fake_guidelines)
-    result = public_health.fetch_vaccination_recommendations(40, "male", "US")
+    with caplog.at_level(logging.WARNING):
+        result = public_health.fetch_vaccination_recommendations(40, "male", "US")
     assert result == []
+    assert "Vaccination API error" in caplog.text
 
 
 def test_caching_avoids_repeated_calls(monkeypatch):


### PR DESCRIPTION
## Summary
- configure global logging format
- replace print statements with logging in backend modules
- update tests to assert logging output

## Testing
- `pytest tests/test_public_health.py tests/test_api_endpoints.py::test_summarize_and_fallback tests/test_api_endpoints.py::test_beautify_and_fallback -q`


------
https://chatgpt.com/codex/tasks/task_e_68938036d93883249bc8e4c460207a72