### PR TITLE
Enforce JWT secret configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ app into an Electron shell for desktop deployment.
 
    If you prefer not to use the UI, you can manually create the file `backend/openai_key.txt` containing your secret key and restart the server.
 
+### JWT secret
+
+Authentication tokens issued by the backend are signed with a secret. In production the `JWT_SECRET` environment variable **must** be set before starting the server. If it is missing while `ENVIRONMENT` is anything other than `development`, the application will raise an error at startup. For local development the default `dev-secret` is used so you can run the app without additional configuration.
+
 ### Offline model mode (experimental)
 
 Set the environment variable `USE_OFFLINE_MODEL=true` before starting the

--- a/backend/main.py
+++ b/backend/main.py
@@ -251,7 +251,12 @@ get_api_key()
 # ---------------------------------------------------------------------------
 # JWT authentication helpers
 # ---------------------------------------------------------------------------
-JWT_SECRET = os.getenv("JWT_SECRET", "dev-secret")
+ENVIRONMENT = os.getenv("ENVIRONMENT", "development").lower()
+JWT_SECRET = os.getenv("JWT_SECRET")
+if not JWT_SECRET:
+    if ENVIRONMENT not in {"development", "dev"}:
+        raise RuntimeError("JWT_SECRET environment variable is required")
+    JWT_SECRET = "dev-secret"
 JWT_ALGORITHM = "HS256"
 security = HTTPBearer()
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,6 +1,8 @@
 import hashlib
 import sqlite3
+import importlib
 
+import pytest
 from fastapi.testclient import TestClient
 
 import backend.main as main
@@ -116,3 +118,12 @@ def test_refresh_token_flow():
     assert client.get('/metrics', headers={'Authorization': f'Bearer {new_token}'}).status_code == 200
     bad = client.post('/refresh', json={'refresh_token': 'bad'})
     assert bad.status_code == 401
+
+
+def test_requires_jwt_secret(monkeypatch):
+    monkeypatch.delenv('JWT_SECRET', raising=False)
+    monkeypatch.setenv('ENVIRONMENT', 'production')
+    with pytest.raises(RuntimeError):
+        importlib.reload(main)
+    monkeypatch.setenv('ENVIRONMENT', 'development')
+    importlib.reload(main)


### PR DESCRIPTION
## Summary
- enforce presence of `JWT_SECRET` outside development, raising a startup error when absent
- document JWT secret requirement
- add test ensuring production mode without `JWT_SECRET` fails

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893803992188324b8d254080ff94cbd