### PR TITLE
feat: add specialty, payer, region controls

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -15,6 +15,7 @@ import shutil
 import time
 from datetime import datetime, timedelta
 from typing import List, Optional, Dict, Any
+from collections import deque
 
 from fastapi import FastAPI, Depends, HTTPException, status, UploadFile, File, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -789,7 +790,7 @@ def deidentify(text: str) -> str:
         re.IGNORECASE,
     )
     dob_pattern = re.compile(
-        r"\bDOB[:\s-]*\d{1,2}/\d{1,2}/\d{2,4}\b",
+        r"\bDOB[:\s-]*(\d{1,2}/\d{1,2}/\d{2,4})\b",
         re.IGNORECASE,
     )
     date_pattern = re.compile(
@@ -824,7 +825,7 @@ def deidentify(text: str) -> str:
 
     patterns = [
         ("PHONE", phone_pattern),
-        ("DATE", dob_pattern),
+        ("DOB", dob_pattern),
         ("DATE", date_pattern),
         ("EMAIL", email_pattern),
         ("SSN", ssn_pattern),
@@ -838,7 +839,10 @@ def deidentify(text: str) -> str:
     ]
 
     for token, pattern in patterns:
-        text = pattern.sub(lambda m: _placeholder(token, m.group(0)), text)
+        text = pattern.sub(
+            lambda m: _placeholder(token, m.group(1) if m.lastindex else m.group(0)),
+            text,
+        )
 
     return text
 

--- a/backend/migrations.py
+++ b/backend/migrations.py
@@ -24,22 +24,17 @@ def ensure_settings_table(conn: sqlite3.Connection) -> None:
     )
 
     columns = {row[1] for row in conn.execute("PRAGMA table_info(settings)")}
-    if "categories" not in columns:
-        conn.execute(
-            "ALTER TABLE settings ADD COLUMN categories TEXT NOT NULL DEFAULT '{}'"
-        )
-    if "rules" not in columns:
-        conn.execute(
-            "ALTER TABLE settings ADD COLUMN rules TEXT NOT NULL DEFAULT '[]'"
-        )
-    if "lang" not in columns:
-        conn.execute("ALTER TABLE settings ADD COLUMN lang TEXT NOT NULL DEFAULT 'en'")
-    if "specialty" not in columns:
-        conn.execute("ALTER TABLE settings ADD COLUMN specialty TEXT")
-    if "payer" not in columns:
-        conn.execute("ALTER TABLE settings ADD COLUMN payer TEXT")
-    if "region" not in columns:
-        conn.execute("ALTER TABLE settings ADD COLUMN region TEXT")
+    required = {
+        "categories": "TEXT NOT NULL DEFAULT '{}'",
+        "rules": "TEXT NOT NULL DEFAULT '[]'",
+        "lang": "TEXT NOT NULL DEFAULT 'en'",
+        "specialty": "TEXT",
+        "payer": "TEXT",
+        "region": "TEXT",
+    }
+    for col, ddl in required.items():
+        if col not in columns:
+            conn.execute(f"ALTER TABLE settings ADD COLUMN {col} {ddl}")
     conn.commit()
 
 def ensure_templates_table(conn: sqlite3.Connection) -> None:

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -145,7 +145,8 @@ function Settings({ settings, updateSettings }) {
   };
 
   const handleSpecialtyChange = async (event) => {
-    const updated = { ...settings, specialty: event.target.value };
+    const value = event.target.value || '';
+    const updated = { ...settings, specialty: value };
     try {
       const saved = await saveSettings(updated);
       updateSettings(saved);
@@ -155,7 +156,8 @@ function Settings({ settings, updateSettings }) {
   };
 
   const handlePayerChange = async (event) => {
-    const updated = { ...settings, payer: event.target.value };
+    const value = event.target.value || '';
+    const updated = { ...settings, payer: value };
     try {
       const saved = await saveSettings(updated);
       updateSettings(saved);
@@ -165,7 +167,8 @@ function Settings({ settings, updateSettings }) {
   };
 
   const handleRegionChange = async (event) => {
-    const updated = { ...settings, region: event.target.value };
+    const value = event.target.value.toUpperCase().trim();
+    const updated = { ...settings, region: value };
     try {
       const saved = await saveSettings(updated);
       updateSettings(saved);
@@ -317,6 +320,7 @@ function Settings({ settings, updateSettings }) {
       <select
         value={settings.specialty || ''}
         onChange={handleSpecialtyChange}
+        aria-label={t('settings.specialty')}
         style={{
           width: '100%',
           padding: '0.5rem',
@@ -336,6 +340,7 @@ function Settings({ settings, updateSettings }) {
       <select
         value={settings.payer || ''}
         onChange={handlePayerChange}
+        aria-label={t('settings.payer')}
         style={{
           width: '100%',
           padding: '0.5rem',
@@ -356,6 +361,7 @@ function Settings({ settings, updateSettings }) {
         value={settings.region || ''}
         onChange={handleRegionChange}
         placeholder={t('settings.regionPlaceholder')}
+        aria-label={t('settings.region')}
         style={{
           width: '100%',
           padding: '0.5rem',


### PR DESCRIPTION
## Summary
- handle specialty, payer, and region updates in Settings UI
- streamline settings migrations for new specialty, payer, and region columns
- improve deidentification regex and import deque for metrics processing

## Testing
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68938ca3e0888324ad2277c98eb977b4