### PR TITLE
feat: add login language selection and complete translations

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -13,6 +13,7 @@ import os
 import re
 import shutil
 import time
+from collections import deque
 from datetime import datetime, timedelta
 from typing import List, Optional, Dict, Any
 
@@ -360,6 +361,7 @@ class RegisterModel(BaseModel):
 class LoginModel(BaseModel):
     username: str
     password: str
+    lang: str = "en"
 
 
 class RefreshModel(BaseModel):
@@ -824,7 +826,7 @@ def deidentify(text: str) -> str:
 
     patterns = [
         ("PHONE", phone_pattern),
-        ("DATE", dob_pattern),
+        ("DOB", dob_pattern),
         ("DATE", date_pattern),
         ("EMAIL", email_pattern),
         ("SSN", ssn_pattern),

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -27,6 +27,8 @@
     "weeklyEvents": "Eventos semanales",
     "codingDistribution": "Distribución de códigos",
     "denialRates": "Tasas de denegación",
+    "documentationGaps": "Principales brechas de documentación",
+    "gapCountLabel": "Ocurrencias",
     "denialRateLabel": "Tasa de denegación (%)",
     "deficiencyRateLabel": "Tasa de deficiencia (%)",
     "allClinicians": "Todos los clínicos",

--- a/src/__tests__/locales.test.js
+++ b/src/__tests__/locales.test.js
@@ -1,6 +1,8 @@
 import { expect, test } from 'vitest';
 import en from '../locales/en.json';
 import es from '../locales/es.json';
+import enPublic from '../../public/locales/en/translation.json';
+import esPublic from '../../public/locales/es/translation.json';
 
 function flatten(obj, prefix = '') {
   return Object.keys(obj).reduce((acc, key) => {
@@ -18,5 +20,11 @@ function flatten(obj, prefix = '') {
 test('Spanish locale matches English keys', () => {
   const enKeys = Object.keys(flatten(en)).sort();
   const esKeys = Object.keys(flatten(es)).sort();
+  expect(esKeys).toEqual(enKeys);
+});
+
+test('Spanish public locale matches English keys', () => {
+  const enKeys = Object.keys(flatten(enPublic)).sort();
+  const esKeys = Object.keys(flatten(esPublic)).sort();
   expect(esKeys).toEqual(enKeys);
 });

--- a/src/api.js
+++ b/src/api.js
@@ -18,7 +18,7 @@ const rawFetch = globalThis.fetch.bind(globalThis);
  * @param {string} password
  * @returns {Promise<{token: string, settings: object|null}>}
  */
-export async function login(username, password) {
+export async function login(username, password, lang = 'en') {
   const baseUrl =
     import.meta?.env?.VITE_API_URL ||
     window.__BACKEND_URL__ ||
@@ -26,7 +26,7 @@ export async function login(username, password) {
   const resp = await rawFetch(`${baseUrl}/login`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ username, password }),
+    body: JSON.stringify({ username, password, lang }),
   });
   if (!resp.ok) {
     const err = await resp.json().catch(() => ({}));
@@ -39,7 +39,7 @@ export async function login(username, password) {
   let settings = null;
   try {
     const s = await getSettings(token);
-    settings = s;
+    settings = { ...s, lang };
   } catch (e) {
     console.error('Failed to fetch settings', e);
   }

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -8,25 +8,31 @@ import { login, resetPassword } from '../api.js';
  * so the application can render the secured views.
  */
 function Login({ onLoggedIn }) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
   const [resetMode, setResetMode] = useState(false);
+  const [lang, setLang] = useState('en');
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     setError(null);
     setLoading(true);
     try {
-      const { token, refreshToken, settings } = await login(username, password);
+      const { token, refreshToken, settings } = await login(
+        username,
+        password,
+        lang
+      );
       if (typeof window !== 'undefined') {
         localStorage.setItem('token', token);
         localStorage.setItem('refreshToken', refreshToken);
       }
-      onLoggedIn(token, settings);
+      const newSettings = settings ? { ...settings, lang } : { lang };
+      onLoggedIn(token, newSettings);
     } catch (err) {
       const msg =
         err.message === 'Login failed' ? t('login.loginFailed') : err.message;
@@ -73,6 +79,22 @@ function Login({ onLoggedIn }) {
               onChange={(e) => setUsername(e.target.value)}
               required
             />
+          </label>
+        </div>
+        <div style={{ marginBottom: '0.5rem' }}>
+          <label>
+            {t('settings.language')}
+            <select
+              value={lang}
+              onChange={(e) => {
+                const l = e.target.value;
+                setLang(l);
+                i18n.changeLanguage(l);
+              }}
+            >
+              <option value="en">{t('settings.english')}</option>
+              <option value="es">{t('settings.spanish')}</option>
+            </select>
           </label>
         </div>
         <div style={{ marginBottom: '0.5rem' }}>

--- a/src/components/__tests__/Login.test.jsx
+++ b/src/components/__tests__/Login.test.jsx
@@ -16,7 +16,7 @@ beforeEach(() => {
 afterEach(() => cleanup());
 
 test('successful login stores token and calls callback', async () => {
-  login.mockResolvedValue({ token: 'token123', settings: { theme: 'modern' } });
+  login.mockResolvedValue({ token: 'token123', refreshToken: 'r', settings: { theme: 'modern' } });
   const onLoggedIn = vi.fn();
   const { getByLabelText, getAllByRole } = render(
     <Login onLoggedIn={onLoggedIn} />
@@ -25,8 +25,9 @@ test('successful login stores token and calls callback', async () => {
   fireEvent.change(getByLabelText('Password'), { target: { value: 'p' } });
   fireEvent.click(getAllByRole('button', { name: /login/i })[0]);
   await waitFor(() =>
-    expect(onLoggedIn).toHaveBeenCalledWith('token123', { theme: 'modern' })
+    expect(onLoggedIn).toHaveBeenCalledWith('token123', { theme: 'modern', lang: 'en' })
   );
+  expect(login).toHaveBeenCalledWith('u', 'p', 'en');
   expect(localStorage.getItem('token')).toBe('token123');
 });
 
@@ -37,5 +38,6 @@ test('shows error on failed login', async () => {
   fireEvent.change(getByLabelText('Password'), { target: { value: 'p' } });
   fireEvent.click(getAllByRole('button', { name: /login/i })[0]);
   expect(await findByText('bad')).toBeTruthy();
+  expect(login).toHaveBeenCalledWith('u', 'p', 'en');
 });
 


### PR DESCRIPTION
## Summary
- translate missing dashboard gap strings for Spanish public locale and add parity test
- allow choosing language on login and pass `lang` through to backend
- extend backend login model and deidentify regex to support language and DOB tokens

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68938ca45c9c8324a07d73b7ac03c4d2