### PR TITLE
feat: support template and export prompt overrides

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -667,6 +667,7 @@ function App() {
         <TemplatesModal
           baseTemplates={baseTemplates}
           specialty={settingsState.specialty}
+          payer={settingsState.payer}
           onSelect={(content) => {
             insertTemplate(content);
             setShowTemplatesModal(false);

--- a/src/components/TemplatesModal.jsx
+++ b/src/components/TemplatesModal.jsx
@@ -1,14 +1,24 @@
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { getTemplates, createTemplate, updateTemplate, deleteTemplate } from '../api.js';
+import {
+  getTemplates,
+  createTemplate,
+  updateTemplate,
+  deleteTemplate,
+  getPromptTemplates,
+} from '../api.js';
 
-function TemplatesModal({ baseTemplates, specialty, onSelect, onClose }) {
+function TemplatesModal({ baseTemplates, specialty, payer, onSelect, onClose }) {
   const { t } = useTranslation();
   const [templates, setTemplates] = useState(baseTemplates);
   const [name, setName] = useState('');
   const [content, setContent] = useState('');
   const [editingId, setEditingId] = useState(null);
   const [error, setError] = useState(null);
+  const [selectedSpecialty, setSelectedSpecialty] = useState(specialty || '');
+  const [selectedPayer, setSelectedPayer] = useState(payer || '');
+  const [specialties, setSpecialties] = useState([specialty || '']);
+  const [payers, setPayers] = useState([payer || '']);
 
   let isAdmin = false;
   if (typeof window !== 'undefined') {
@@ -23,7 +33,7 @@ function TemplatesModal({ baseTemplates, specialty, onSelect, onClose }) {
   }
 
   useEffect(() => {
-    getTemplates(specialty)
+    getTemplates(selectedSpecialty)
       .then((data) => setTemplates([...baseTemplates, ...data]))
       .catch((e) => {
         if (e.message === 'Unauthorized' && typeof window !== 'undefined') {
@@ -34,7 +44,33 @@ function TemplatesModal({ baseTemplates, specialty, onSelect, onClose }) {
           setError(e.message);
         }
       });
-  }, [baseTemplates, specialty]);
+  }, [baseTemplates, selectedSpecialty, selectedPayer]);
+
+  useEffect(() => {
+    if (!isAdmin) return;
+    getPromptTemplates()
+      .then((data) => {
+        const specSet = new Set([
+          '',
+          ...Object.keys(data.specialty || {}),
+          ...Object.keys(data.specialty_modifiers || {}),
+        ]);
+        setSpecialties(Array.from(specSet));
+        const payerSet = new Set([
+          '',
+          ...Object.keys(data.payer || {}),
+          ...Object.keys(data.payer_modifiers || {}),
+        ]);
+        setPayers(Array.from(payerSet));
+      })
+      .catch((e) => {
+        if (e.message === 'Unauthorized' && typeof window !== 'undefined') {
+          alert(t('dashboard.accessDenied'));
+          localStorage.removeItem('token');
+          window.location.href = '/';
+        }
+      });
+  }, [isAdmin, t]);
 
   const handleSave = async () => {
     if (!name.trim() || !content.trim()) return;
@@ -43,14 +79,16 @@ function TemplatesModal({ baseTemplates, specialty, onSelect, onClose }) {
         const tpl = await updateTemplate(editingId, {
           name: name.trim(),
           content: content.trim(),
-          specialty,
+          specialty: selectedSpecialty,
+          payer: selectedPayer,
         });
         setTemplates((prev) => prev.map((t) => (t.id === editingId ? tpl : t)));
       } else {
         const tpl = await createTemplate({
           name: name.trim(),
           content: content.trim(),
-          specialty,
+          specialty: selectedSpecialty,
+          payer: selectedPayer,
         });
         setTemplates((prev) => [...prev, tpl]);
       }
@@ -94,6 +132,38 @@ function TemplatesModal({ baseTemplates, specialty, onSelect, onClose }) {
       <div className="modal card">
         <h3>{t('templatesModal.title')}</h3>
         {error && <p style={{ color: 'red' }}>{error}</p>}
+        {isAdmin && (
+          <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.5rem' }}>
+            <div style={{ flex: 1 }}>
+              <label style={{ display: 'block' }}>{t('settings.specialty')}</label>
+              <select
+                value={selectedSpecialty}
+                onChange={(e) => setSelectedSpecialty(e.target.value)}
+                style={{ width: '100%' }}
+              >
+                {specialties.map((s) => (
+                  <option key={s} value={s}>
+                    {s || '--'}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div style={{ flex: 1 }}>
+              <label style={{ display: 'block' }}>{t('settings.payer')}</label>
+              <select
+                value={selectedPayer}
+                onChange={(e) => setSelectedPayer(e.target.value)}
+                style={{ width: '100%' }}
+              >
+                {payers.map((p) => (
+                  <option key={p} value={p}>
+                    {p || '--'}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+        )}
         <ul>
           {templates.map((tpl) => (
             <li key={tpl.id || tpl.name}>

--- a/src/components/__tests__/TemplatesModal.test.jsx
+++ b/src/components/__tests__/TemplatesModal.test.jsx
@@ -9,6 +9,7 @@ vi.mock('../../api.js', () => ({
   createTemplate: vi.fn(async (tpl) => ({ id: 2, ...tpl })),
   updateTemplate: vi.fn(async (id, tpl) => ({ id, ...tpl })),
   deleteTemplate: vi.fn(async () => {}),
+  getPromptTemplates: vi.fn().mockResolvedValue({}),
 }));
 import * as api from '../../api.js';
 
@@ -22,6 +23,7 @@ test('lists and selects templates', async () => {
     <TemplatesModal
       baseTemplates={[{ name: 'Base', content: 'B' }]}
       specialty="cardiology"
+      payer="medicare"
       onSelect={onSelect}
       onClose={() => {}}
     />,
@@ -34,7 +36,7 @@ test('lists and selects templates', async () => {
 
 test('creates template', async () => {
   const { getByPlaceholderText, getByText, findByText } = render(
-    <TemplatesModal baseTemplates={[]} specialty="cardiology" onSelect={() => {}} onClose={() => {}} />,
+    <TemplatesModal baseTemplates={[]} specialty="cardiology" payer="" onSelect={() => {}} onClose={() => {}} />,
   );
   fireEvent.change(getByPlaceholderText('Name'), { target: { value: 'Extra' } });
   fireEvent.change(getByPlaceholderText('Content'), { target: { value: 'X' } });
@@ -44,7 +46,7 @@ test('creates template', async () => {
 
 test('edits and deletes template', async () => {
   const { getByText, getByPlaceholderText, findByText, queryByText } = render(
-    <TemplatesModal baseTemplates={[]} specialty="cardiology" onSelect={() => {}} onClose={() => {}} />,
+    <TemplatesModal baseTemplates={[]} specialty="cardiology" payer="" onSelect={() => {}} onClose={() => {}} />,
   );
   await findByText('Custom');
   fireEvent.click(getByText('Edit'));


### PR DESCRIPTION
## Summary
- expand prompt utilities with specialty/payer support for template and export categories
- allow admins to choose specialty and payer when managing note templates

## Testing
- `pytest` *(fails: NameError: name 'deque' is not defined)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68938ca5511483249c4d7db7db2b4944