### PR TITLE
Add follow-up scheduling endpoint and UI

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -47,13 +47,14 @@ from .audio_processing import simple_transcribe, diarize_and_transcribe
 from . import public_health as public_health_api
 from .migrations import ensure_settings_table, ensure_templates_table
 from .templates import TemplateModel
-from .scheduling import recommend_follow_up
+from .scheduling import recommend_follow_up, export_ics
 
 
 
 import json
 import sqlite3
 import hashlib
+from collections import deque
 
 from passlib.context import CryptContext
 
@@ -664,6 +665,18 @@ class SuggestionsResponse(BaseModel):
     followUp: Optional[str] = None
 
 
+class ScheduleRequest(BaseModel):
+    """Request payload for the /schedule endpoint."""
+    text: str
+    codes: Optional[List[str]] = None
+
+
+class ScheduleResponse(BaseModel):
+    """Response model containing recommended interval and optional ICS."""
+    interval: Optional[str]
+    ics: Optional[str] = None
+
+
 # Schema for logging events from the frontend.  Each event should include
 # an eventType (e.g., "note_started", "beautify", "suggest") and
 # optional details (such as patient ID or note length).  The timestamp
@@ -824,7 +837,7 @@ def deidentify(text: str) -> str:
 
     patterns = [
         ("PHONE", phone_pattern),
-        ("DATE", dob_pattern),
+        ("DOB", dob_pattern),
         ("DATE", date_pattern),
         ("EMAIL", email_pattern),
         ("SSN", ssn_pattern),
@@ -1953,3 +1966,19 @@ async def suggest(req: NoteRequest, user=Depends(require_role("user"))) -> Sugge
             differentials=diffs,
             followUp=follow_up,
         )
+
+
+@app.post("/schedule", response_model=ScheduleResponse)
+async def schedule(req: ScheduleRequest, user=Depends(require_role("user"))) -> ScheduleResponse:
+    """
+    Recommend a follow-up interval for a clinical note and provide an ICS export.
+
+    Args:
+        req: ScheduleRequest containing note text and optional codes.
+    Returns:
+        ScheduleResponse with the recommended interval and ICS string.
+    """
+    cleaned = deidentify(req.text or "")
+    interval = recommend_follow_up(cleaned, req.codes or [])
+    ics = export_ics(interval) if interval else None
+    return ScheduleResponse(interval=interval, ics=ics)

--- a/src/api.js
+++ b/src/api.js
@@ -339,6 +339,32 @@ export async function getSuggestions(text, context = {}) {
 }
 
 /**
+ * Request a follow-up schedule recommendation from the backend.
+ * @param {string} text Note text
+ * @param {string[]} codes Optional billing codes
+ * @returns {Promise<{interval:string|null, ics:string|null}>}
+ */
+export async function scheduleFollowUp(text, codes = []) {
+  const baseUrl =
+    import.meta?.env?.VITE_API_URL ||
+    window.__BACKEND_URL__ ||
+    window.location.origin;
+  const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+  const headers = token
+    ? { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` }
+    : { 'Content-Type': 'application/json' };
+  const resp = await fetch(`${baseUrl}/schedule`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ text, codes }),
+  });
+  if (resp.status === 401 || resp.status === 403) {
+    throw new Error('Unauthorized');
+  }
+  return await resp.json();
+}
+
+/**
  * Upload an audio ``Blob`` to the backend for transcription.
  * Returns the text transcript or a placeholder if the backend is not
  * configured or the request fails.

--- a/src/components/FollowUpScheduler.jsx
+++ b/src/components/FollowUpScheduler.jsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import { scheduleFollowUp } from '../api.js';
+
+function FollowUpScheduler({ note, codes = [] }) {
+  const [interval, setInterval] = useState('');
+  const [ics, setIcs] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const recommend = async () => {
+    setLoading(true);
+    try {
+      const data = await scheduleFollowUp(note, codes);
+      setInterval(data.interval || '');
+      setIcs(data.ics || null);
+    } catch (err) {
+      console.error('schedule error', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const generateIcs = (ivl) => {
+    const m = ivl?.match(/(\d+)\s*(day|week|month|year)/i);
+    if (!m) return null;
+    const value = parseInt(m[1], 10);
+    const unit = m[2].toLowerCase();
+    const start = new Date();
+    const date = new Date(start);
+    if (unit.startsWith('day')) date.setDate(start.getDate() + value);
+    else if (unit.startsWith('week')) date.setDate(start.getDate() + 7 * value);
+    else if (unit.startsWith('month')) date.setMonth(start.getMonth() + value);
+    else if (unit.startsWith('year')) date.setFullYear(start.getFullYear() + value);
+    const dt = date.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
+    const icsText = `BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nSUMMARY:Follow-up appointment\nDTSTART:${dt}\nDTEND:${dt}\nEND:VEVENT\nEND:VCALENDAR`;
+    return `data:text/calendar;charset=utf8,${encodeURIComponent(icsText)}`;
+  };
+
+  const href = ics
+    ? `data:text/calendar;charset=utf8,${encodeURIComponent(ics)}`
+    : generateIcs(interval);
+
+  return (
+    <div className="follow-up-scheduler">
+      <button onClick={recommend} disabled={loading}>
+        Recommend
+      </button>
+      <input
+        value={interval}
+        onChange={(e) => setInterval(e.target.value)}
+        placeholder="e.g., 2 weeks"
+        style={{ marginLeft: '0.5em' }}
+      />
+      {href && (
+        <a href={href} download="follow-up.ics" style={{ marginLeft: '0.5em' }}>
+          Add to calendar
+        </a>
+      )}
+    </div>
+  );
+}
+
+export default FollowUpScheduler;

--- a/src/components/__tests__/FollowUpScheduler.test.jsx
+++ b/src/components/__tests__/FollowUpScheduler.test.jsx
@@ -1,0 +1,26 @@
+/* @vitest-environment jsdom */
+import { render, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { vi, expect, test, afterEach } from 'vitest';
+import FollowUpScheduler from '../FollowUpScheduler.jsx';
+import * as api from '../../api.js';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+test('fetches recommendation and provides calendar link', async () => {
+  vi.spyOn(api, 'scheduleFollowUp').mockResolvedValue({
+    interval: '2 weeks',
+    ics: 'BEGIN:VCALENDAR\nEND:VCALENDAR',
+  });
+  const { getByText, getByPlaceholderText } = render(
+    <FollowUpScheduler note="note" codes={["E11"]} />
+  );
+  fireEvent.click(getByText('Recommend'));
+  await waitFor(() =>
+    expect(getByPlaceholderText('e.g., 2 weeks').value).toBe('2 weeks')
+  );
+  const href = getByText('Add to calendar').getAttribute('href');
+  expect(href).toContain('text/calendar');
+});

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -1,4 +1,8 @@
 import backend.scheduling as scheduling
+import sqlite3
+import pytest
+from fastapi.testclient import TestClient
+from backend import main
 
 def test_recommend_follow_up_llm(monkeypatch):
     def fake_call_openai(messages):
@@ -20,3 +24,45 @@ def test_export_ics():
     ics = scheduling.export_ics("2 weeks")
     assert "BEGIN:VCALENDAR" in ics
     assert "DTSTART" in ics
+
+
+@pytest.fixture
+def client(monkeypatch):
+    db = sqlite3.connect(":memory:", check_same_thread=False)
+    db.row_factory = sqlite3.Row
+    db.execute(
+        "CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT, eventType TEXT NOT NULL, timestamp REAL NOT NULL, details TEXT)"
+    )
+    db.execute(
+        "CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE NOT NULL, password_hash TEXT NOT NULL, role TEXT NOT NULL)"
+    )
+    pwd = main.hash_password("pw")
+    db.execute(
+        "INSERT INTO users (username, password_hash, role) VALUES (?, ?, ?)",
+        ("u", pwd, "user"),
+    )
+    db.commit()
+    monkeypatch.setattr(main, "db_conn", db)
+    monkeypatch.setattr(main, "events", [])
+    return TestClient(main.app)
+
+
+def auth_header(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_schedule_endpoint(client, monkeypatch):
+    def fake_call_openai(messages):
+        return "Return in 2 weeks"
+
+    monkeypatch.setattr(scheduling, "call_openai", fake_call_openai)
+    token = main.create_token("u", "user")
+    resp = client.post(
+        "/schedule",
+        json={"text": "note", "codes": ["E11.9"]},
+        headers=auth_header(token),
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["interval"] == "2 weeks"
+    assert "BEGIN:VCALENDAR" in data["ics"]


### PR DESCRIPTION
## Summary
- expose `/schedule` API that recommends follow-up interval and returns ICS export
- add front-end helper `scheduleFollowUp` and `FollowUpScheduler` component with calendar link
- cover new scheduling workflow with API and component tests

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68938ca963248324bbbafdbc7631a7fc