### PR TITLE
Extend undo history and add NoteEditor integration test

### DIFF
--- a/src/components/NoteEditor.jsx
+++ b/src/components/NoteEditor.jsx
@@ -25,6 +25,9 @@ const quillFormats = [
   'bullet',
 ];
 
+// Maximum number of history entries to retain for undo/redo in beautified mode
+const HISTORY_LIMIT = 20;
+
 function useAudioRecorder(onTranscribed) {
   const { t } = useTranslation();
   const [recording, setRecording] = useState(false);
@@ -118,7 +121,7 @@ const NoteEditor = forwardRef(function NoteEditor(
       if (current === value) return prev;
       const base = prev.slice(0, historyIndex + 1);
       const appended = [...base, value];
-      const newHist = appended.slice(-5);
+      const newHist = appended.slice(-HISTORY_LIMIT);
       setHistoryIndex(newHist.length - 1);
       return newHist;
     });
@@ -294,9 +297,7 @@ const NoteEditor = forwardRef(function NoteEditor(
       )}
     </div>
   ) : (
-    <p style={{ marginBottom: '0.5rem' }}>
-      {t('noteEditor.audioUnsupported')}
-    </p>
+    <p style={{ marginBottom: '0.5rem' }}>{t('noteEditor.audioUnsupported')}</p>
   );
 
   const transcriptControls = (transcript.provider || transcript.patient) && (

--- a/src/components/__tests__/NoteEditor.test.jsx
+++ b/src/components/__tests__/NoteEditor.test.jsx
@@ -16,6 +16,7 @@ vi.mock('../../api.js', () => ({
 
 }));
 
+import { fetchLastTranscript } from '../../api.js';
 import '../../i18n.js';
 import NoteEditor from '../NoteEditor.jsx';
 
@@ -66,6 +67,28 @@ test('selecting template inserts content', async () => {
   await waitFor(() => expect(editor.innerHTML).toContain('Hello'));
 });
 
+test('inserts template and merges audio transcript', async () => {
+  fetchLastTranscript.mockResolvedValue({ provider: 'Hi there', patient: '' });
+
+  function Wrapper() {
+    const [val, setVal] = useState('');
+    return <NoteEditor id="m" value={val} onChange={setVal} />;
+  }
+
+  const { findByLabelText, container, findAllByText } = render(<Wrapper />);
+  const select = await findByLabelText('Templates');
+  fireEvent.change(select, { target: { value: '1' } });
+  const [insertProvider] = await findAllByText('Insert');
+  fireEvent.click(insertProvider);
+
+  const editor = container.querySelector('.ql-editor');
+  await waitFor(() => {
+    expect(editor.innerHTML).toContain('Hello');
+    expect(editor.innerHTML).toContain('Hi there');
+  });
+  fetchLastTranscript.mockResolvedValue({ provider: '', patient: '' });
+});
+
 test('maintains beautified history with undo/redo', () => {
   const onChange = vi.fn();
   const { rerender, getByText } = render(
@@ -81,16 +104,15 @@ test('maintains beautified history with undo/redo', () => {
   expect(onChange).toHaveBeenLastCalledWith('Second');
 });
 
-test('limits beautified history to five entries', () => {
-  const { rerender, getByText, queryByText } = render(
+test('supports undo beyond five beautified entries', () => {
+  const { rerender, getByText } = render(
     <NoteEditor id="c" value="1" onChange={() => {}} mode="beautified" />
   );
-  ['2', '3', '4', '5', '6'].forEach((v) =>
+  ['2', '3', '4', '5', '6', '7'].forEach((v) =>
     rerender(<NoteEditor id="c" value={v} onChange={() => {}} mode="beautified" />)
   );
-  for (let i = 0; i < 5; i += 1) {
+  for (let i = 0; i < 6; i += 1) {
     fireEvent.click(getByText('Undo'));
   }
-  expect(queryByText('1')).toBeNull();
-  expect(getByText('2')).toBeTruthy();
+  expect(getByText('1')).toBeTruthy();
 });


### PR DESCRIPTION
## Summary
- allow more than five undo/redo steps in NoteEditor by expanding history limit
- add integration test covering template insertion and transcript merging
- test undo navigation across histories beyond five entries

## Testing
- `npm test`
- `npm run lint` *(fails: code style issues in src/components/SuggestionPanel.jsx, src/components/TemplatesModal.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68938caa66f48324af0b6de742c376aa