### PR TITLE
Handle keyring errors and validate API key

### DIFF
--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -15,6 +15,7 @@ import {
 
 const SPECIALTIES = ['', 'cardiology', 'dermatology'];
 const PAYERS = ['', 'medicare', 'aetna'];
+const API_KEY_REGEX = /^sk-(?:proj-)?[A-Za-z0-9]{16,}$/;
 // Region/country codes are user-entered to keep the list flexible
 
 function Settings({ settings, updateSettings }) {
@@ -113,9 +114,16 @@ function Settings({ settings, updateSettings }) {
     }
   };
   const handleSaveKey = async () => {
-    if (!apiKeyInput.trim()) return;
+    const trimmed = apiKeyInput.trim();
+    if (!trimmed) return;
+    if (!API_KEY_REGEX.test(trimmed)) {
+      setApiKeyStatus(t('settings.invalidApiKey'));
+      setApiKeyInput('');
+      setTimeout(() => setApiKeyStatus(''), 4000);
+      return;
+    }
     try {
-      const res = await setApiKey(apiKeyInput.trim());
+      const res = await setApiKey(trimmed);
       // The backend returns {status: 'saved'} on success or an
       // object with a message on failure.  Display the appropriate
       // status message.

--- a/src/components/__tests__/Settings.test.jsx
+++ b/src/components/__tests__/Settings.test.jsx
@@ -165,6 +165,31 @@ test('setApiKey called when saving API key', async () => {
   await waitFor(() => expect(setApiKey).toHaveBeenCalled());
 });
 
+test('invalid API key shows error and does not call setApiKey', async () => {
+  const settings = {
+    theme: 'modern',
+    enableCodes: true,
+    enableCompliance: true,
+    enablePublicHealth: true,
+    enableDifferentials: true,
+    rules: [],
+    lang: 'en',
+    region: '',
+  };
+  const { getAllByPlaceholderText, getByText, getAllByText } = render(
+    <Settings settings={settings} updateSettings={() => {}} />,
+  );
+  const input = getAllByPlaceholderText('sk-... (e.g., sk-proj-...)')[0];
+  fireEvent.change(input, {
+    target: { value: 'invalid-key' },
+  });
+  fireEvent.click(getAllByText('Save Key')[0]);
+  await waitFor(() => expect(setApiKey).not.toHaveBeenCalled());
+  await waitFor(() => {
+    expect(getByText('Invalid API key format')).toBeTruthy();
+  });
+});
+
 test('changing theme triggers saveSettings', async () => {
   const settings = {
     theme: 'modern',

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -144,6 +144,7 @@
     "apiKey": "OpenAI API Key",
     "apiKeyHelp": "Enter your OpenAI API key here. The key will be stored securely on your machine and used by the backend to call the language model. You can update it at any time.",
     "saveKey": "Save Key",
+    "invalidApiKey": "Invalid API key format",
     "theme": "Theme",
     "modern": "Modern Minimal",
     "dark": "Dark Elegance",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -144,6 +144,7 @@
     "apiKey": "Clave de API de OpenAI",
     "apiKeyHelp": "Introduzca aquí su clave de API de OpenAI. La clave se almacenará de forma segura en su máquina y será utilizada por el backend para llamar al modelo de lenguaje. Puede actualizarla en cualquier momento.",
     "saveKey": "Guardar clave",
+    "invalidApiKey": "Formato de clave de API inválido",
     "theme": "Tema",
     "modern": "Minimal moderno",
     "dark": "Elegancia oscura",


### PR DESCRIPTION
## Summary
- handle keyring errors explicitly and support Windows file permissions
- add API key format validation and translations in settings UI
- cover invalid API key scenario with unit test

## Testing
- `pytest` *(fails: NameError: name 'DEFAULT_TEMPLATES' is not defined)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68939b44eb788324af632d9dbf8c6122