### PR TITLE
feat: add summary language option

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -120,6 +120,7 @@
     "customRulesHelp": "Enter one rule per line. These rules will be passed to the AI model to customise suggestions based on payer or clinic‑specific requirements.",
     "customRulesPlaceholder": "e.g. Commercial payer X requires three ROS for 99214; Include time spent on counselling for CPT 99406",
     "language": "Language",
+    "summaryLanguage": "Summary language",
     "specialty": "Specialty",
     "payer": "Payer",
     "templates": "Templates",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -120,6 +120,7 @@
     "customRulesHelp": "Introduzca una regla por línea. Estas reglas se pasarán al modelo de IA para personalizar las sugerencias según requisitos del pagador o de la clínica.",
     "customRulesPlaceholder": "p. ej., El pagador comercial X requiere tres ROS para 99214; Incluir tiempo dedicado a asesoría para CPT 99406",
     "language": "Idioma",
+    "summaryLanguage": "Idioma del resumen",
     "specialty": "Especialidad",
     "payer": "Pagador",
     "templates": "Plantillas",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -129,6 +129,7 @@ function App() {
     enablePublicHealth: true,
     enableDifferentials: true,
     lang: 'en',
+    summaryLang: 'en',
     specialty: '',
     payer: '',
     // Array of custom clinical rules supplied by the user.  When non‑empty,
@@ -318,7 +319,7 @@ function App() {
     summarizeNote(plain, {
       chart: chartText,
       audio: `${audioTranscript.provider} ${audioTranscript.patient}`.trim(),
-      lang: settingsState.lang,
+      lang: settingsState.summaryLang,
       specialty: settingsState.specialty,
       payer: settingsState.payer,
       useLocalModels: settingsState.useLocalModels,

--- a/src/api.js
+++ b/src/api.js
@@ -39,7 +39,7 @@ export async function login(username, password, lang = 'en') {
   let settings = null;
   try {
     const s = await getSettings(token);
-    settings = { ...s, lang };
+    settings = { ...s, lang, summaryLang: s.summaryLang || lang };
   } catch (e) {
     console.error('Failed to fetch settings', e);
   }
@@ -169,6 +169,7 @@ export async function getSettings(token) {
     enableDifferentials: categories.differentials !== false,
     rules: data.rules || [],
     lang: data.lang || 'en',
+    summaryLang: data.summaryLang || data.lang || 'en',
     specialty: data.specialty || '',
     payer: data.payer || '',
     region: data.region || '',
@@ -202,6 +203,7 @@ export async function saveSettings(settings, token) {
     },
     rules: settings.rules || [],
     lang: settings.lang || 'en',
+    summaryLang: settings.summaryLang || settings.lang || 'en',
     specialty: settings.specialty || null,
     payer: settings.payer || null,
     region: settings.region || '',
@@ -226,6 +228,7 @@ export async function saveSettings(settings, token) {
     enableDifferentials: categories.differentials !== false,
     rules: data.rules || [],
     lang: data.lang || 'en',
+    summaryLang: data.summaryLang || data.lang || 'en',
     specialty: data.specialty || '',
     payer: data.payer || '',
     region: data.region || '',
@@ -873,7 +876,8 @@ export async function summarizeNote(text, context = {}) {
     window.__BACKEND_URL__ ||
     window.location.origin;
   if (baseUrl) {
-    const payload = { text, lang: context.lang };
+    const payload = { text };
+    if (context.lang) payload.lang = context.lang;
     if (context.chart) payload.chart = context.chart;
     if (context.audio) payload.audio = context.audio;
     if (context.specialty) payload.specialty = context.specialty;

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -25,13 +25,15 @@ function Login({ onLoggedIn }) {
       const { token, refreshToken, settings } = await login(
         username,
         password,
-        lang
+        lang,
       );
       if (typeof window !== 'undefined') {
         localStorage.setItem('token', token);
         localStorage.setItem('refreshToken', refreshToken);
       }
-      const newSettings = settings ? { ...settings, lang } : { lang };
+      const newSettings = settings
+        ? { ...settings, lang, summaryLang: settings.summaryLang || lang }
+        : { lang, summaryLang: lang };
       onLoggedIn(token, newSettings);
     } catch (err) {
       const msg =

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -144,6 +144,18 @@ function Settings({ settings, updateSettings }) {
     }
   };
 
+  const handleSummaryLangChange = async (event) => {
+    const newLang = event.target.value;
+    if (newLang === settings.summaryLang) return;
+    const updated = { ...settings, summaryLang: newLang };
+    try {
+      const saved = await saveSettings(updated);
+      updateSettings(saved);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
   const handleSpecialtyChange = async (event) => {
     const value = event.target.value || '';
     const updated = { ...settings, specialty: value };
@@ -323,6 +335,16 @@ function Settings({ settings, updateSettings }) {
         value={settings.lang}
         onChange={handleLangChange}
         aria-label={t('settings.language')}
+      >
+        <option value="en">{t('settings.english')}</option>
+        <option value="es">{t('settings.spanish')}</option>
+      </select>
+
+      <h3>{t('settings.summaryLanguage')}</h3>
+      <select
+        value={settings.summaryLang}
+        onChange={handleSummaryLangChange}
+        aria-label={t('settings.summaryLanguage')}
       >
         <option value="en">{t('settings.english')}</option>
         <option value="es">{t('settings.spanish')}</option>

--- a/src/components/__tests__/Login.test.jsx
+++ b/src/components/__tests__/Login.test.jsx
@@ -25,7 +25,7 @@ test('successful login stores token and calls callback', async () => {
   fireEvent.change(getByLabelText('Password'), { target: { value: 'p' } });
   fireEvent.click(getAllByRole('button', { name: /login/i })[0]);
   await waitFor(() =>
-    expect(onLoggedIn).toHaveBeenCalledWith('token123', { theme: 'modern', lang: 'en' })
+    expect(onLoggedIn).toHaveBeenCalledWith('token123', { theme: 'modern', lang: 'en', summaryLang: 'en' })
   );
   expect(login).toHaveBeenCalledWith('u', 'p', 'en');
   expect(localStorage.getItem('token')).toBe('token123');

--- a/src/components/__tests__/Settings.test.jsx
+++ b/src/components/__tests__/Settings.test.jsx
@@ -34,6 +34,7 @@ test('saveSettings called when preferences change', async () => {
       enableDifferentials: true,
       rules: [],
       lang: 'en',
+      summaryLang: 'en',
       specialty: '',
       payer: '',
       region: '',
@@ -56,6 +57,7 @@ test('saveSettings called when specialty and payer change', async () => {
     enableDifferentials: true,
     rules: [],
     lang: 'en',
+    summaryLang: 'en',
     specialty: '',
     payer: '',
     region: '',
@@ -65,9 +67,9 @@ test('saveSettings called when specialty and payer change', async () => {
     <Settings settings={settings} updateSettings={updateSettings} />
   );
   const selects = getAllByRole('combobox');
-  // selects[0] is language, [1] specialty, [2] payer
-  fireEvent.change(selects[1], { target: { value: 'cardiology' } });
-  fireEvent.change(selects[2], { target: { value: 'medicare' } });
+  // selects[0] is language, [1] summary language, [2] specialty, [3] payer
+  fireEvent.change(selects[2], { target: { value: 'cardiology' } });
+  fireEvent.change(selects[3], { target: { value: 'medicare' } });
   await waitFor(() => expect(saveSettings).toHaveBeenCalledTimes(2));
 });
 
@@ -80,6 +82,7 @@ test('changing region triggers saveSettings', async () => {
     enableDifferentials: true,
     rules: [],
     lang: 'en',
+    summaryLang: 'en',
     specialty: '',
     payer: '',
     region: '',
@@ -104,6 +107,7 @@ test('renders Spanish translations when lang is es', () => {
     enableDifferentials: true,
     rules: [],
     lang: 'es',
+    summaryLang: 'es',
     region: '',
   };
   i18n.changeLanguage('es');
@@ -123,6 +127,7 @@ test('changing language calls saveSettings with new lang', async () => {
     enableDifferentials: true,
     rules: [],
     lang: 'en',
+    summaryLang: 'en',
     region: '',
   };
   const updateSettings = vi.fn();
@@ -143,6 +148,35 @@ test('changing language calls saveSettings with new lang', async () => {
   expect(i18n.language).toBe('es');
 });
 
+test('changing summary language calls saveSettings with new summaryLang', async () => {
+  const settings = {
+    theme: 'modern',
+    enableCodes: true,
+    enableCompliance: true,
+    enablePublicHealth: true,
+    enableDifferentials: true,
+    rules: [],
+    lang: 'en',
+    summaryLang: 'en',
+    region: '',
+  };
+  const updateSettings = vi.fn();
+  const { getByLabelText } = render(
+    <Settings settings={settings} updateSettings={updateSettings} />
+  );
+  await fireEvent.change(getByLabelText('Summary language'), {
+    target: { value: 'es' },
+  });
+  await waitFor(() =>
+    expect(saveSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ summaryLang: 'es' })
+    )
+  );
+  expect(updateSettings).toHaveBeenCalledWith(
+    expect.objectContaining({ summaryLang: 'es' })
+  );
+});
+
 test('setApiKey called when saving API key', async () => {
   const settings = {
     theme: 'modern',
@@ -152,6 +186,7 @@ test('setApiKey called when saving API key', async () => {
     enableDifferentials: true,
     rules: [],
     lang: 'en',
+    summaryLang: 'en',
     region: '',
   };
   const { getAllByPlaceholderText, getAllByText } = render(
@@ -174,6 +209,7 @@ test('changing theme triggers saveSettings', async () => {
     enableDifferentials: true,
     rules: [],
     lang: 'en',
+    summaryLang: 'en',
     region: '',
   };
   const updateSettings = vi.fn();

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -157,6 +157,7 @@
     "customRulesHelp": "Enter one rule per line. These rules will be passed to the AI model to customise suggestions based on payer or clinic‑specific requirements.",
     "customRulesPlaceholder": "e.g. Commercial payer X requires three ROS for 99214; Include time spent on counselling for CPT 99406",
     "language": "Language",
+    "summaryLanguage": "Summary language",
     "specialty": "Specialty",
     "payer": "Payer",
     "templates": "Templates",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -157,6 +157,7 @@
     "customRulesHelp": "Introduzca una regla por línea. Estas reglas se pasarán al modelo de IA para personalizar las sugerencias según requisitos del pagador o de la clínica.",
     "customRulesPlaceholder": "p. ej., El pagador comercial X requiere tres ROS para 99214; Incluir tiempo dedicado a asesoría para CPT 99406",
     "language": "Idioma",
+    "summaryLanguage": "Idioma del resumen",
     "specialty": "Especialidad",
     "payer": "Pagador",
     "templates": "Plantillas",


### PR DESCRIPTION
## Summary
- pass selected language through `/summarize` API and persist `summaryLang` setting
- add summary language selector in settings UI with translations

## Testing
- `npm run lint` *(fails: Code style issues found in 4 files)*
- `npm test`
- `pytest` *(fails: DEFAULT_TEMPLATES not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68939b479db88324bb6f0b87bfcbdfdc