### PR TITLE
feat: enhance EHR integration and auth

### DIFF
--- a/backend/ehr_integration.py
+++ b/backend/ehr_integration.py
@@ -9,21 +9,65 @@ additional resource types or authentication mechanisms.
 
 from __future__ import annotations
 
+import base64
 import os
-from typing import List, Dict, Any
+import time
+from typing import Any, Dict, List, Optional
 
 import requests
 
 FHIR_SERVER_URL = os.getenv("FHIR_SERVER_URL", "https://fhir.example.com")
+TOKEN_URL = os.getenv("EHR_TOKEN_URL")
+CLIENT_ID = os.getenv("EHR_CLIENT_ID")
+CLIENT_SECRET = os.getenv("EHR_CLIENT_SECRET")
+
+_token_cache: Dict[str, Any] = {"token": None, "expires_at": 0}
 
 
-def _build_bundle(note: str, codes: List[str]) -> Dict[str, Any]:
+def get_ehr_token() -> Optional[str]:
+    """Return an OAuth2 bearer token for the configured EHR server.
+
+    The token is cached in-memory until shortly before expiry to avoid
+    unnecessary requests.  If the required environment variables are not set,
+    ``None`` is returned and no authentication header will be added.
+    """
+
+    if not (TOKEN_URL and CLIENT_ID and CLIENT_SECRET):
+        return None
+
+    now = time.time()
+    if (
+        _token_cache.get("token")
+        and _token_cache.get("expires_at", 0) - 60 > now
+    ):
+        return _token_cache["token"]
+
+    resp = requests.post(
+        TOKEN_URL,
+        data={"grant_type": "client_credentials"},
+        auth=(CLIENT_ID, CLIENT_SECRET),
+        timeout=10,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    token = data.get("access_token")
+    expires = data.get("expires_in", 3600)
+    _token_cache["token"] = token
+    _token_cache["expires_at"] = now + int(expires)
+    return token
+
+
+def _build_bundle(
+    note: str,
+    codes: List[str],
+    patient_id: Optional[str] = None,
+    encounter_id: Optional[str] = None,
+) -> Dict[str, Any]:
     """Return a FHIR transaction bundle for ``note`` and ``codes``.
 
-    ``note`` is wrapped in an ``Observation`` resource while each code is
-    represented as a ``Condition`` with a single coding entry.  The bundle is
-    intentionally simple and omits many optional fields so the tests can focus
-    on verifying the HTTP interaction rather than full FHIR compliance.
+    The bundle includes the note as both an ``Observation`` and a
+    ``DocumentReference``.  Billing codes are represented in ``Condition``
+    resources and combined into a single ``Claim``.
     """
 
     bundle: Dict[str, Any] = {
@@ -41,6 +85,7 @@ def _build_bundle(note: str, codes: List[str]) -> Dict[str, Any]:
             }
         ],
     }
+
     for code in codes:
         bundle["entry"].append(
             {
@@ -51,37 +96,76 @@ def _build_bundle(note: str, codes: List[str]) -> Dict[str, Any]:
                 },
             }
         )
+
+    doc_resource: Dict[str, Any] = {
+        "resourceType": "DocumentReference",
+        "status": "current",
+        "type": {"text": "Clinical Note"},
+        "content": [
+            {
+                "attachment": {
+                    "contentType": "text/plain",
+                    "data": base64.b64encode(note.encode()).decode(),
+                }
+            }
+        ],
+    }
+    if patient_id:
+        doc_resource["subject"] = {"reference": f"Patient/{patient_id}"}
+    if encounter_id:
+        doc_resource["context"] = {"encounter": [{"reference": f"Encounter/{encounter_id}"}]}
+    bundle["entry"].append(
+        {"request": {"method": "POST", "url": "DocumentReference"}, "resource": doc_resource}
+    )
+
+    claim_resource: Dict[str, Any] = {
+        "resourceType": "Claim",
+        "status": "active",
+        "type": {"text": "professional"},
+        "item": [
+            {
+                "sequence": idx + 1,
+                "productOrService": {"coding": [{"code": code}]},
+            }
+            for idx, code in enumerate(codes)
+        ],
+    }
+    if patient_id:
+        claim_resource["patient"] = {"reference": f"Patient/{patient_id}"}
+    if encounter_id:
+        claim_resource["encounter"] = [{"reference": f"Encounter/{encounter_id}"}]
+    bundle["entry"].append(
+        {"request": {"method": "POST", "url": "Claim"}, "resource": claim_resource}
+    )
+
     return bundle
 
 
-def post_note_and_codes(note: str, codes: List[str]) -> Dict[str, Any]:
-    """Send ``note`` and ``codes`` to the configured FHIR server.
-
-    A transaction bundle is POSTed to ``FHIR_SERVER_URL`` (or the value of the
-    environment variable of the same name).  The server's JSON response is
-    returned.  ``requests`` exceptions are allowed to propagate so callers can
-    surface an appropriate error to clients.
-    """
+def post_note_and_codes(
+    note: str,
+    codes: List[str],
+    patient_id: Optional[str] = None,
+    encounter_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Send ``note`` and ``codes`` to the configured FHIR server."""
 
     url = f"{FHIR_SERVER_URL.rstrip('/')}/Bundle"
-    payload = _build_bundle(note, codes)
-    resp = requests.post(url, json=payload, timeout=10)
+    payload = _build_bundle(note, codes, patient_id, encounter_id)
+    headers: Dict[str, str] = {}
+    token = get_ehr_token()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
 
-    # Many FHIR servers require authentication and will reply with a
-    # 401/403 status when credentials are missing or invalid.  Instead of
-    # raising an exception we report the condition to the caller so the
-    # API endpoint can surface a helpful message to the frontend.
+    resp = requests.post(url, json=payload, headers=headers or None, timeout=10)
+
     if resp.status_code in {401, 403}:
         return {"status": "auth_error"}
 
     resp.raise_for_status()
-
-    # The server's JSON response is included alongside a success status so
-    # callers can inspect any returned identifiers if desired.
     data = resp.json()
     if isinstance(data, dict):
         data = {**data}
     return {"status": "exported", **data}
 
 
-__all__ = ["post_note_and_codes"]
+__all__ = ["post_note_and_codes", "get_ehr_token"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -48,6 +48,7 @@ from platformdirs import user_data_dir
 from .audio_processing import simple_transcribe, diarize_and_transcribe
 from . import public_health as public_health_api
 from .migrations import ensure_settings_table, ensure_templates_table
+from .templates import DEFAULT_TEMPLATES
 from .templates import TemplateModel
 from .scheduling import recommend_follow_up, export_ics
 
@@ -1178,6 +1179,8 @@ class ExportRequest(BaseModel):
 
     note: str
     codes: List[str] = Field(default_factory=list)
+    patientId: Optional[str] = None
+    encounterId: Optional[str] = None
 
 
 @app.post("/export_to_ehr")
@@ -1194,7 +1197,9 @@ async def export_to_ehr(
     try:
         from . import ehr_integration
 
-        result = ehr_integration.post_note_and_codes(req.note, req.codes)
+        result = ehr_integration.post_note_and_codes(
+            req.note, req.codes, req.patientId, req.encounterId
+        )
     except Exception as exc:  # pragma: no cover - network failures
         raise HTTPException(status_code=502, detail=str(exc))
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -103,7 +103,8 @@ function App() {
   const [templateContext, setTemplateContext] = useState('');
 
   // Track the current patient ID for draft saving
-  const [patientID, setPatientID] = useState('');
+    const [patientID, setPatientID] = useState('');
+    const [encounterID, setEncounterID] = useState('');
   // Demographic details used for public health suggestions
   const [age, setAge] = useState('');
   const [sex, setSex] = useState('');
@@ -644,28 +645,35 @@ function App() {
                 </div>
                 <div className="editor-area card">
                   {activeTab === 'draft' ? (
-                    <NoteEditor
-                      ref={editorRef}
-                      id="draft-input"
-                      value={draftText}
-                      onChange={handleDraftChange}
-                      onTranscriptChange={handleTranscriptChange}
-                      error={transcriptionError}
-                      templateContext={templateContext}
-                      suggestionContext={suggestionContext}
-                      onSuggestions={handleSuggestions}
-                      onSuggestionsLoading={setLoadingSuggestions}
-                    />
-                  ) : activeTab === 'beautified' ? (
-                    <NoteEditor
-                      id="beautified-output"
-                      value={beautified}
-                      onChange={setBeautified}
-                      mode="beautified"
-                    />
-                  ) : (
-                    <div className="beautified-view">{summaryText}</div>
-                  )}
+                      <NoteEditor
+                        ref={editorRef}
+                        id="draft-input"
+                        value={draftText}
+                        onChange={handleDraftChange}
+                        onTranscriptChange={handleTranscriptChange}
+                        error={transcriptionError}
+                        templateContext={templateContext}
+                        suggestionContext={suggestionContext}
+                        onSuggestions={handleSuggestions}
+                        onSuggestionsLoading={setLoadingSuggestions}
+                        role={userRole}
+                        patientId={patientID}
+                        encounterId={encounterID}
+                      />
+                    ) : activeTab === 'beautified' ? (
+                      <NoteEditor
+                        id="beautified-output"
+                        value={beautified}
+                        onChange={setBeautified}
+                        mode="beautified"
+                        codes={suggestions.codes.map((c) => c.code)}
+                        patientId={patientID}
+                        encounterId={encounterID}
+                        role={userRole}
+                      />
+                    ) : (
+                      <div className="beautified-view">{summaryText}</div>
+                    )}
                 </div>
               </div>
               {(() => {

--- a/src/__tests__/NoteEditor.test.jsx
+++ b/src/__tests__/NoteEditor.test.jsx
@@ -61,9 +61,15 @@ test('displays error when transcript load fails', async () => {
 });
 
 test('EHR export button triggers API call', async () => {
-  const { getByText } = render(
-    <NoteEditor id="be" value="Final" onChange={() => {}} mode="beautified" />,
-  );
+    const { getByText } = render(
+      <NoteEditor
+        id="be"
+        value="Final"
+        onChange={() => {}}
+        mode="beautified"
+        role="admin"
+      />,
+    );
   fireEvent.click(getByText('EHR Export'));
   await waitFor(() => expect(exportToEhr).toHaveBeenCalled());
 });

--- a/src/api.js
+++ b/src/api.js
@@ -830,9 +830,19 @@ export async function setApiKey(key) {
 /**
  * Export a note to an EHR system. Requires an admin token.
  * @param {string} note
+ * @param {string[]} [codes]
+ * @param {string} [patientId]
+ * @param {string} [encounterId]
  * @param {string} [token]
  */
-export async function exportToEhr(note, codes = [], direct = false, token) {
+export async function exportToEhr(
+  note,
+  codes = [],
+  patientId = '',
+  encounterId = '',
+  direct = false,
+  token,
+) {
   // ``direct`` acts as a frontend toggle. When false the function resolves
   // immediately without contacting the backend so the caller can simply copy
   // the note manually. This keeps the UI logic straightforward while allowing
@@ -855,7 +865,7 @@ export async function exportToEhr(note, codes = [], direct = false, token) {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${auth}`,
     },
-    body: JSON.stringify({ note, codes }),
+    body: JSON.stringify({ note, codes, patientId, encounterId }),
   });
   if (!resp.ok) throw new Error('Export failed');
   return await resp.json();

--- a/src/components/NoteEditor.jsx
+++ b/src/components/NoteEditor.jsx
@@ -91,10 +91,21 @@ function useAudioRecorder(onTranscribed) {
 }
 
 const NoteEditor = forwardRef(function NoteEditor(
-  { id, value, onChange, onTranscriptChange, mode = 'draft' },
+  {
+    id,
+    value,
+    onChange,
+    onTranscriptChange,
+    mode = 'draft',
+    codes = [],
+    patientId = '',
+    encounterId = '',
+    role = '',
+  },
   ref,
 ) {
   const { t } = useTranslation();
+  const isAdmin = role === 'admin';
   const [localValue, setLocalValue] = useState(value || '');
   const [history, setHistory] = useState(value ? [value] : []);
   const [historyIndex, setHistoryIndex] = useState(value ? 0 : -1);
@@ -400,7 +411,13 @@ const NoteEditor = forwardRef(function NoteEditor(
 
   const handleExportEhr = async () => {
     try {
-      const res = await exportToEhr(value, [], true);
+      const res = await exportToEhr(
+        value,
+        codes,
+        patientId,
+        encounterId,
+        true,
+      );
       if (res.status === 'exported') {
         setEhrFeedback(t('clipboard.exported'));
       } else if (res.status === 'auth_error') {
@@ -433,17 +450,21 @@ const NoteEditor = forwardRef(function NoteEditor(
           >
             {t('noteEditor.redo')}
           </button>
-          <button
-            type="button"
-            onClick={handleExportEhr}
-            style={{ marginLeft: '0.5rem' }}
-          >
-            {t('ehrExport')}
-          </button>
-          {ehrFeedback && (
-            <span style={{ marginLeft: '0.5rem' }}>{ehrFeedback}</span>
-          )}
-        </div>
+            {isAdmin && (
+              <>
+                <button
+                  type="button"
+                  onClick={handleExportEhr}
+                  style={{ marginLeft: '0.5rem' }}
+                >
+                  {t('ehrExport')}
+                </button>
+                {ehrFeedback && (
+                  <span style={{ marginLeft: '0.5rem' }}>{ehrFeedback}</span>
+                )}
+              </>
+            )}
+          </div>
         <div className="beautified-view" style={{ whiteSpace: 'pre-wrap' }}>
           {history[historyIndex] || ''}
         </div>

--- a/src/components/__tests__/NoteEditor.test.jsx
+++ b/src/components/__tests__/NoteEditor.test.jsx
@@ -120,9 +120,15 @@ test('supports undo beyond five beautified entries', () => {
 });
 
 test('EHR export button triggers API call', async () => {
-  const { getByText } = render(
-    <NoteEditor id="e" value="Some" onChange={() => {}} mode="beautified" />,
-  );
+    const { getByText } = render(
+      <NoteEditor
+        id="e"
+        value="Some"
+        onChange={() => {}}
+        mode="beautified"
+        role="admin"
+      />,
+    );
   fireEvent.click(getByText('EHR Export'));
   await waitFor(() => expect(exportToEhr).toHaveBeenCalled());
 });

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -201,9 +201,11 @@ def test_export_to_ehr_requires_admin(client, monkeypatch):
     ).json()["access_token"]
 
     # Avoid real HTTP calls by stubbing the FHIR helper
-    def fake_post(note, codes):
+    def fake_post(note, codes, patient_id=None, encounter_id=None):
         assert note == "hi"
         assert codes == []
+        assert patient_id is None
+        assert encounter_id is None
         return {"status": "exported"}
 
     monkeypatch.setattr(ehr_integration, "post_note_and_codes", fake_post)


### PR DESCRIPTION
## Summary
- support OAuth2 token retrieval and include Claim & DocumentReference in FHIR bundle
- accept patientId/encounterId and secure /export_to_ehr for admins
- show Export to EHR button for admins and send codes & identifiers

## Testing
- `pytest -q`
- `npx vitest run src/__tests__/NoteEditor.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_6893a888bbf88324bb7178bf83c49f57