### PR TITLE
feat: add multilingual beautification and offline model support

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -48,7 +48,7 @@ from platformdirs import user_data_dir
 from .audio_processing import simple_transcribe, diarize_and_transcribe
 from . import public_health as public_health_api
 from .migrations import ensure_settings_table, ensure_templates_table
-from .templates import TemplateModel
+from .templates import TemplateModel, DEFAULT_TEMPLATES
 from .scheduling import recommend_follow_up, export_ics
 
 

--- a/backend/prompt_templates.json
+++ b/backend/prompt_templates.json
@@ -2,15 +2,21 @@
   "default": {
     "beautify": {
       "en": "Base instruction applied to all notes. Focus on clarity, avoid duplicating information or adding disclaimers, and remove filler words.",
+      "fr": "Instruction de base appliquée à toutes les notes. Concentrez-vous sur la clarté, évitez de dupliquer les informations ou d'ajouter des avertissements, et supprimez les mots superflus.",
+      "de": "Grundlegende Anweisung, die auf alle Notizen angewendet wird. Konzentrieren Sie sich auf Klarheit, vermeiden Sie doppelte Informationen oder Haftungsausschlüsse und entfernen Sie Füllwörter.",
       "examples": [
         {
           "user": {
             "en": "chief complaint: cough for 3 days. vitals t 37.8C hr 80. no known allergies.",
-            "es": "motivo de consulta: tos desde hace 3 días. signos vitales t 37,8C fc 80. sin alergias conocidas."
+            "es": "motivo de consulta: tos desde hace 3 días. signos vitales t 37,8C fc 80. sin alergias conocidas.",
+            "fr": "motif de consultation : toux depuis 3 jours. signes vitaux t 37,8C fc 80. pas d'allergies connues.",
+            "de": "Vorstellungsgrund: Husten seit 3 Tagen. Vitalzeichen T 37,8C HF 80. Keine bekannten Allergien."
           },
           "assistant": {
             "en": "Subjective:\n- Cough for 3 days\nObjective:\n- Temp 37.8 C, HR 80\nAssessment:\n- Acute cough\nPlan:\n- Rest and fluids",
-            "es": "Subjetivo:\n- Tos desde hace 3 días\nObjetivo:\n- Temp 37,8 C, FC 80\nEvaluación:\n- Tos aguda\nPlan:\n- Reposo e hidratación"
+            "es": "Subjetivo:\n- Tos desde hace 3 días\nObjetivo:\n- Temp 37,8 C, FC 80\nEvaluación:\n- Tos aguda\nPlan:\n- Reposo e hidratación",
+            "fr": "Subjectif:\n- Toux depuis 3 jours\nObjectif:\n- Temp 37,8 C, FC 80\nÉvaluation:\n- Toux aiguë\nPlan:\n- Repos et hydratation",
+            "de": "Subjektiv:\n- Husten seit 3 Tagen\nObjektiv:\n- Temp 37,8 C, HF 80\nBeurteilung:\n- Akuter Husten\nPlan:\n- Ruhe und Flüssigkeit"
           }
         }
       ]

--- a/backend/prompts.py
+++ b/backend/prompts.py
@@ -170,13 +170,39 @@ def build_beautify_prompt(
             "legibilidad y devuelva únicamente la nota limpia con los encabezados SOAP y sin "
             "comentarios adicionales ni marcas. La nota devuelta debe estar en español."
         ),
+        "fr": (
+            "Vous êtes un spécialiste hautement qualifié de la documentation clinique. "
+            "Votre tâche consiste à prendre une note non formatée et à en retourner une version "
+            "polie et professionnelle. N'inventez ni n'inférez de nouvelles informations "
+            "cliniques et supprimez tout identifiant du patient ou toute information de santé protégée. "
+            "Organisez le contenu en sections claires 'Subjectif :', 'Objectif :', 'Évaluation :' et 'Plan :', "
+            "en utilisant exactement ces intitulés et en préservant chaque détail clinique du texte original. "
+            "Si une section manque dans la source, omettez l'intitulé au lieu de créer du contenu nouveau. "
+            "Corrigez la grammaire et l'orthographe, améliorez la clarté et la lisibilité et renvoyez uniquement "
+            "la note nettoyée avec les en-têtes SOAP, sans commentaire ou balisage supplémentaire. La note retournée doit être en français."
+        ),
+        "de": (
+            "Sie sind ein hochqualifizierter Spezialist für klinische Dokumentation. Ihre Aufgabe besteht darin, "
+            "einen unformatierten Entwurf zu übernehmen und eine überarbeitete, professionelle Version zurückzugeben. "
+            "Erfinden oder vermuten Sie keine neuen klinischen Informationen und entfernen Sie alle Patientenkennungen "
+            "oder geschützten Gesundheitsinformationen (PHI). Gliedern Sie den Inhalt in die Abschnitte 'Subjektiv:', 'Objektiv:', "
+            "'Beurteilung:' und 'Plan:', verwenden Sie genau diese Überschriften und bewahren Sie jedes klinische Detail aus dem Originaltext. "
+            "Fehlt ein Abschnitt in der Quelle, lassen Sie die Überschrift weg, anstatt neuen Inhalt zu erstellen. "
+            "Korrigieren Sie Grammatik und Rechtschreibung, verbessern Sie Klarheit und Lesbarkeit und geben Sie nur die bereinigte Notiz "
+            "mit den SOAP-Überschriften ohne zusätzlichen Kommentar oder Markup zurück. Die Notiz muss auf Deutsch sein."
+        ),
     }
     instructions = default_instructions.get(lang, default_instructions["en"])
     extra = _get_custom_instruction("beautify", lang, specialty, payer)
     if extra:
         instructions = f"{instructions} {extra}"
-    if lang == "es":
-        instructions = f"{instructions} Responde en español."
+    lang_suffix = {
+        "es": "Responde en español.",
+        "fr": "Réponds en français.",
+        "de": "Antworte auf Deutsch.",
+    }
+    if lang in lang_suffix:
+        instructions = f"{instructions} {lang_suffix[lang]}"
     messages: List[Dict[str, str]] = [{"role": "system", "content": instructions}]
     messages.extend(_get_custom_examples("beautify", lang, specialty, payer))
     messages.append({"role": "user", "content": text})
@@ -258,13 +284,25 @@ def build_summary_prompt(
         "es": (
             "Usted es un experto comunicador clínico. Reescriba la siguiente nota clínica en un resumen conciso que un paciente pueda entender fácilmente. Preserve todos los hechos médicos importantes (síntomas, diagnósticos, tratamientos, seguimiento), pero elimine los códigos de facturación y la jerga técnica. Escriba en un lenguaje sencillo equivalente a un nivel de lectura de octavo grado. No invente información que no esté presente en la nota. No incluya identificadores del paciente ni PHI. El resumen debe estar en español."
         ),
+        "fr": (
+            "Vous êtes un expert en communication clinique. Réécrivez la note clinique suivante "
+            "en un résumé concis qu'un patient peut comprendre facilement. Préservez tous les faits médicaux importants (symptômes, diagnostics, traitements, suivi) mais supprimez les codes de facturation et le jargon technique. Rédigez dans un langage simple d'un niveau d'environ la classe de 4e. N'inventez pas d'informations absentes de la note et n'incluez aucun identifiant patient ni PHI. Le résumé doit être en français."
+        ),
+        "de": (
+            "Sie sind ein Experte für klinische Kommunikation. Formulieren Sie die folgende klinische Notiz zu einer prägnanten Zusammenfassung um, die ein Patient leicht verstehen kann. Erhalten Sie alle wichtigen medizinischen Fakten (Symptome, Diagnosen, Behandlungen, Nachsorge), entfernen Sie jedoch Abrechnungscodes und Fachjargon. Schreiben Sie in einfacher Sprache auf etwa Achtklassen-Niveau. Erfinden Sie keine Informationen, die nicht in der Notiz stehen, und fügen Sie keine Patientenkennungen oder PHI hinzu. Die Zusammenfassung muss auf Deutsch sein."
+        ),
     }
     instructions = default_instructions.get(lang, default_instructions["en"])
     extra = _get_custom_instruction("summary", lang, specialty, payer)
     if extra:
         instructions = f"{instructions} {extra}"
-    if lang == "es":
-        instructions = f"{instructions} Responde en español."
+    lang_suffix = {
+        "es": "Responde en español.",
+        "fr": "Réponds en français.",
+        "de": "Antworte auf Deutsch.",
+    }
+    if lang in lang_suffix:
+        instructions = f"{instructions} {lang_suffix[lang]}"
     messages: List[Dict[str, str]] = [{"role": "system", "content": instructions}]
     messages.extend(_get_custom_examples("summary", lang, specialty, payer))
     messages.append({"role": "user", "content": text})

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -96,6 +96,8 @@ function Login({ onLoggedIn }) {
             >
               <option value="en">{t('settings.english')}</option>
               <option value="es">{t('settings.spanish')}</option>
+              <option value="fr">{t('settings.french')}</option>
+              <option value="de">{t('settings.german')}</option>
             </select>
           </label>
         </div>

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -346,6 +346,8 @@ function Settings({ settings, updateSettings }) {
       >
         <option value="en">{t('settings.english')}</option>
         <option value="es">{t('settings.spanish')}</option>
+        <option value="fr">{t('settings.french')}</option>
+        <option value="de">{t('settings.german')}</option>
       </select>
 
       <h3>{t('settings.summaryLanguage')}</h3>
@@ -356,6 +358,8 @@ function Settings({ settings, updateSettings }) {
       >
         <option value="en">{t('settings.english')}</option>
         <option value="es">{t('settings.spanish')}</option>
+        <option value="fr">{t('settings.french')}</option>
+        <option value="de">{t('settings.german')}</option>
       </select>
 
       <h3>{t('settings.specialty')}</h3>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -169,6 +169,8 @@
     "invalidPromptTemplates": "Invalid template format",
     "english": "English",
     "spanish": "Spanish",
+    "french": "French",
+    "german": "German",
     "region": "Region",
     "regionPlaceholder": "e.g., US",
     "specialties": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -169,6 +169,8 @@
     "invalidPromptTemplates": "Formato de plantilla inválido",
     "english": "Inglés",
     "spanish": "Español",
+    "french": "Francés",
+    "german": "Alemán",
     "region": "Región",
     "regionPlaceholder": "p. ej., US",
     "specialties": {

--- a/tests/test_offline_mode.py
+++ b/tests/test_offline_mode.py
@@ -43,25 +43,33 @@ def offline_client(monkeypatch):
 def test_offline_beautify(offline_client):
     client, main_module = offline_client
     token = main_module.create_token("u", "user")
-    resp = client.post("/beautify", json={"text": "hello"}, headers=auth_header(token))
-    assert resp.status_code == 200
-    assert resp.json()["beautified"]
+    payload = {"text": "hello"}
+    resp1 = client.post("/beautify", json=payload, headers=auth_header(token))
+    resp2 = client.post("/beautify", json=payload, headers=auth_header(token))
+    assert resp1.status_code == 200
+    assert resp2.status_code == 200
+    assert resp1.json()["beautified"] == "Beautified (offline): hello"
+    assert resp1.json()["beautified"] == resp2.json()["beautified"]
 
 
 def test_offline_suggest(offline_client):
     client, main_module = offline_client
     token = main_module.create_token("u", "user")
-    resp = client.post("/suggest", json={"text": "note"}, headers=auth_header(token))
-    data = resp.json()
-    assert data["codes"]
-    assert data["compliance"]
-    assert data["publicHealth"]
-    assert data["differentials"]
+    payload = {"text": "note"}
+    r1 = client.post("/suggest", json=payload, headers=auth_header(token)).json()
+    r2 = client.post("/suggest", json=payload, headers=auth_header(token)).json()
+    assert r1 == r2
+    assert r1["codes"]
+    assert r1["compliance"]
+    assert r1["publicHealth"]
+    assert r1["differentials"]
 
 
 def test_offline_summarize(offline_client):
     client, main_module = offline_client
     token = main_module.create_token("u", "user")
-    resp = client.post("/summarize", json={"text": "hello"}, headers=auth_header(token))
-    assert resp.status_code == 200
-    assert resp.json()["summary"]
+    payload = {"text": "hello"}
+    s1 = client.post("/summarize", json=payload, headers=auth_header(token)).json()
+    s2 = client.post("/summarize", json=payload, headers=auth_header(token)).json()
+    assert s1 == s2
+    assert s1["summary"] == "Summary (offline): hello"

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -14,13 +14,23 @@ def reset_templates() -> Iterator[None]:
 def test_beautify_prompt_language():
     en = prompts.build_beautify_prompt("note", lang="en")
     es = prompts.build_beautify_prompt("nota", lang="es")
+    fr = prompts.build_beautify_prompt("note", lang="fr")
+    de = prompts.build_beautify_prompt("note", lang="de")
     assert "clinical documentation specialist" in en[0]["content"]
     assert "documentación clínica" in es[0]["content"]
+    assert "documentation clinique" in fr[0]["content"]
+    assert "klinische Dokumentation" in de[0]["content"]
     assert "en español" in es[0]["content"]
+    assert "en français" in fr[0]["content"]
+    assert "auf Deutsch" in de[0]["content"]
     for heading in ["Subjective", "Objective", "Assessment", "Plan"]:
         assert heading in en[0]["content"]
     for heading in ["Subjetivo", "Objetivo", "Evaluación", "Plan"]:
         assert heading in es[0]["content"]
+    for heading in ["Subjectif", "Objectif", "Évaluation", "Plan"]:
+        assert heading in fr[0]["content"]
+    for heading in ["Subjektiv", "Objektiv", "Beurteilung", "Plan"]:
+        assert heading in de[0]["content"]
 
 
 def test_suggest_prompt_language():
@@ -34,9 +44,15 @@ def test_suggest_prompt_language():
 def test_summary_prompt_language():
     en = prompts.build_summary_prompt("note", lang="en")
     es = prompts.build_summary_prompt("nota", lang="es")
+    fr = prompts.build_summary_prompt("note", lang="fr")
+    de = prompts.build_summary_prompt("note", lang="de")
     assert "clinical communicator" in en[0]["content"]
     assert "comunicador clínico" in es[0]["content"]
+    assert "communication clinique" in fr[0]["content"]
+    assert "klinische Kommunikation" in de[0]["content"]
     assert "en español" in es[0]["content"]
+    assert "en français" in fr[0]["content"]
+    assert "auf Deutsch" in de[0]["content"]
 
 
 def test_specialty_and_payer_overrides():


### PR DESCRIPTION
## Summary
- expand prompt templates and prompts to handle French and German
- enable language selectors for beautify and summary in the UI
- verify deterministic offline responses and multilingual prompts

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893a897db3883248d5038b67fe32c72