### PR TITLE
feat: expand patient summaries with language and age

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -48,7 +48,7 @@ from platformdirs import user_data_dir
 from .audio_processing import simple_transcribe, diarize_and_transcribe
 from . import public_health as public_health_api
 from .migrations import ensure_settings_table, ensure_templates_table
-from .templates import TemplateModel
+from .templates import TemplateModel, DEFAULT_TEMPLATES
 from .scheduling import recommend_follow_up, export_ics
 
 
@@ -650,10 +650,13 @@ class NoteRequest(BaseModel):
     lang: str = "en"
     specialty: Optional[str] = None
     payer: Optional[str] = None
-    age: Optional[int] = None
+    age: Optional[int] = Field(None, alias="patientAge")
     sex: Optional[str] = None
     region: Optional[str] = None
     useLocalModels: Optional[bool] = False
+
+    class Config:
+        populate_by_name = True
 
 
 class CodeSuggestion(BaseModel):
@@ -1634,7 +1637,7 @@ async def get_metrics(
 @app.post("/summarize")
 async def summarize(
     req: NoteRequest, user=Depends(require_role("user"))
-) -> Dict[str, str]:
+) -> Dict[str, Any]:
     """
     Generate a patient‑friendly summary of a clinical note.  This endpoint
     combines the draft text with any optional chart and audio transcript,
@@ -1645,7 +1648,7 @@ async def summarize(
     Args:
         req: NoteRequest with the clinical note and optional context.
     Returns:
-        A dictionary containing the summary under the key "summary".
+        A dictionary containing "summary", "recommendations" and "warnings".
     """
     combined = req.text or ""
     if req.chart:
@@ -1656,14 +1659,21 @@ async def summarize(
     if USE_OFFLINE_MODEL:
         from .offline_model import summarize as offline_summarize
 
-        summary = offline_summarize(
-            cleaned, req.lang, req.specialty, req.payer, use_local=req.useLocalModels
+        data = offline_summarize(
+            cleaned,
+            req.lang,
+            req.specialty,
+            req.payer,
+            req.age,
+            use_local=req.useLocalModels,
         )
     else:
         try:
-            messages = build_summary_prompt(cleaned, req.lang, req.specialty, req.payer)
+            messages = build_summary_prompt(
+                cleaned, req.lang, req.specialty, req.payer, req.age
+            )
             response_content = call_openai(messages)
-            summary = response_content.strip()
+            data = json.loads(response_content)
         except Exception as exc:
             # If the LLM call fails, fall back to a simple truncation of the
             # cleaned text.  Take the first 200 characters and append ellipsis
@@ -1673,7 +1683,8 @@ async def summarize(
             summary = cleaned[:200]
             if len(cleaned) > 200:
                 summary += "..."
-    return {"summary": summary}
+            data = {"summary": summary, "recommendations": [], "warnings": []}
+    return data
 
 
 @app.post("/transcribe")

--- a/backend/offline_model.py
+++ b/backend/offline_model.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import json
 import os
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Any
 
 
 _PIPELINES = {}
@@ -70,8 +70,9 @@ def summarize(
     lang: str = "en",
     specialty: Optional[str] = None,
     payer: Optional[str] = None,
+    patient_age: Optional[int] = None,
     use_local: Optional[bool] = None,
-) -> str:
+) -> Dict[str, Any]:
     """Summarise ``text`` with a local model or deterministic placeholder."""
 
     if use_local is None:
@@ -83,11 +84,22 @@ def summarize(
             try:
                 pipe = _get_pipeline("summarization", model)
                 result = pipe(text)[0]
-                return result.get("summary_text", "").strip() or result.get("generated_text", "").strip()
+                summary_text = result.get("summary_text", "").strip() or result.get(
+                    "generated_text", ""
+                ).strip()
+                return {
+                    "summary": summary_text,
+                    "recommendations": [],
+                    "warnings": [],
+                }
             except Exception:
                 pass
     snippet = text.strip()[:50]
-    return f"Summary (offline): {snippet}"
+    return {
+        "summary": f"Summary (offline): {snippet}",
+        "recommendations": [],
+        "warnings": [],
+    }
 
 
 def suggest(

--- a/backend/prompts.py
+++ b/backend/prompts.py
@@ -244,22 +244,20 @@ def build_summary_prompt(
     lang: str = "en",
     specialty: Optional[str] = None,
     payer: Optional[str] = None,
+    patient_age: Optional[int] = None,
 ) -> List[Dict[str, str]]:
     """Build a summary prompt in the requested language."""
     default_instructions = {
         "en": (
-            "You are an expert clinical communicator.  Rewrite the following clinical note "
-            "into a concise summary that a patient can easily understand.  Preserve all "
-            "important medical facts (symptoms, diagnoses, treatments, follow‑up), but remove "
-            "billing codes and technical jargon.  Write in plain language at about an 8th "
-            "grade reading level.  Do not invent information that is not present in the note. "
-            "Do not include any patient identifiers or PHI."
+            "You are an expert clinical communicator. Rewrite the following clinical note into a JSON object with keys 'summary', 'recommendations' and 'warnings'. 'summary' should be a brief paragraph in plain language that a patient can easily understand. 'recommendations' should be a bullet list of next steps for the patient. 'warnings' should be a bullet list of any urgent issues. Avoid billing codes and technical jargon. Do not invent information that is not present in the note. Do not include any patient identifiers or PHI."
         ),
         "es": (
-            "Usted es un experto comunicador clínico. Reescriba la siguiente nota clínica en un resumen conciso que un paciente pueda entender fácilmente. Preserve todos los hechos médicos importantes (síntomas, diagnósticos, tratamientos, seguimiento), pero elimine los códigos de facturación y la jerga técnica. Escriba en un lenguaje sencillo equivalente a un nivel de lectura de octavo grado. No invente información que no esté presente en la nota. No incluya identificadores del paciente ni PHI. El resumen debe estar en español."
+            "Usted es un experto comunicador clínico. Reescriba la siguiente nota clínica en un objeto JSON con claves 'summary', 'recommendations' y 'warnings'. 'summary' debe ser un breve párrafo en lenguaje sencillo que un paciente pueda entender. 'recommendations' debe ser una lista con viñetas de próximos pasos para el paciente. 'warnings' debe ser una lista con viñetas de cualquier problema urgente. Evite códigos de facturación y jerga técnica. No invente información que no esté presente en la nota. No incluya identificadores del paciente ni PHI. El resumen debe estar en español."
         ),
     }
     instructions = default_instructions.get(lang, default_instructions["en"])
+    if patient_age is not None:
+        instructions = f"{instructions} Use words a {patient_age}-year-old would understand."
     extra = _get_custom_instruction("summary", lang, specialty, payer)
     if extra:
         instructions = f"{instructions} {extra}"

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -169,6 +169,8 @@
     "back": "Back to Notes",
     "file": "File",
     "patientId": "Patient ID",
+    "patientLanguage": "Patient language",
+    "patientAge": "Patient age",
     "templates": "Templates",
     "beautifying": "Beautifying…",
     "beautify": "Beautify",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -169,6 +169,8 @@
     "back": "Volver a las notas",
     "file": "Archivo",
     "patientId": "ID de paciente",
+    "patientLanguage": "Idioma del paciente",
+    "patientAge": "Edad del paciente",
     "templates": "Plantillas",
     "beautifying": "Embelleciendo…",
     "beautify": "Embellecer",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -320,12 +320,20 @@ function App() {
       chart: chartText,
       audio: `${audioTranscript.provider} ${audioTranscript.patient}`.trim(),
       lang: settingsState.summaryLang,
+      patientAge: age ? parseInt(age, 10) : undefined,
       specialty: settingsState.specialty,
       payer: settingsState.payer,
       useLocalModels: settingsState.useLocalModels,
     })
-      .then((summary) => {
-        setSummaryText(summary);
+      .then((data) => {
+        let combined = data.summary;
+        if (data.recommendations?.length) {
+          combined += `\n\n${data.recommendations.map((r) => `- ${r}`).join('\n')}`;
+        }
+        if (data.warnings?.length) {
+          combined += `\n\n${data.warnings.map((w) => `! ${w}`).join('\n')}`;
+        }
+        setSummaryText(combined);
         setActiveTab('summary');
         if (patientID) {
           const codes = suggestions.codes.map((c) => c.code);
@@ -536,6 +544,22 @@ function App() {
                 value={patientID}
                 onChange={(e) => setPatientID(e.target.value)}
                 className="patient-input"
+              />
+              <select
+                value={settingsState.summaryLang}
+                onChange={(e) => setSettingsState({ ...settingsState, summaryLang: e.target.value })}
+                aria-label={t('app.patientLanguage')}
+              >
+                <option value="en">English</option>
+                <option value="es">Español</option>
+              </select>
+              <input
+                type="number"
+                placeholder={t('app.patientAge')}
+                value={age}
+                onChange={(e) => setAge(e.target.value)}
+                className="patient-age-input"
+                style={{ width: '4rem', marginLeft: '0.5rem' }}
               />
               <button
                 onClick={() => setShowTemplatesModal(true)}

--- a/src/api.js
+++ b/src/api.js
@@ -878,6 +878,7 @@ export async function summarizeNote(text, context = {}) {
   if (baseUrl) {
     const payload = { text };
     if (context.lang) payload.lang = context.lang;
+    if (context.patientAge != null) payload.patientAge = context.patientAge;
     if (context.chart) payload.chart = context.chart;
     if (context.audio) payload.audio = context.audio;
     if (context.specialty) payload.specialty = context.specialty;
@@ -902,14 +903,18 @@ export async function summarizeNote(text, context = {}) {
         throw new Error('Unauthorized');
       }
       const data = await resp.json();
-      return data.summary || '';
+      return {
+        summary: data.summary || '',
+        recommendations: data.recommendations || [],
+        warnings: data.warnings || [],
+      };
     } catch (err) {
       console.error('Error summarizing note:', err);
       // fall through to stub behaviour
     }
   }
   // fallback: return the first sentence or first 200 characters
-  if (!text) return '';
+  if (!text) return { summary: '', recommendations: [], warnings: [] };
   // Try to extract the first sentence by splitting on period; otherwise truncate
   const sentences = text.split(/\.(\s|$)/);
   let summary = sentences[0];
@@ -920,7 +925,7 @@ export async function summarizeNote(text, context = {}) {
     summary = summary.trim();
     if (!summary.endsWith('...')) summary += '...';
   }
-  return summary;
+  return { summary, recommendations: [], warnings: [] };
 }
 
 /**

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -235,6 +235,8 @@
     "back": "Back to Notes",
     "file": "File",
     "patientId": "Patient ID",
+    "patientLanguage": "Patient language",
+    "patientAge": "Patient age",
     "templates": "Templates",
     "beautifying": "Beautifying…",
     "beautify": "Beautify",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -235,6 +235,8 @@
     "back": "Volver a las notas",
     "file": "Archivo",
     "patientId": "ID de paciente",
+    "patientLanguage": "Idioma del paciente",
+    "patientAge": "Edad del paciente",
     "templates": "Plantillas",
     "beautifying": "Embelleciendo…",
     "beautify": "Embellecer",

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -2,6 +2,7 @@ import json
 import sqlite3
 import hashlib
 import logging
+import json
 
 
 import pytest
@@ -220,12 +221,22 @@ def test_export_to_ehr_requires_admin(client, monkeypatch):
 
 def test_summarize_and_fallback(client, monkeypatch, caplog):
 
-    monkeypatch.setattr(main, "call_openai", lambda msgs: "great summary")
+    monkeypatch.setattr(
+        main,
+        "call_openai",
+        lambda msgs: json.dumps(
+            {"summary": "great summary", "recommendations": ["do"], "warnings": []}
+        ),
+    )
     token = main.create_token("u", "user")
     resp = client.post(
         "/summarize", json={"text": "hello"}, headers=auth_header(token)
     )
-    assert resp.json()["summary"] == "great summary"
+    assert resp.json() == {
+        "summary": "great summary",
+        "recommendations": ["do"],
+        "warnings": [],
+    }
 
     def boom(_):
         raise RuntimeError("no key")
@@ -237,20 +248,28 @@ def test_summarize_and_fallback(client, monkeypatch, caplog):
             "/summarize", json={"text": long_text}, headers=auth_header(token)
         )
     assert resp.status_code == 200
-    assert len(resp.json()["summary"]) <= 203  # truncated fallback
+    data = resp.json()
+    assert len(data["summary"]) <= 203  # truncated fallback
+    assert data["recommendations"] == []
+    assert data["warnings"] == []
     assert "Error during summary LLM call" in caplog.text
 
 
 def test_summarize_spanish_language(client, monkeypatch):
     def fake_call_openai(msgs):
-        # Ensure the system prompt is in Spanish
+        # Ensure the system prompt is in Spanish and includes age guidance
         assert "comunicador clínico" in msgs[0]["content"]
-        return "resumen"
+        assert "10-year-old" in msgs[0]["content"]
+        return json.dumps(
+            {"summary": "resumen", "recommendations": [], "warnings": []}
+        )
 
     monkeypatch.setattr(main, "call_openai", fake_call_openai)
     token = main.create_token("u", "user")
     resp = client.post(
-        "/summarize", json={"text": "hola", "lang": "es"}, headers=auth_header(token)
+        "/summarize",
+        json={"text": "hola", "lang": "es", "patientAge": 10},
+        headers=auth_header(token),
     )
     assert resp.status_code == 200
     assert resp.json()["summary"] == "resumen"

--- a/tests/test_local_models.py
+++ b/tests/test_local_models.py
@@ -35,7 +35,11 @@ def test_local_summarize(monkeypatch):
             return [{"summary_text": "short"}]
 
     monkeypatch.setattr(om, "_get_pipeline", lambda task, model: Pipe())
-    assert om.summarize("long note") == "short"
+    assert om.summarize("long note") == {
+        "summary": "short",
+        "recommendations": [],
+        "warnings": [],
+    }
 
 
 def test_local_summarize_fallback(monkeypatch):
@@ -46,7 +50,10 @@ def test_local_summarize_fallback(monkeypatch):
         raise RuntimeError("no model")
 
     monkeypatch.setattr(om, "_get_pipeline", raiser)
-    assert om.summarize("note").startswith("Summary (offline):")
+    out = om.summarize("note")
+    assert out["summary"].startswith("Summary (offline):")
+    assert out["recommendations"] == []
+    assert out["warnings"] == []
 
 
 def test_local_suggest(monkeypatch):

--- a/tests/test_offline_mode.py
+++ b/tests/test_offline_mode.py
@@ -62,6 +62,11 @@ def test_offline_suggest(offline_client):
 def test_offline_summarize(offline_client):
     client, main_module = offline_client
     token = main_module.create_token("u", "user")
-    resp = client.post("/summarize", json={"text": "hello"}, headers=auth_header(token))
+    resp = client.post(
+        "/summarize", json={"text": "hello"}, headers=auth_header(token)
+    )
     assert resp.status_code == 200
-    assert resp.json()["summary"]
+    data = resp.json()
+    assert data["summary"]
+    assert data["recommendations"] == []
+    assert data["warnings"] == []


### PR DESCRIPTION
## Summary
- extend summary prompt to output patient-friendly JSON with recommendations and warnings
- allow `/summarize` to accept patientAge and return structured data
- add UI inputs for patient language and age and propagate to the API

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893a8a018bc8324aeb645d5bdfc2ab5