### PR TITLE
feat: enhance audio processing and transcript history

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -13,11 +13,9 @@ import os
 import re
 import shutil
 import time
-from collections import deque
+from collections import defaultdict, deque
 from datetime import datetime, timedelta
 from typing import List, Optional, Dict, Any
-from collections import deque
-
 from fastapi import FastAPI, Depends, HTTPException, status, UploadFile, File, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -48,7 +46,7 @@ from platformdirs import user_data_dir
 from .audio_processing import simple_transcribe, diarize_and_transcribe
 from . import public_health as public_health_api
 from .migrations import ensure_settings_table, ensure_templates_table
-from .templates import TemplateModel
+from .templates import TemplateModel, DEFAULT_TEMPLATES
 from .scheduling import recommend_follow_up, export_ics
 
 
@@ -168,10 +166,13 @@ app.add_middleware(
 # to a database.
 events: List[Dict[str, Any]] = []
 
-# Last audio transcript returned by the ``/transcribe`` endpoint.  This is a
-# simple in-memory store so the frontend can fetch or re-use the most recent
-# transcript without re-uploading the audio.  It is reset on server restart.
-last_transcript: Dict[str, Any] = {"provider": "", "patient": "", "segments": []}
+# Cache of recent audio transcripts per user.  Each user retains the last
+# ``TRANSCRIPT_HISTORY_LIMIT`` transcripts so clinicians can revisit previous
+# conversations.  The cache is stored in-memory and reset on server restart.
+TRANSCRIPT_HISTORY_LIMIT = int(os.getenv("TRANSCRIPT_HISTORY", "5"))
+transcript_history: Dict[str, deque] = defaultdict(
+    lambda: deque(maxlen=TRANSCRIPT_HISTORY_LIMIT)
+)
 
 # Set up a SQLite database for persistent analytics storage.  The database
 # now lives in the user's data directory (platform-specific) so analytics
@@ -1680,6 +1681,7 @@ async def summarize(
 async def transcribe(
     file: UploadFile = File(...),
     diarise: bool = False,
+    lang: Optional[str] = None,
     user=Depends(require_role("user")),
 ) -> Dict[str, Any]:
     """Transcribe uploaded audio.
@@ -1694,9 +1696,9 @@ async def transcribe(
 
     audio_bytes = await file.read()
     if diarise:
-        result = diarize_and_transcribe(audio_bytes)
+        result = diarize_and_transcribe(audio_bytes, language=lang)
     else:
-        text = simple_transcribe(audio_bytes)
+        text = simple_transcribe(audio_bytes, language=lang)
         result = {
             "provider": text,
             "patient": "",
@@ -1704,25 +1706,17 @@ async def transcribe(
                 {"speaker": "provider", "start": 0.0, "end": 0.0, "text": text}
             ],
         }
-    # Store the most recent transcript so other endpoints or subsequent
-    # requests can reuse it without reprocessing the audio.  Replace the
-    # previous contents entirely so stale keys (e.g. error messages) do
-    # not persist across requests.
-    last_transcript.clear()
-    last_transcript.update(result)
+    # Store the transcript in the user's history so it can be revisited
+    transcript_history[user["sub"]].append(result)
     return result
 
 
 @app.get("/transcribe")
 async def get_last_transcript(user=Depends(require_role("user"))) -> Dict[str, Any]:
-    """Return the most recent audio transcript.
+    """Return recent audio transcripts for the current user."""
 
-    This endpoint allows the frontend to retrieve the last transcript
-    produced by :func:`transcribe` without uploading the audio again.
-    The transcript is stored in-memory and reset when the server restarts.
-    """
-
-    return last_transcript
+    history = list(transcript_history.get(user["sub"], []))
+    return {"history": history}
 
 
 # Endpoint: set the OpenAI API key.  Accepts a JSON body with a single

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -2,6 +2,7 @@ import json
 import sqlite3
 import hashlib
 import logging
+from collections import defaultdict, deque
 
 
 import pytest
@@ -37,6 +38,11 @@ def client(monkeypatch, tmp_path):
     db.commit()
     monkeypatch.setattr(main, "db_conn", db)
     monkeypatch.setattr(main, "events", [])
+    monkeypatch.setattr(
+        main,
+        "transcript_history",
+        defaultdict(lambda: deque(maxlen=main.TRANSCRIPT_HISTORY_LIMIT)),
+    )
     return TestClient(main.app)
 
 
@@ -257,11 +263,11 @@ def test_summarize_spanish_language(client, monkeypatch):
 
 
 def test_transcribe_endpoint(client, monkeypatch):
-    monkeypatch.setattr(main, "simple_transcribe", lambda b: "hello")
+    monkeypatch.setattr(main, "simple_transcribe", lambda b, language=None: "hello")
     monkeypatch.setattr(
         main,
         "diarize_and_transcribe",
-        lambda b: {
+        lambda b, language=None: {
             "provider": "p",
             "patient": "q",
             "segments": [
@@ -304,7 +310,7 @@ def test_transcribe_endpoint_diarise_failure(client, monkeypatch):
 
     monkeypatch.setattr(ap, "Pipeline", FailPipeline)
     monkeypatch.setattr(ap, "_DIARISATION_AVAILABLE", True)
-    monkeypatch.setattr(ap, "simple_transcribe", lambda b: "fallback")
+    monkeypatch.setattr(ap, "simple_transcribe", lambda b, language=None: "fallback")
     token = main.create_token("u", "user")
     resp = client.post(
         "/transcribe?diarise=true",
@@ -319,14 +325,28 @@ def test_transcribe_endpoint_diarise_failure(client, monkeypatch):
     assert "error" in data
 
 
+def test_transcribe_language_param(client, monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        main, "simple_transcribe", lambda b, language=None: captured.setdefault("lang", language) or "text"
+    )
+    token = main.create_token("u", "user")
+    client.post(
+        "/transcribe?lang=es",
+        files={"file": ("a.wav", b"bytes")},
+        headers=auth_header(token),
+    )
+    assert captured["lang"] == "es"
+
+
 def test_transcribe_endpoint_offline(client, monkeypatch):
     import backend.audio_processing as ap
 
     class DummyModel:
-        def transcribe(self, path):  # noqa: ARG002
+        def transcribe(self, path, language=None):  # noqa: ARG002
             return {"text": "offline text"}
 
-    monkeypatch.setattr(ap, "_load_local_model", lambda: DummyModel())
+    monkeypatch.setattr(ap, "_load_local_model", lambda lang: DummyModel())
     monkeypatch.setenv("OFFLINE_TRANSCRIBE", "true")
     monkeypatch.setattr(ap, "get_api_key", lambda: None)
     token = main.create_token("u", "user")
@@ -343,11 +363,11 @@ def test_transcribe_endpoint_offline(client, monkeypatch):
 
 
 def test_get_last_transcript(client, monkeypatch):
-    monkeypatch.setattr(main, "simple_transcribe", lambda b: "hello")
+    monkeypatch.setattr(main, "simple_transcribe", lambda b, language=None: "hello")
     monkeypatch.setattr(
         main,
         "diarize_and_transcribe",
-        lambda b: {
+        lambda b, language=None: {
             "provider": "p",
             "patient": "q",
             "segments": [
@@ -365,11 +385,15 @@ def test_get_last_transcript(client, monkeypatch):
     )
     resp = client.get("/transcribe", headers=auth_header(token))
     assert resp.json() == {
-        "provider": "hello",
-        "patient": "",
-        "segments": [
-            {"speaker": "provider", "start": 0.0, "end": 0.0, "text": "hello"}
-        ],
+        "history": [
+            {
+                "provider": "hello",
+                "patient": "",
+                "segments": [
+                    {"speaker": "provider", "start": 0.0, "end": 0.0, "text": "hello"}
+                ],
+            }
+        ]
     }
 
     # Now call with diarisation and ensure both parts returned
@@ -380,12 +404,23 @@ def test_get_last_transcript(client, monkeypatch):
     )
     resp = client.get("/transcribe", headers=auth_header(token))
     assert resp.json() == {
-        "provider": "p",
-        "patient": "q",
-        "segments": [
-            {"speaker": "provider", "start": 0.0, "end": 0.0, "text": "p"},
-            {"speaker": "patient", "start": 0.0, "end": 0.0, "text": "q"},
-        ],
+        "history": [
+            {
+                "provider": "hello",
+                "patient": "",
+                "segments": [
+                    {"speaker": "provider", "start": 0.0, "end": 0.0, "text": "hello"}
+                ],
+            },
+            {
+                "provider": "p",
+                "patient": "q",
+                "segments": [
+                    {"speaker": "provider", "start": 0.0, "end": 0.0, "text": "p"},
+                    {"speaker": "patient", "start": 0.0, "end": 0.0, "text": "q"},
+                ],
+            },
+        ]
     }
 
 

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -1,6 +1,10 @@
 import sqlite3
 from fastapi.testclient import TestClient
 
+import sqlite3
+from collections import defaultdict, deque
+from fastapi.testclient import TestClient
+
 import backend.main as main
 
 
@@ -12,7 +16,7 @@ def setup_module(module):
     # ensure in-memory db; transcribe endpoint doesn't touch DB but required for app
     main.db_conn = sqlite3.connect(":memory:", check_same_thread=False)
     main.db_conn.row_factory = sqlite3.Row
-    main.last_transcript.clear()
+    main.transcript_history = defaultdict(lambda: deque(maxlen=main.TRANSCRIPT_HISTORY_LIMIT))
 
 
 def test_get_last_transcript_empty():
@@ -20,13 +24,13 @@ def test_get_last_transcript_empty():
     token = main.create_token("alice", "user")
     resp = client.get("/transcribe", headers=auth_header(token))
     assert resp.status_code == 200
-    assert resp.json() == {}
+    assert resp.json() == {"history": []}
 
 
 def test_transcribe_updates_last_transcript(monkeypatch):
     client = TestClient(main.app)
     token = main.create_token("alice", "user")
-    monkeypatch.setattr(main, "simple_transcribe", lambda b: "hi")
+    monkeypatch.setattr(main, "simple_transcribe", lambda b, language=None: "hi")
     resp = client.post(
         "/transcribe",
         files={"file": ("a.wav", b"bytes")},
@@ -36,4 +40,14 @@ def test_transcribe_updates_last_transcript(monkeypatch):
     assert resp.json()["provider"] == "hi"
 
     resp2 = client.get("/transcribe", headers=auth_header(token))
-    assert resp2.json()["provider"] == "hi"
+    assert resp2.json() == {
+        "history": [
+            {
+                "provider": "hi",
+                "patient": "",
+                "segments": [
+                    {"speaker": "provider", "start": 0.0, "end": 0.0, "text": "hi"}
+                ],
+            }
+        ]
+    }


### PR DESCRIPTION
## Summary
- support language-specific Whisper models and integrate pyannote diarization with basic noise reduction
- allow audio transcription endpoint to pick language and persist per-user transcript history
- add tests for multi-language transcription, diarization, and transcript caching

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893a8a984e08324abd817d19e357cf5