### PR TITLE
feat: add specialty-aware templates

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -48,7 +48,7 @@ from platformdirs import user_data_dir
 from .audio_processing import simple_transcribe, diarize_and_transcribe
 from . import public_health as public_health_api
 from .migrations import ensure_settings_table, ensure_templates_table
-from .templates import TemplateModel
+from .templates import TemplateModel, load_builtin_templates
 from .scheduling import recommend_follow_up, export_ics
 
 
@@ -404,6 +404,7 @@ class UserSettings(BaseModel):
     specialty: Optional[str] = None
     payer: Optional[str] = None
     region: str = ""
+    template: Optional[int] = None
     useLocalModels: StrictBool = False
 
     @validator("theme")
@@ -583,7 +584,7 @@ async def get_audit_logs(user=Depends(require_role("admin"))) -> List[Dict[str, 
 async def get_user_settings(user=Depends(require_role("user"))) -> Dict[str, Any]:
     """Return the current user's saved settings or defaults if none exist."""
     row = db_conn.execute(
-        "SELECT s.theme, s.categories, s.rules, s.lang, s.specialty, s.payer, s.region, s.use_local_models "
+        "SELECT s.theme, s.categories, s.rules, s.lang, s.specialty, s.payer, s.region, s.use_local_models, s.template "
         "FROM settings s JOIN users u ON s.user_id = u.id WHERE u.username=?",
         (user["sub"],),
     ).fetchone()
@@ -597,6 +598,7 @@ async def get_user_settings(user=Depends(require_role("user"))) -> Dict[str, Any
             specialty=row["specialty"],
             payer=row["payer"],
             region=row["region"] or "",
+            template=row["template"],
             useLocalModels=bool(row["use_local_models"]),
         )
         return settings.dict()
@@ -615,8 +617,8 @@ async def save_user_settings(
     if not row:
         raise HTTPException(status_code=400, detail="User not found")
     db_conn.execute(
-        "INSERT OR REPLACE INTO settings (user_id, theme, categories, rules, lang, specialty, payer, region, use_local_models) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT OR REPLACE INTO settings (user_id, theme, categories, rules, lang, specialty, payer, region, use_local_models, template) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (
             row["id"],
             model.theme,
@@ -627,6 +629,7 @@ async def save_user_settings(
             model.payer,
             model.region,
             int(model.useLocalModels),
+            model.template,
         ),
     )
 
@@ -1065,24 +1068,26 @@ def save_prompt_templates(
 
 @app.get("/templates", response_model=List[TemplateModel])
 def get_templates(
-    specialty: Optional[str] = None, user=Depends(require_role("user"))
+    specialty: Optional[str] = None,
+    payer: Optional[str] = None,
+    user=Depends(require_role("user")),
 ) -> List[TemplateModel]:
-    """Return templates for the current user and clinic, optionally filtered by specialty."""
+    """Return templates for the current user and clinic, optionally filtered by specialty or payer."""
 
     clinic = user.get("clinic")
     cursor = db_conn.cursor()
+    base_query = (
+        "SELECT id, name, content, specialty, payer FROM templates "
+        "WHERE (user=? OR (user IS NULL AND clinic=?))"
+    )
+    params: List[Any] = [user["sub"], clinic]
     if specialty:
-        rows = cursor.execute(
-            "SELECT id, name, content, specialty FROM templates "
-            "WHERE (user=? OR (user IS NULL AND clinic=?)) AND specialty=?",
-            (user["sub"], clinic, specialty),
-        ).fetchall()
-    else:
-        rows = cursor.execute(
-            "SELECT id, name, content, specialty FROM templates "
-            "WHERE (user=? OR (user IS NULL AND clinic=?))",
-            (user["sub"], clinic),
-        ).fetchall()
+        base_query += " AND specialty=?"
+        params.append(specialty)
+    if payer:
+        base_query += " AND payer=?"
+        params.append(payer)
+    rows = cursor.execute(base_query, params).fetchall()
 
     templates = [
         TemplateModel(
@@ -1090,12 +1095,15 @@ def get_templates(
             name=row["name"],
             content=row["content"],
             specialty=row["specialty"],
+            payer=row["payer"],
         )
         for row in rows
     ]
 
-    for tpl in DEFAULT_TEMPLATES:
+    for tpl in load_builtin_templates():
         if specialty and tpl.specialty != specialty:
+            continue
+        if payer and tpl.payer != payer:
             continue
         templates.append(tpl)
 
@@ -1112,13 +1120,17 @@ def create_template(
     owner = None if user.get("role") == "admin" else user["sub"]
     cursor = db_conn.cursor()
     cursor.execute(
-        "INSERT INTO templates (user, clinic, specialty, name, content) VALUES (?, ?, ?, ?, ?)",
-        (owner, clinic, tpl.specialty, tpl.name, tpl.content),
+        "INSERT INTO templates (user, clinic, specialty, payer, name, content) VALUES (?, ?, ?, ?, ?, ?)",
+        (owner, clinic, tpl.specialty, tpl.payer, tpl.name, tpl.content),
     )
     db_conn.commit()
     tpl_id = cursor.lastrowid
     return TemplateModel(
-        id=tpl_id, name=tpl.name, content=tpl.content, specialty=tpl.specialty
+        id=tpl_id,
+        name=tpl.name,
+        content=tpl.content,
+        specialty=tpl.specialty,
+        payer=tpl.payer,
     )
 
 
@@ -1132,20 +1144,39 @@ def update_template(
     cursor = db_conn.cursor()
     if user.get("role") == "admin":
         cursor.execute(
-            "UPDATE templates SET name=?, content=?, specialty=? "
+            "UPDATE templates SET name=?, content=?, specialty=?, payer=? "
             "WHERE id=? AND (user=? OR (user IS NULL AND clinic=?))",
-            (tpl.name, tpl.content, tpl.specialty, template_id, user["sub"], clinic),
+            (
+                tpl.name,
+                tpl.content,
+                tpl.specialty,
+                tpl.payer,
+                template_id,
+                user["sub"],
+                clinic,
+            ),
         )
     else:
         cursor.execute(
-            "UPDATE templates SET name=?, content=?, specialty=? WHERE id=? AND user=?",
-            (tpl.name, tpl.content, tpl.specialty, template_id, user["sub"]),
+            "UPDATE templates SET name=?, content=?, specialty=?, payer=? WHERE id=? AND user=?",
+            (
+                tpl.name,
+                tpl.content,
+                tpl.specialty,
+                tpl.payer,
+                template_id,
+                user["sub"],
+            ),
         )
     db_conn.commit()
     if cursor.rowcount == 0:
         raise HTTPException(status_code=404, detail="Template not found")
     return TemplateModel(
-        id=template_id, name=tpl.name, content=tpl.content, specialty=tpl.specialty
+        id=template_id,
+        name=tpl.name,
+        content=tpl.content,
+        specialty=tpl.specialty,
+        payer=tpl.payer,
     )
 
 

--- a/backend/migrations.py
+++ b/backend/migrations.py
@@ -19,6 +19,7 @@ def ensure_settings_table(conn: sqlite3.Connection) -> None:
         "specialty TEXT,"
         "payer TEXT,"
         "region TEXT,"
+        "template INTEGER,"
         "FOREIGN KEY(user_id) REFERENCES users(id)"
         ")"
     )
@@ -45,6 +46,8 @@ def ensure_settings_table(conn: sqlite3.Connection) -> None:
         conn.execute(
             "ALTER TABLE settings ADD COLUMN use_local_models INTEGER NOT NULL DEFAULT 0"
         )
+    if "template" not in columns:
+        conn.execute("ALTER TABLE settings ADD COLUMN template INTEGER")
 
     conn.commit()
 
@@ -56,6 +59,7 @@ def ensure_templates_table(conn: sqlite3.Connection) -> None:
         "user TEXT,"
         "clinic TEXT,"
         "specialty TEXT,"
+        "payer TEXT,"
         "name TEXT,"
         "content TEXT"
         ")"
@@ -64,4 +68,6 @@ def ensure_templates_table(conn: sqlite3.Connection) -> None:
     columns = {row[1] for row in conn.execute("PRAGMA table_info(templates)")}
     if "specialty" not in columns:
         conn.execute("ALTER TABLE templates ADD COLUMN specialty TEXT")
+    if "payer" not in columns:
+        conn.execute("ALTER TABLE templates ADD COLUMN payer TEXT")
     conn.commit()

--- a/backend/prompt_templates.json
+++ b/backend/prompt_templates.json
@@ -129,5 +129,47 @@
         "en": "Follow Aetna summary requirements."
       }
     }
+  },
+  "note_templates": {
+    "default": [
+      {
+        "name": "SOAP Note Template",
+        "content": "Subjective: \n\nObjective: \n\nAssessment: \n\nPlan: "
+      }
+    ],
+    "specialty": {
+      "pediatrics": [
+        {
+          "name": "Pediatric Visit",
+          "content": "Chief Complaint:\nHistory of Present Illness:\nAssessment/Plan:\n"
+        }
+      ],
+      "geriatrics": [
+        {
+          "name": "Geriatric Assessment",
+          "content": "Chief Complaint:\nFunctional Status:\nAssessment/Plan:\n"
+        }
+      ],
+      "psychiatry": [
+        {
+          "name": "Psychiatry Evaluation",
+          "content": "Chief Complaint:\nMental Status Exam:\nAssessment/Plan:\n"
+        }
+      ],
+      "cardiology": [
+        {
+          "name": "Cardiology Consultation",
+          "content": "Chief Complaint:\nCardiac History:\nAssessment/Plan:\n"
+        }
+      ]
+    },
+    "payer": {
+      "medicare": [
+        {
+          "name": "Medicare Follow-up",
+          "content": "Chief Complaint:\nMedicare Requirements:\nAssessment/Plan:\n"
+        }
+      ]
+    }
   }
 }

--- a/backend/templates.py
+++ b/backend/templates.py
@@ -1,33 +1,62 @@
 from typing import Optional, List
 from pydantic import BaseModel
 
+from . import prompts as prompt_utils
+
 
 class TemplateModel(BaseModel):
-    """Schema for note templates that can be filtered by specialty."""
+    """Schema for note templates that can be filtered by specialty or payer."""
 
     id: Optional[int] = None
     name: str
     content: str
     specialty: Optional[str] = None
+    payer: Optional[str] = None
 
 
-DEFAULT_TEMPLATES: List[TemplateModel] = [
-    TemplateModel(
-        id=-1,
-        name="Pediatric Visit",
-        content="Chief Complaint:\nHistory of Present Illness:\nAssessment/Plan:\n",
-        specialty="pediatrics",
-    ),
-    TemplateModel(
-        id=-2,
-        name="Geriatric Assessment",
-        content="Chief Complaint:\nFunctional Status:\nAssessment/Plan:\n",
-        specialty="geriatrics",
-    ),
-    TemplateModel(
-        id=-3,
-        name="Psychiatry Evaluation",
-        content="Chief Complaint:\nMental Status Exam:\nAssessment/Plan:\n",
-        specialty="psychiatry",
-    ),
-]
+def load_builtin_templates() -> List[TemplateModel]:
+    """Load note templates defined in prompt_templates.json.
+
+    Templates are specified under the ``note_templates`` section and grouped
+    by ``default``, ``specialty`` and ``payer`` keys.  Each template returned
+    receives a negative id so it does not conflict with database identifiers.
+    """
+
+    data = prompt_utils._load_custom_templates().get("note_templates", {})
+    templates: List[TemplateModel] = []
+    next_id = -1
+
+    for tpl in data.get("default", []):
+        templates.append(
+            TemplateModel(id=next_id, name=tpl["name"], content=tpl["content"])
+        )
+        next_id -= 1
+
+    for spec, items in data.get("specialty", {}).items():
+        for tpl in items:
+            templates.append(
+                TemplateModel(
+                    id=next_id,
+                    name=tpl["name"],
+                    content=tpl["content"],
+                    specialty=spec,
+                    payer=tpl.get("payer"),
+                )
+            )
+            next_id -= 1
+
+    for payer, items in data.get("payer", {}).items():
+        for tpl in items:
+            templates.append(
+                TemplateModel(
+                    id=next_id,
+                    name=tpl["name"],
+                    content=tpl["content"],
+                    payer=payer,
+                    specialty=tpl.get("specialty"),
+                )
+            )
+            next_id -= 1
+
+    return templates
+

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import {
   logEvent,
   summarizeNote,
   getSettings,
+  saveSettings,
   refreshAccessToken,
 } from './api.js';
 import Sidebar from './components/Sidebar.jsx';
@@ -138,6 +139,7 @@ function App() {
     rules: [],
     region: '',
     useLocalModels: false,
+    template: null,
   };
   // User settings controlling theme and which suggestion categories are enabled.
   const [settingsState, setSettingsState] = useState(defaultSettings);
@@ -145,6 +147,16 @@ function App() {
   // Function to update settings
   const updateSettings = (newSettings) => {
     setSettingsState(newSettings);
+  };
+
+  const handleDefaultTemplateChange = async (tplId) => {
+    const newSettings = { ...settingsState, template: tplId };
+    setSettingsState(newSettings);
+    try {
+      await saveSettings(newSettings);
+    } catch (e) {
+      console.error('Failed to save template selection', e);
+    }
   };
 
   const logout = () => {
@@ -650,6 +662,10 @@ function App() {
                       value={draftText}
                       onChange={handleDraftChange}
                       onTranscriptChange={handleTranscriptChange}
+                      specialty={settingsState.specialty}
+                      payer={settingsState.payer}
+                      defaultTemplateId={settingsState.template}
+                      onTemplateChange={handleDefaultTemplateChange}
                       error={transcriptionError}
                       templateContext={templateContext}
                       suggestionContext={suggestionContext}

--- a/src/__tests__/NoteEditor.test.jsx
+++ b/src/__tests__/NoteEditor.test.jsx
@@ -30,24 +30,27 @@ afterEach(() => {
 });
 
 test('transcript persists across reloads', async () => {
-  const { findByText, unmount } = render(
+  const { findByText, getByText, unmount } = render(
     <NoteEditor id="n1" value="" onChange={() => {}} />
   );
+  fireEvent.click(getByText('Transcript:'));
   await findByText(/Provider:/);
   expect(fetchLastTranscript).toHaveBeenCalledTimes(1);
   unmount();
-  const { findByText: findByText2 } = render(
+  const { findByText: findByText2, getByText: getByText2 } = render(
     <NoteEditor id="n1" value="" onChange={() => {}} />
   );
+  fireEvent.click(getByText2('Transcript:'));
   await findByText2(/Provider:/);
   expect(fetchLastTranscript).toHaveBeenCalledTimes(2);
 });
 
 test('shows diarised output when available', async () => {
   fetchLastTranscript.mockResolvedValue({ provider: 'Doc', patient: 'Pat' });
-  const { findByText } = render(
+  const { findByText, getByText } = render(
     <NoteEditor id="n2" value="" onChange={() => {}} />
   );
+  fireEvent.click(getByText('Transcript:'));
   await findByText(/Provider:/);
   await findByText(/Patient:/);
 });

--- a/src/api.js
+++ b/src/api.js
@@ -173,6 +173,7 @@ export async function getSettings(token) {
     specialty: data.specialty || '',
     payer: data.payer || '',
     region: data.region || '',
+    template: data.template || null,
     useLocalModels: data.useLocalModels || false,
   };
 }
@@ -207,6 +208,7 @@ export async function saveSettings(settings, token) {
     specialty: settings.specialty || null,
     payer: settings.payer || null,
     region: settings.region || '',
+    template: settings.template || null,
     useLocalModels: settings.useLocalModels || false,
   };
   const resp = await fetch(`${baseUrl}/settings`, {
@@ -232,6 +234,7 @@ export async function saveSettings(settings, token) {
     specialty: data.specialty || '',
     payer: data.payer || '',
     region: data.region || '',
+    template: data.template || null,
     useLocalModels: data.useLocalModels || false,
   };
 }
@@ -628,7 +631,7 @@ export async function getMetrics(filters = {}) {
  * Returns an empty array if the backend is unreachable.
  * @returns {Promise<Array<{id:number,name:string,content:string}>>}
  */
-export async function getTemplates(specialty) {
+export async function getTemplates(specialty, payer) {
   const baseUrl =
     import.meta?.env?.VITE_API_URL ||
     window.__BACKEND_URL__ ||
@@ -637,7 +640,10 @@ export async function getTemplates(specialty) {
   const token =
     typeof window !== 'undefined' ? localStorage.getItem('token') : null;
   const headers = token ? { Authorization: `Bearer ${token}` } : {};
-  const query = specialty ? `?specialty=${encodeURIComponent(specialty)}` : '';
+  const params = new URLSearchParams();
+  if (specialty) params.append('specialty', specialty);
+  if (payer) params.append('payer', payer);
+  const query = params.toString() ? `?${params.toString()}` : '';
   const resp = await fetch(`${baseUrl}/templates${query}`, { headers });
   if (resp.status === 401 || resp.status === 403) {
     throw new Error('Unauthorized');

--- a/src/components/NoteEditor.jsx
+++ b/src/components/NoteEditor.jsx
@@ -91,7 +91,17 @@ function useAudioRecorder(onTranscribed) {
 }
 
 const NoteEditor = forwardRef(function NoteEditor(
-  { id, value, onChange, onTranscriptChange, mode = 'draft' },
+  {
+    id,
+    value,
+    onChange,
+    onTranscriptChange,
+    mode = 'draft',
+    specialty,
+    payer,
+    defaultTemplateId,
+    onTemplateChange,
+  },
   ref,
 ) {
   const { t } = useTranslation();
@@ -99,6 +109,7 @@ const NoteEditor = forwardRef(function NoteEditor(
   const [history, setHistory] = useState(value ? [value] : []);
   const [historyIndex, setHistoryIndex] = useState(value ? 0 : -1);
   const [templates, setTemplates] = useState([]);
+  const [sideTab, setSideTab] = useState('templates');
   const [transcript, setTranscript] = useState({ provider: '', patient: '' });
   const [segments, setSegments] = useState([]);
   const [audioUrl, setAudioUrl] = useState('');
@@ -128,15 +139,26 @@ const NoteEditor = forwardRef(function NoteEditor(
     });
   }, [value, mode]);
 
-  let mounted = true;
   useEffect(() => {
-    getTemplates()
-      .then((tpls) => mounted && setTemplates(tpls))
-      .catch(() => mounted && setTemplates([]));
+    let active = true;
+    getTemplates(specialty, payer)
+      .then((tpls) => {
+        if (!active) return;
+        setTemplates(tpls);
+        if (!value && defaultTemplateId) {
+          const tpl = tpls.find(
+            (t) => String(t.id) === String(defaultTemplateId),
+          );
+          if (tpl) insertText(tpl.content);
+        }
+      })
+      .catch(() => {
+        if (active) setTemplates([]);
+      });
     return () => {
-      mounted = false;
+        active = false;
     };
-  }, []);
+  }, [specialty, payer, defaultTemplateId]);
 
   const loadTranscript = async () => {
     setLoadingTranscript(true);
@@ -197,11 +219,9 @@ const NoteEditor = forwardRef(function NoteEditor(
   };
 
   useImperativeHandle(ref, () => ({ insertAtCursor: insertText }));
-
-  const handleTemplateSelect = (e) => {
-    const tpl = templates.find((t) => String(t.id) === e.target.value);
-    if (tpl) insertText(tpl.content);
-    e.target.value = '';
+  const handleTemplateClick = (tpl) => {
+    insertText(tpl.content);
+    if (onTemplateChange) onTemplateChange(tpl.id);
   };
 
   const {
@@ -241,38 +261,18 @@ const NoteEditor = forwardRef(function NoteEditor(
     if (seg) setCurrentSpeaker(seg.speaker);
   };
 
-  const groupedTemplates = templates.reduce((acc, tpl) => {
-    const key = tpl.specialty || 'General';
-    (acc[key] ||= []).push(tpl);
-    return acc;
-  }, {});
-
-  const templateChooser = templates.length ? (
-    <select
-      aria-label={t('app.templates')}
-      defaultValue=""
-      onChange={handleTemplateSelect}
-      style={{ marginBottom: '0.5rem' }}
-    >
-      <option value="">{t('app.templates')}</option>
-      {Object.entries(groupedTemplates).map(([spec, tpls]) => (
-        <optgroup key={spec} label={spec}>
-          {tpls.map((tpl) => (
-            <option key={tpl.id} value={tpl.id}>
-              {tpl.name}
-            </option>
-          ))}
-        </optgroup>
+  const templateList = templates.length ? (
+    <ul style={{ listStyle: 'none', paddingLeft: 0 }}>
+      {templates.map((tpl) => (
+        <li key={tpl.id} style={{ marginBottom: '0.25rem' }}>
+          <button type="button" onClick={() => handleTemplateClick(tpl)}>
+            {tpl.name}
+          </button>
+        </li>
       ))}
-    </select>
+    </ul>
   ) : (
-    <select
-      aria-label={t('app.templates')}
-      disabled
-      style={{ marginBottom: '0.5rem' }}
-    >
-      <option>{t('settings.noTemplates')}</option>
-    </select>
+    <p>{t('settings.noTemplates')}</p>
   );
 
   const recordingSupported =
@@ -380,6 +380,38 @@ const NoteEditor = forwardRef(function NoteEditor(
       </div>
     ) : null;
 
+  const sidebar = (
+    <div style={{ width: '200px', marginLeft: '0.5rem' }}>
+      <div style={{ marginBottom: '0.5rem' }}>
+        <button
+          type="button"
+          onClick={() => setSideTab('templates')}
+          disabled={sideTab === 'templates'}
+        >
+          {t('app.templates')}
+        </button>
+        <button
+          type="button"
+          onClick={() => setSideTab('transcript')}
+          disabled={sideTab === 'transcript'}
+          style={{ marginLeft: '0.5rem' }}
+        >
+          {t('noteEditor.transcript')}
+        </button>
+      </div>
+      <div>
+        {sideTab === 'templates' ? (
+          templateList
+        ) : (
+          <div>
+            {segmentList}
+            {transcriptControls}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
   const handleUndo = () => {
     setHistoryIndex((idx) => {
       if (idx <= 0) return idx;
@@ -453,16 +485,47 @@ const NoteEditor = forwardRef(function NoteEditor(
 
   if (ReactQuill) {
     return (
-      <div style={{ height: '100%', width: '100%' }}>
+      <div style={{ display: 'flex', height: '100%', width: '100%' }}>
+        <div style={{ flex: 1 }}>
+          {audioControls}
+          <ReactQuill
+            ref={quillRef}
+            id={id}
+            theme="snow"
+            value={value}
+            formats={quillFormats}
+            style={{ height: '100%', width: '100%' }}
+          />
+          {audioUrl && (
+            <audio
+              ref={audioRef}
+              src={audioUrl}
+              controls
+              onTimeUpdate={handleTimeUpdate}
+              style={{ width: '100%', marginTop: '0.5rem' }}
+            />
+          )}
+          {(recorderError || fetchError) && (
+            <p style={{ color: 'red' }}>{recorderError || fetchError}</p>
+          )}
+          {loadingTranscript && <p>{t('noteEditor.loadingTranscript')}</p>}
+        </div>
+        {sidebar}
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', width: '100%', height: '100%' }}>
+      <div style={{ flex: 1 }}>
         {audioControls}
-        {templateChooser}
-        <ReactQuill
-          ref={quillRef}
+        <textarea
+          ref={textAreaRef}
           id={id}
-          theme="snow"
-          value={value}
-          formats={quillFormats}
-          style={{ height: '100%', width: '100%' }}
+          value={localValue}
+          onChange={handleTextAreaChange}
+          style={{ width: '100%', height: '100%', padding: '0.5rem' }}
+          placeholder={t('noteEditor.placeholder')}
         />
         {audioUrl && (
           <audio
@@ -473,43 +536,12 @@ const NoteEditor = forwardRef(function NoteEditor(
             style={{ width: '100%', marginTop: '0.5rem' }}
           />
         )}
-        {segmentList}
-        {transcriptControls}
         {(recorderError || fetchError) && (
           <p style={{ color: 'red' }}>{recorderError || fetchError}</p>
         )}
         {loadingTranscript && <p>{t('noteEditor.loadingTranscript')}</p>}
       </div>
-    );
-  }
-
-  return (
-    <div style={{ width: '100%', height: '100%' }}>
-      {audioControls}
-      {templateChooser}
-      <textarea
-        ref={textAreaRef}
-        id={id}
-        value={localValue}
-        onChange={handleTextAreaChange}
-        style={{ width: '100%', height: '100%', padding: '0.5rem' }}
-        placeholder={t('noteEditor.placeholder')}
-      />
-      {audioUrl && (
-        <audio
-          ref={audioRef}
-          src={audioUrl}
-          controls
-          onTimeUpdate={handleTimeUpdate}
-          style={{ width: '100%', marginTop: '0.5rem' }}
-        />
-      )}
-      {segmentList}
-      {transcriptControls}
-      {(recorderError || fetchError) && (
-        <p style={{ color: 'red' }}>{recorderError || fetchError}</p>
-      )}
-      {loadingTranscript && <p>{t('noteEditor.loadingTranscript')}</p>}
+      {sidebar}
     </div>
   );
 });

--- a/src/components/__tests__/NoteEditor.test.jsx
+++ b/src/components/__tests__/NoteEditor.test.jsx
@@ -62,9 +62,9 @@ test('selecting template inserts content', async () => {
     const [val, setVal] = useState('');
     return <NoteEditor id="t" value={val} onChange={setVal} />;
   }
-  const { findByLabelText, container } = render(<Wrapper />);
-  const select = await findByLabelText('Templates');
-  fireEvent.change(select, { target: { value: '1' } });
+  const { findByText, container } = render(<Wrapper />);
+  const btn = await findByText('Tpl');
+  fireEvent.click(btn);
   const editor = container.querySelector('.ql-editor');
   await waitFor(() => expect(editor.innerHTML).toContain('Hello'));
 });
@@ -77,9 +77,9 @@ test('inserts template and merges audio transcript', async () => {
     return <NoteEditor id="m" value={val} onChange={setVal} />;
   }
 
-  const { findByLabelText, container, findAllByText } = render(<Wrapper />);
-  const select = await findByLabelText('Templates');
-  fireEvent.change(select, { target: { value: '1' } });
+  const { findByText, container, findAllByText } = render(<Wrapper />);
+  const btn = await findByText('Tpl');
+  fireEvent.click(btn);
   const [insertProvider] = await findAllByText('Insert');
   fireEvent.click(insertProvider);
 
@@ -89,6 +89,24 @@ test('inserts template and merges audio transcript', async () => {
     expect(editor.innerHTML).toContain('Hi there');
   });
   fetchLastTranscript.mockResolvedValue({ provider: '', patient: '' });
+});
+
+test('preloads default template', async () => {
+  function Wrapper() {
+    const [val, setVal] = useState('');
+    return (
+      <NoteEditor
+        id="p"
+        value={val}
+        onChange={setVal}
+        defaultTemplateId={1}
+      />
+    );
+  }
+  const { container, findByText } = render(<Wrapper />);
+  await findByText('Tpl');
+  const editor = container.querySelector('.ql-editor');
+  await waitFor(() => expect(editor.innerHTML).toContain('Hello'));
 });
 
 test('maintains beautified history with undo/redo', () => {

--- a/tests/test_settings_persistence.py
+++ b/tests/test_settings_persistence.py
@@ -42,6 +42,7 @@ def test_settings_roundtrip(monkeypatch):
         "specialty": "cardiology",
         "payer": "medicare",
         "region": "us",
+        "template": -1,
     }
 
     resp = client.post(
@@ -57,4 +58,5 @@ def test_settings_roundtrip(monkeypatch):
     assert data["specialty"] == "cardiology"
     assert data["payer"] == "medicare"
     assert data["region"] == "us"
+    assert data["template"] == -1
 

--- a/tests/test_settings_roundtrip.py
+++ b/tests/test_settings_roundtrip.py
@@ -38,6 +38,7 @@ def test_settings_roundtrip(client):
     assert data['lang'] == 'en'
     assert data['specialty'] is None
     assert data['payer'] is None
+    assert data.get('template') is None
 
     new_settings = {
         'theme': 'dark',
@@ -52,6 +53,7 @@ def test_settings_roundtrip(client):
         'specialty': 'cardiology',
         'payer': 'medicare',
         'region': '',
+        'template': -1,
     }
     resp = client.post('/settings', json=new_settings, headers=auth_header(token))
     assert resp.status_code == 200
@@ -65,6 +67,7 @@ def test_settings_roundtrip(client):
     assert data['lang'] == 'es'
     assert data['specialty'] == 'cardiology'
     assert data['payer'] == 'medicare'
+    assert data['template'] == -1
 
 
 def test_invalid_settings_rejected(client):

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -9,7 +9,7 @@ def setup_module(module):
     main.db_conn = sqlite3.connect(":memory:", check_same_thread=False)
     main.db_conn.row_factory = sqlite3.Row
     main.db_conn.execute(
-        "CREATE TABLE templates (id INTEGER PRIMARY KEY AUTOINCREMENT, user TEXT, clinic TEXT, specialty TEXT, name TEXT, content TEXT)"
+        "CREATE TABLE templates (id INTEGER PRIMARY KEY AUTOINCREMENT, user TEXT, clinic TEXT, specialty TEXT, payer TEXT, name TEXT, content TEXT)"
     )
     main.db_conn.commit()
 
@@ -31,6 +31,17 @@ def test_builtin_template_filter():
     )
     data = resp.json()
     assert data and all(t["specialty"] == "psychiatry" for t in data)
+
+
+def test_builtin_template_payer_filter():
+    client = TestClient(main.app)
+    token = main.create_token("alice", "user", clinic="clinic1")
+    resp = client.get(
+        "/templates?payer=medicare",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    data = resp.json()
+    assert data and all(t.get("payer") == "medicare" for t in data)
 
 
 def test_create_update_and_list_templates():


### PR DESCRIPTION
## Summary
- define specialty and payer note templates in prompt templates file
- expose `/templates` endpoint and persist default template in settings
- add template sidebar in editor with default loading

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893a8c4fc888324ba58351f36c3f6c0