### PR TITLE
Remove redundant deque import

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -55,7 +55,6 @@ from .scheduling import recommend_follow_up, export_ics
 import json
 import sqlite3
 import hashlib
-from collections import deque
 
 from .auth import (
     authenticate_user,


### PR DESCRIPTION
## Summary
- remove duplicate `from collections import deque` import in `backend/main.py`

## Testing
- `python -m flake8 backend/main.py --select=F401 --extend-ignore=E999`
- `pytest tests/test_beautify.py::test_beautify_spanish -q` *(fails: IndentationError: unexpected indent)*

------
https://chatgpt.com/codex/tasks/task_e_6893b24a294083248a101b9b3a51cb37