### PR TITLE
docs: finalize packaging and distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,10 +299,10 @@ deploy RevenuePilot, consider the following steps:
    improve coding accuracy.
 
 5. **Secure and scale**: Implement authentication, persist analytics
-   events to a database, and wrap the app in Electron using
-   `electron-builder` when you’re ready to distribute a desktop version.
-   Remember to maintain HIPAA compliance by de‑identifying notes before
-   sending them to any external API.
+   events to a database, and consult the packaging guide to produce
+   signed installers via `electron-builder` when distributing a desktop
+   version. Remember to maintain HIPAA compliance by de‑identifying notes
+   before sending them to any external API.
 
 ### De-identification assumptions
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -43,7 +43,7 @@ This document provides a high‑level overview of the components that make up th
 
 ## Deployment Notes
 
-The current repository is designed for local development.  The `start.sh` script (or `start.ps1` on Windows) runs `uvicorn` for the backend on port 8000 and `npm run dev` for the React frontend on port 5173, setting `VITE_API_URL` accordingly.  In production, the frontend can be bundled with Electron and the backend can be packaged with Gunicorn/Uvicorn.  The roadmap includes tasks for Electron packaging, code‑signing, auto‑updates and migration to a full database such as Postgres.
+The current repository is designed for local development.  The `start.sh` script (or `start.ps1` on Windows) runs `uvicorn` for the backend on port 8000 and `npm run dev` for the React frontend on port 5173, setting `VITE_API_URL` accordingly.  For distribution, the project provides an Electron builder setup that bundles the frontend with the FastAPI backend, performs code signing and enables auto‑updates.  Production deployments can alternatively package the backend with Gunicorn/Uvicorn.  Future work will migrate the embedded SQLite database to a full database such as Postgres.
 
 ## Customising Prompt Templates
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,7 +8,6 @@ This roadmap reflects the outstanding bugs, missing features and future enhancem
 - **Advanced PHI Scrubbing:** Upgrade `backend/main.py`’s `deidentify` function to a ML‑based scrubber that detects names, dates and other PHI beyond simple regexes.  Consider integrating a library such as Philter.
 - **Role‑Based Authentication:** Implement a simple login with JWT tokens.  Distinguish clinician and admin roles and restrict sensitive endpoints (e.g. `/metrics`, `/events`) to authorised users.
 - **Analytics Visualisation:** Expand `Dashboard.jsx` to render time‑series charts for each metric using Chart.js or Recharts.  Enhance `/metrics` to return aggregated data by day/week.
-- **Packaging & Distribution:** Create an Electron builder configuration, handle code signing and implement an auto‑update mechanism.  Ensure the backend is bundled alongside the frontend.
 - **Test Coverage:** Establish unit and integration tests for both backend and frontend.  Cover all endpoints, UI flows and edge cases.  Integrate `pytest`, `pytest‑asyncio`, `pytest‑cov` and React Testing Library.
 
 ## P1 – Important Enhancements


### PR DESCRIPTION
## Summary
- Document Electron packaging, code signing, and auto-update support in architecture guide
- Remove Packaging & Distribution from P0 roadmap and point README to packaging instructions

## Testing
- `npm test`
- `pytest` *(fails: IndentationError in backend/main.py)*

------
https://chatgpt.com/codex/tasks/task_e_6893b349c4588324935047ca04110cda