### PR TITLE
feat: enhance PHI scrubbing and docs

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -46,7 +46,7 @@ from platformdirs import user_data_dir
 from .audio_processing import simple_transcribe, diarize_and_transcribe
 from . import public_health as public_health_api
 from .migrations import ensure_settings_table, ensure_templates_table
-from .templates import TemplateModel, load_builtin_templates, DEFAULT_TEMPLATES
+from .templates import TemplateModel, load_builtin_templates
 from .scheduling import recommend_follow_up, export_ics
 
 
@@ -268,6 +268,13 @@ get_api_key()
 # required to enable them, keeping the behaviour simple out of the box.  Tests
 # may monkeypatch ``_PRESIDIO_AVAILABLE`` or ``_PHILTER_AVAILABLE`` to force the
 # fallback implementation when these optional dependencies are missing.
+if _DEID_ENGINE == "regex":
+    if _PRESIDIO_AVAILABLE:
+        _DEID_ENGINE = "presidio"
+    elif _PHILTER_AVAILABLE:
+        _DEID_ENGINE = "philter"
+    elif _SCRUBBER_AVAILABLE:
+        _DEID_ENGINE = "scrubadub"
 
 # ---------------------------------------------------------------------------
 # JWT authentication helpers
@@ -803,6 +810,13 @@ def deidentify(text: str) -> str:
                 "MEDICAL_RECORD",
             ]
             results = _analyzer.analyze(text=text, language="en", entities=entities)
+            # Remove nested results (e.g., URL inside EMAIL_ADDRESS) to avoid
+            # replacing overlapping spans twice.
+            filtered: List[Any] = []
+            for r in sorted(results, key=lambda r: (r.start, -r.end)):
+                if any(f.start <= r.start and r.end <= f.end for f in filtered):
+                    continue
+                filtered.append(r)
             token_map = {
                 "PERSON": "NAME",
                 "PHONE_NUMBER": "PHONE",
@@ -814,7 +828,7 @@ def deidentify(text: str) -> str:
                 "URL": "URL",
                 "MEDICAL_RECORD": "MRN",
             }
-            for r in sorted(results, key=lambda r: r.start, reverse=True):
+            for r in sorted(filtered, key=lambda r: r.start, reverse=True):
                 token = token_map.get(r.entity_type, r.entity_type)
                 value = text[r.start : r.end]
                 text = text[: r.start] + _placeholder(token, value) + text[r.end :]
@@ -838,6 +852,9 @@ def deidentify(text: str) -> str:
             filths = list(scrubber.iter_filth(text))
             for filth in sorted(filths, key=lambda f: f.beg, reverse=True):
                 token = filth.__class__.__name__.replace("Filth", "").upper()
+                token = {"EMAILADDRESS": "EMAIL", "IPADDRESS": "IP"}.get(
+                    token, token
+                )
                 text = (
                     text[: filth.beg]
                     + _placeholder(token, filth.text)
@@ -2197,12 +2214,6 @@ async def suggest(
                         public_health.append(
                             PublicHealthSuggestion(recommendation=str(rec))
                         )
-        follow_up = recommend_follow_up(cleaned, [c.code for c in codes])
-
-                if rec not in existing:
-                    public_health.append(
-                        PublicHealthSuggestion(recommendation=rec, reason=None)
-                    )
         follow_up = recommend_follow_up(
             [c.code for c in codes],
             [d.diagnosis for d in diffs],

--- a/docs/CHAT_ARCHIVE.md
+++ b/docs/CHAT_ARCHIVE.md
@@ -18,7 +18,7 @@ The `rp_chats` archive contained a set of planning documents and business discus
 
 ## Key Design Choices
 
-- **Local de‑identification:** Before any LLM call, the note is scrubbed of phone numbers, dates, emails, SSNs, addresses and capitalised names using regular expressions.  This prevents PHI leakage【565843205015217†screenshot】.
+- **Local de‑identification:** Before any LLM call, the note is scrubbed of phone numbers, dates, emails, SSNs, addresses and capitalised names using optional ML‑based engines (Presidio, Philter or scrubadub) with a regex fallback.  This prevents PHI leakage【565843205015217†screenshot】.
 - **Prompt discipline:** System messages instruct the model to adhere to the SOAP structure, restrict output to JSON, limit the number of codes/differentials and avoid hallucination.  Custom clinical rules entered by the user are appended to the prompt.
 - **Per‑call API key lookup:** The OpenAI key is read from `openai_key.txt` on each request.  This avoids server restarts when the key changes and simplifies packaging.
 - **SQLite analytics:** A zero‑configuration database records events.  The roadmap notes that the design can later migrate to Postgres or Redis for scalability【565843205015217†screenshot】.
@@ -38,7 +38,6 @@ The `rp_chats` archive contained a set of planning documents and business discus
 The archive identifies several unfinished or missing capabilities that need prioritisation:
 
 - **Speech‑to‑text & diarisation:** `audio_processing.py` contains stubs; the roadmap calls for integrating Whisper or a similar model and adding a `/transcribe` endpoint.
-- **Advanced PHI scrubbing:** The current regex‑based de‑identifier misses names and dates in many formats.  An ML‑based scrubber or library such as Philter is suggested【565843205015217†screenshot】.
 - **Role‑based authentication:** There is no login or user management.  A simple JWT‑based auth system is proposed to distinguish clinicians from admins.
 - **Analytics visualisation:** The dashboard currently displays counts only.  Charts (e.g. time‑series graphs) should be implemented using a library like Chart.js.
 - **Packaging:** The project needs an Electron builder config, code signing and auto‑update pipeline before distribution【447379025536466†screenshot】.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,7 +5,6 @@ This roadmap reflects the outstanding bugs, missing features and future enhancem
 ## P0 – Blockers
 
 - **Speech‑to‑Text & Diarisation:** Replace the stubs in `backend/audio_processing.py` with real transcription (e.g. OpenAI Whisper) and speaker separation.  Expose a `/transcribe` endpoint and update the UI to display transcripts.
-- **Advanced PHI Scrubbing:** Upgrade `backend/main.py`’s `deidentify` function to a ML‑based scrubber that detects names, dates and other PHI beyond simple regexes.  Consider integrating a library such as Philter.
 - **Role‑Based Authentication:** Implement a simple login with JWT tokens.  Distinguish clinician and admin roles and restrict sensitive endpoints (e.g. `/metrics`, `/events`) to authorised users.
 - **Analytics Visualisation:** Expand `Dashboard.jsx` to render time‑series charts for each metric using Chart.js or Recharts.  Enhance `/metrics` to return aggregated data by day/week.
 - **Packaging & Distribution:** Create an Electron builder configuration, handle code signing and implement an auto‑update mechanism.  Ensure the backend is bundled alongside the frontend.


### PR DESCRIPTION
## Summary
- auto-select available PHI scrubbing backends and normalize scrubadub tokens
- handle overlapping Presidio entities to avoid partial replacements
- document that PHI scrubbing is now powered by optional ML engines and remove it from the roadmap

## Testing
- `pytest` *(fails: tests/test_api_endpoints.py::test_login_and_settings, tests/test_api_endpoints.py::test_suggest_and_fallback, tests/test_api_endpoints.py::test_suggest_returns_follow_up, tests/test_api_endpoints.py::test_suggest_with_demographics, tests/test_api_endpoints.py::test_suggest_includes_public_health_from_api, tests/test_api_endpoints.py::test_suggest_parses_public_health_reason, tests/test_scheduling.py::test_chronic_code_interval, tests/test_scheduling.py::test_acute_code_interval, tests/test_scheduling.py::test_code_specific_intervals, tests/test_scheduling.py::test_schedule_endpoint, tests/test_settings_persistence.py::test_settings_roundtrip, tests/test_settings_roundtrip.py::test_settings_roundtrip)*

------
https://chatgpt.com/codex/tasks/task_e_6893b2eed2748324ba39fd5c19d8954d