### PR TITLE
test: add Sidebar coverage

### DIFF
--- a/src/components/__tests__/Sidebar.test.jsx
+++ b/src/components/__tests__/Sidebar.test.jsx
@@ -1,0 +1,43 @@
+/* @vitest-environment jsdom */
+import { render, fireEvent } from '@testing-library/react';
+import { vi, expect, test } from 'vitest';
+import '../../i18n.js';
+import Sidebar from '../Sidebar.jsx';
+
+test('renders user navigation and handles actions', () => {
+  const onNavigate = vi.fn();
+  const toggleCollapsed = vi.fn();
+  const onLogout = vi.fn();
+  const { getByText, getByTitle, queryByText } = render(
+    <Sidebar
+      collapsed={false}
+      toggleCollapsed={toggleCollapsed}
+      onNavigate={onNavigate}
+      role="user"
+      onLogout={onLogout}
+    />
+  );
+  fireEvent.click(getByText('Notes'));
+  expect(onNavigate).toHaveBeenCalledWith('note');
+  expect(queryByText('Users')).toBeNull();
+  fireEvent.click(getByTitle('Collapse sidebar'));
+  expect(toggleCollapsed).toHaveBeenCalled();
+  fireEvent.click(getByText('Logout'));
+  expect(onLogout).toHaveBeenCalled();
+});
+
+test('shows admin link and collapsed state', () => {
+  const { getByText, getByTitle, container } = render(
+    <Sidebar
+      collapsed={true}
+      toggleCollapsed={() => {}}
+      onNavigate={() => {}}
+      role="admin"
+      onLogout={() => {}}
+    />
+  );
+  expect(getByText('Users')).toBeTruthy();
+  expect(container.firstChild.className).toContain('collapsed');
+  expect(getByTitle('Expand sidebar')).toBeTruthy();
+});
+


### PR DESCRIPTION
## Summary
- add comprehensive tests for the Sidebar component
- ensure navigation, collapse toggle, admin branch, and logout paths are exercised

## Testing
- `npm test`
- `pip install -r backend/requirements.txt`
- `pytest` *(fails: 15 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6893b37566b08324873e01cd2517e6c4