### PR TITLE
Add summary language to settings

### DIFF
--- a/backend/migrations.py
+++ b/backend/migrations.py
@@ -16,10 +16,13 @@ def ensure_settings_table(conn: sqlite3.Connection) -> None:
         "categories TEXT NOT NULL DEFAULT '{}',"
         "rules TEXT NOT NULL DEFAULT '[]',"
         "lang TEXT NOT NULL DEFAULT 'en',"
+        "summary_lang TEXT NOT NULL DEFAULT 'en',"
         "specialty TEXT,"
         "payer TEXT,"
         "region TEXT,"
         "template INTEGER,"
+        "use_local_models INTEGER NOT NULL DEFAULT 0,"
+        "agencies TEXT NOT NULL DEFAULT '[]',"
         "FOREIGN KEY(user_id) REFERENCES users(id)"
         ")"
     )
@@ -36,6 +39,10 @@ def ensure_settings_table(conn: sqlite3.Connection) -> None:
         )
     if "lang" not in columns:
         conn.execute("ALTER TABLE settings ADD COLUMN lang TEXT NOT NULL DEFAULT 'en'")
+    if "summary_lang" not in columns:
+        conn.execute(
+            "ALTER TABLE settings ADD COLUMN summary_lang TEXT NOT NULL DEFAULT 'en'"
+        )
     if "specialty" not in columns:
         conn.execute("ALTER TABLE settings ADD COLUMN specialty TEXT")
     if "payer" not in columns:

--- a/tests/test_settings_roundtrip.py
+++ b/tests/test_settings_roundtrip.py
@@ -36,10 +36,13 @@ def test_settings_roundtrip(client):
     assert data['rules'] == []
 
     assert data['lang'] == 'en'
+    assert data['summaryLang'] == 'en'
     assert data['specialty'] is None
     assert data['payer'] is None
     assert data['agencies'] == ['CDC', 'WHO']
     assert data.get('template') is None
+    assert data['region'] == ''
+    assert data['useLocalModels'] is False
 
 
     new_settings = {
@@ -52,11 +55,13 @@ def test_settings_roundtrip(client):
         },
         'rules': ['r1', 'r2'],
         'lang': 'es',
+        'summaryLang': 'fr',
         'specialty': 'cardiology',
         'payer': 'medicare',
-        'region': '',
+        'region': 'US',
         'agencies': ['CDC'],
         'template': -1,
+        'useLocalModels': True,
     }
     resp = client.post('/settings', json=new_settings, headers=auth_header(token))
     assert resp.status_code == 200
@@ -68,10 +73,13 @@ def test_settings_roundtrip(client):
     assert data['categories']['publicHealth'] is False
     assert data['rules'] == ['r1', 'r2']
     assert data['lang'] == 'es'
+    assert data['summaryLang'] == 'fr'
     assert data['specialty'] == 'cardiology'
     assert data['payer'] == 'medicare'
+    assert data['region'] == 'US'
     assert data['agencies'] == ['CDC']
     assert data['template'] == -1
+    assert data['useLocalModels'] is True
 
 
 


### PR DESCRIPTION
## Summary
- persist summary language in backend settings and migrations
- surface summary language through login, retrieval, and save APIs
- test settings roundtrip including summary language and local model toggles

## Testing
- `pytest tests/test_settings_roundtrip.py::test_settings_roundtrip --cov=backend --cov-report=term-missing --cov-fail-under=0 -q`
- `pytest tests/test_settings_persistence.py::test_settings_roundtrip --cov=backend --cov-report=term-missing --cov-fail-under=0 -q`
- `pytest tests/test_auth.py::test_register_and_login --cov=backend --cov-report=term-missing --cov-fail-under=0 -q`
- `pytest tests/test_migrations.py::test_ensure_settings_table_adds_columns --cov=backend --cov-report=term-missing --cov-fail-under=0 -q`


------
https://chatgpt.com/codex/tasks/task_e_6893b857dc54832484a8170c0a0ea4de