### PR TITLE
feat: allow per-endpoint local models

### DIFF
--- a/backend/migrations.py
+++ b/backend/migrations.py
@@ -55,6 +55,13 @@ def ensure_settings_table(conn: sqlite3.Connection) -> None:
     if "template" not in columns:
         conn.execute("ALTER TABLE settings ADD COLUMN template INTEGER")
 
+    if "beautify_model" not in columns:
+        conn.execute("ALTER TABLE settings ADD COLUMN beautify_model TEXT")
+    if "suggest_model" not in columns:
+        conn.execute("ALTER TABLE settings ADD COLUMN suggest_model TEXT")
+    if "summarize_model" not in columns:
+        conn.execute("ALTER TABLE settings ADD COLUMN summarize_model TEXT")
+
 
     conn.commit()
 

--- a/backend/offline_model.py
+++ b/backend/offline_model.py
@@ -55,6 +55,7 @@ def beautify(
     specialty: Optional[str] = None,
     payer: Optional[str] = None,
     use_local: Optional[bool] = None,
+    model_path: Optional[str] = None,
 ) -> str:
     """Beautify ``text`` via llama.cpp or deterministic placeholder."""
 
@@ -62,7 +63,11 @@ def beautify(
         use_local = _use_local()
 
     if use_local:
-        model = os.getenv("LOCAL_BEAUTIFY_MODEL") or os.getenv("LOCAL_LLM_MODEL")
+        model = (
+            model_path
+            or os.getenv("LOCAL_BEAUTIFY_MODEL")
+            or os.getenv("LOCAL_LLM_MODEL")
+        )
         if model and os.path.exists(model):
             try:
                 llm = _get_llama(model)
@@ -91,6 +96,7 @@ def summarize(
     payer: Optional[str] = None,
     patient_age: Optional[int] = None,
     use_local: Optional[bool] = None,
+    model_path: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Summarise ``text`` with a local model or deterministic placeholder."""
 
@@ -98,7 +104,7 @@ def summarize(
         use_local = _use_local()
 
     if use_local:
-        model = os.getenv("LOCAL_SUMMARIZE_MODEL")
+        model = model_path or os.getenv("LOCAL_SUMMARIZE_MODEL")
         if model:
             try:
                 pipe = _get_pipeline("summarization", model)
@@ -130,6 +136,7 @@ def suggest(
     sex: Optional[str] = None,
     region: Optional[str] = None,
     use_local: Optional[bool] = None,
+    model_path: Optional[str] = None,
 ) -> Dict[str, List]:
     """Return suggestions via a local model or deterministic placeholder."""
 
@@ -137,14 +144,20 @@ def suggest(
         use_local = _use_local()
 
     if use_local:
-        model = os.getenv("LOCAL_SUGGEST_MODEL") or os.getenv("LOCAL_LLM_MODEL")
+        model = (
+            model_path
+            or os.getenv("LOCAL_SUGGEST_MODEL")
+            or os.getenv("LOCAL_LLM_MODEL")
+        )
         if model and os.path.exists(model):
             try:
                 llm = _get_llama(model)
                 prompt = (
                     "You are a medical coding assistant. Given the clinical note "
                     "below, reply with JSON containing keys codes, compliance, "
-                    "publicHealth and differentials.\n\nNote:\n" + text.strip() + "\n\nJSON:"
+                    "publicHealth and differentials.\n\nNote:\n"
+                    + text.strip()
+                    + "\n\nJSON:"
                 )
                 out = llm(
                     prompt,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -142,6 +142,9 @@ function App() {
     useLocalModels: false,
     agencies: ['CDC', 'WHO'],
     template: null,
+    beautifyModel: '',
+    suggestModel: '',
+    summarizeModel: '',
   };
   // User settings controlling theme and which suggestion categories are enabled.
   const [settingsState, setSettingsState] = useState(defaultSettings);
@@ -191,6 +194,7 @@ function App() {
     region: settingsState.region,
     useLocalModels: settingsState.useLocalModels,
     agencies: settingsState.agencies,
+    suggestModel: settingsState.suggestModel,
   };
 
   useEffect(() => {
@@ -289,6 +293,7 @@ function App() {
       specialty: settingsState.specialty,
       payer: settingsState.payer,
       useLocalModels: settingsState.useLocalModels,
+      beautifyModel: settingsState.beautifyModel,
     })
       .then((cleaned) => {
         setBeautified(cleaned);
@@ -339,6 +344,7 @@ function App() {
       specialty: settingsState.specialty,
       payer: settingsState.payer,
       useLocalModels: settingsState.useLocalModels,
+      summarizeModel: settingsState.summarizeModel,
     })
       .then((data) => {
         let combined = data.summary;

--- a/src/api.js
+++ b/src/api.js
@@ -193,6 +193,9 @@ export async function getSettings(token) {
     region: data.region || '',
     template: data.template || null,
     useLocalModels: data.useLocalModels || false,
+    beautifyModel: data.beautifyModel || '',
+    suggestModel: data.suggestModel || '',
+    summarizeModel: data.summarizeModel || '',
   };
 }
 
@@ -229,6 +232,9 @@ export async function saveSettings(settings, token) {
     template: settings.template || null,
     useLocalModels: settings.useLocalModels || false,
     agencies: settings.agencies || [],
+    beautifyModel: settings.beautifyModel || null,
+    suggestModel: settings.suggestModel || null,
+    summarizeModel: settings.summarizeModel || null,
   };
   const resp = await fetch(`${baseUrl}/settings`, {
     method: 'POST',
@@ -256,6 +262,9 @@ export async function saveSettings(settings, token) {
     template: data.template || null,
     useLocalModels: data.useLocalModels || false,
     agencies: data.agencies || [],
+    beautifyModel: data.beautifyModel || '',
+    suggestModel: data.suggestModel || '',
+    summarizeModel: data.summarizeModel || '',
   };
 }
 
@@ -277,6 +286,7 @@ export async function beautifyNote(text, lang = 'en', context = {}) {
     if (context.payer) payload.payer = context.payer;
     if (typeof context.useLocalModels === 'boolean')
       payload.useLocalModels = context.useLocalModels;
+    if (context.beautifyModel) payload.beautifyModel = context.beautifyModel;
     const token =
       typeof window !== 'undefined' ? localStorage.getItem('token') : null;
     const headers = token
@@ -343,6 +353,7 @@ export async function getSuggestions(text, context = {}) {
       : { 'Content-Type': 'application/json' };
     if (typeof context.useLocalModels === 'boolean')
       payload.useLocalModels = context.useLocalModels;
+    if (context.suggestModel) payload.suggestModel = context.suggestModel;
     const resp = await fetch(`${baseUrl}/suggest`, {
       method: 'POST',
       headers,
@@ -934,6 +945,7 @@ export async function summarizeNote(text, context = {}) {
     if (context.payer) payload.payer = context.payer;
     if (typeof context.useLocalModels === 'boolean')
       payload.useLocalModels = context.useLocalModels;
+    if (context.summarizeModel) payload.summarizeModel = context.summarizeModel;
     try {
       const token =
         typeof window !== 'undefined' ? localStorage.getItem('token') : null;

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -210,6 +210,16 @@ function Settings({ settings, updateSettings }) {
     }
   };
 
+  const handleModelChange = async (key, value) => {
+    const updated = { ...settings, [key]: value };
+    try {
+      const saved = await saveSettings(updated);
+      updateSettings(saved);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
   return (
     <div
       className="settings-page"
@@ -254,6 +264,52 @@ function Settings({ settings, updateSettings }) {
       <p style={{ fontSize: '0.9rem', color: '#6B7280', marginTop: '-0.5rem' }}>
         {t('settings.useLocalModelsHelp')}
       </p>
+
+      <label style={{ display: 'block', marginBottom: '0.5rem' }}>
+        {t('settings.beautifyModel')}
+        <input
+          type="text"
+          value={settings.beautifyModel || ''}
+          onChange={(e) => handleModelChange('beautifyModel', e.target.value)}
+          style={{
+            width: '100%',
+            padding: '0.5rem',
+            border: '1px solid var(--disabled)',
+            borderRadius: '4px',
+            marginTop: '0.25rem',
+          }}
+        />
+      </label>
+      <label style={{ display: 'block', marginBottom: '0.5rem' }}>
+        {t('settings.suggestModel')}
+        <input
+          type="text"
+          value={settings.suggestModel || ''}
+          onChange={(e) => handleModelChange('suggestModel', e.target.value)}
+          style={{
+            width: '100%',
+            padding: '0.5rem',
+            border: '1px solid var(--disabled)',
+            borderRadius: '4px',
+            marginTop: '0.25rem',
+          }}
+        />
+      </label>
+      <label style={{ display: 'block', marginBottom: '0.5rem' }}>
+        {t('settings.summarizeModel')}
+        <input
+          type="text"
+          value={settings.summarizeModel || ''}
+          onChange={(e) => handleModelChange('summarizeModel', e.target.value)}
+          style={{
+            width: '100%',
+            padding: '0.5rem',
+            border: '1px solid var(--disabled)',
+            borderRadius: '4px',
+            marginTop: '0.25rem',
+          }}
+        />
+      </label>
 
       <h3>{t('settings.theme')}</h3>
       <label style={{ display: 'block', marginBottom: '0.5rem' }}>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -188,7 +188,10 @@
       "aetna": "Aetna"
     },
     "useLocalModels": "Enable local models",
-    "useLocalModelsHelp": "Use downloaded models when offline instead of placeholders."
+    "useLocalModelsHelp": "Use downloaded models when offline instead of placeholders.",
+    "beautifyModel": "Beautify model path",
+    "suggestModel": "Suggest model path",
+    "summarizeModel": "Summarize model path"
   },
   "sidebar": {
     "notes": "Notes",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -188,7 +188,10 @@
       "aetna": "Aetna"
     },
     "useLocalModels": "Activar modelos locales",
-    "useLocalModelsHelp": "Usar modelos descargados sin conexión en lugar de marcadores de posición."
+    "useLocalModelsHelp": "Usar modelos descargados sin conexión en lugar de marcadores de posición.",
+    "beautifyModel": "Ruta del modelo de embellecimiento",
+    "suggestModel": "Ruta del modelo de sugerencias",
+    "summarizeModel": "Ruta del modelo de resumen"
   },
   "sidebar": {
     "notes": "Notas",

--- a/tests/test_offline_mode.py
+++ b/tests/test_offline_mode.py
@@ -68,12 +68,15 @@ def test_offline_suggest(offline_client):
 def test_offline_summarize(offline_client):
     client, main_module = offline_client
     token = main_module.create_token("u", "user")
-    resp = client.post(
-        "/summarize", json={"text": "hello"}, headers=auth_header(token)
-    )
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["summary"]
-    assert data["recommendations"] == []
-    assert data["warnings"] == []
+    payload = {"text": "hello"}
+    r1 = client.post("/summarize", json=payload, headers=auth_header(token))
+    r2 = client.post("/summarize", json=payload, headers=auth_header(token))
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    d1 = r1.json()
+    d2 = r2.json()
+    assert d1 == d2
+    assert d1["summary"]
+    assert d1["recommendations"] == []
+    assert d1["warnings"] == []
 


### PR DESCRIPTION
## Summary
- allow specifying model path per endpoint in offline model
- expose local model path inputs in settings
- add deterministic offline summarization test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893b85c63288324927f00e6b9c94ef0