### PR TITLE
Add French localisation and i18n hooks

### DIFF
--- a/backend/prompt_templates.example.yaml
+++ b/backend/prompt_templates.example.yaml
@@ -4,18 +4,22 @@
 
 default:
   beautify:
-    en: "Base instruction applied to all notes"
+    en: 'Base instruction applied to all notes'
+    fr: 'Instruction de base appliquée à toutes les notes'
 
 specialty:
   cardiology:
     beautify:
-      en: "Cardiology specific beautify instruction"
-      es: "Instrucción de embellecer específica de cardiología"
+      en: 'Cardiology specific beautify instruction'
+      es: 'Instrucción de embellecer específica de cardiología'
+      fr: "Instruction d'embellissement spécifique à la cardiologie"
 
 payer:
   medicare:
     suggest:
-      en: "Follow Medicare coding rules"
-      es: "Siga las reglas de codificación de Medicare"
+      en: 'Follow Medicare coding rules'
+      es: 'Siga las reglas de codificación de Medicare'
+      fr: 'Suivez les règles de codage de Medicare'
     beautify:
-      en: "Ensure documentation meets Medicare standards"
+      en: 'Ensure documentation meets Medicare standards'
+      fr: 'Assurez-vous que la documentation respecte les normes de Medicare'

--- a/backend/prompt_templates.json
+++ b/backend/prompt_templates.json
@@ -28,7 +28,8 @@
           "user": "Example suggest note",
           "assistant": "{\"codes\": [], \"compliance\": [], \"public_health\": [], \"differentials\": []}"
         }
-      ]
+      ],
+      "fr": "Conseils de base pour les suggestions. Fournissez des éléments concis et actionnables et évitez les commentaires superflus."
     },
     "summary": {
       "en": "Base summary guidance. Keep summaries brief and patient-friendly.",
@@ -37,21 +38,25 @@
           "user": "Example summary note",
           "assistant": "Example patient-friendly summary."
         }
-      ]
+      ],
+      "fr": "Instruction de résumé de base. Gardez les résumés concis et adaptés aux patients."
     }
   },
   "specialty_modifiers": {
     "cardiology": {
       "en": "Remember to include cardiac-specific terminology and avoid extraneous detail. Emphasise cholesterol screening and lipid management when appropriate.",
-      "es": "Recuerda incluir terminología cardiaca y evitar detalles innecesarios. Destaca el control del colesterol y el manejo de lípidos cuando sea apropiado."
+      "es": "Recuerda incluir terminología cardiaca y evitar detalles innecesarios. Destaca el control del colesterol y el manejo de lípidos cuando sea apropiado.",
+      "fr": "N'oubliez pas d'inclure une terminologie spécifique au cœur et d'éviter les détails superflus. Mettez l'accent sur le dépistage du cholestérol et la gestion des lipides lorsque cela est approprié."
     },
     "paediatrics": {
-      "en": "Adjust tone for pediatric cases and use family-friendly language. Include immunisation schedules and vaccine reminders where relevant."
+      "en": "Adjust tone for pediatric cases and use family-friendly language. Include immunisation schedules and vaccine reminders where relevant.",
+      "fr": "Adaptez le ton pour les cas pédiatriques et utilisez un langage adapté aux familles. Incluez les calendriers de vaccination et les rappels de vaccins lorsque cela est pertinent."
     }
   },
   "payer_modifiers": {
     "medicare": {
-      "en": "Apply Medicare reimbursement guidelines and reference relevant policy. Highlight preventive services covered under Medicare."
+      "en": "Apply Medicare reimbursement guidelines and reference relevant policy. Highlight preventive services covered under Medicare.",
+      "fr": "Appliquez les directives de remboursement de Medicare et référencez la politique pertinente. Mettez en avant les services préventifs couverts par Medicare."
     }
   },
   "specialty": {

--- a/src/components/AuditLog.jsx
+++ b/src/components/AuditLog.jsx
@@ -27,12 +27,12 @@ export default function AuditLog({ token }) {
         const resp = await fetch(`${baseUrl}/audit`, {
           headers: { Authorization: `Bearer ${token}` },
         });
-        if (!resp.ok) throw new Error('Failed to fetch');
+        if (!resp.ok) throw new Error(t('auditLog.fetchError'));
         const data = await resp.json();
         setEntries(data);
         setError(null);
       } catch (err) {
-        setError(err.message);
+        setError(err.message || t('auditLog.fetchError'));
       } finally {
         setLoading(false);
       }

--- a/src/components/FollowUpScheduler.jsx
+++ b/src/components/FollowUpScheduler.jsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { scheduleFollowUp } from '../api.js';
 
 function FollowUpScheduler({ note, codes = [] }) {
+  const { t } = useTranslation();
   const [interval, setInterval] = useState('');
   const [ics, setIcs] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -29,9 +31,10 @@ function FollowUpScheduler({ note, codes = [] }) {
     if (unit.startsWith('day')) date.setDate(start.getDate() + value);
     else if (unit.startsWith('week')) date.setDate(start.getDate() + 7 * value);
     else if (unit.startsWith('month')) date.setMonth(start.getMonth() + value);
-    else if (unit.startsWith('year')) date.setFullYear(start.getFullYear() + value);
+    else if (unit.startsWith('year'))
+      date.setFullYear(start.getFullYear() + value);
     const dt = date.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
-    const icsText = `BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nSUMMARY:Follow-up appointment\nDTSTART:${dt}\nDTEND:${dt}\nEND:VEVENT\nEND:VCALENDAR`;
+    const icsText = `BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nSUMMARY:${t('suggestion.followUpAppointment')}\nDTSTART:${dt}\nDTEND:${dt}\nEND:VEVENT\nEND:VCALENDAR`;
     return `data:text/calendar;charset=utf8,${encodeURIComponent(icsText)}`;
   };
 
@@ -42,17 +45,17 @@ function FollowUpScheduler({ note, codes = [] }) {
   return (
     <div className="follow-up-scheduler">
       <button onClick={recommend} disabled={loading}>
-        Recommend
+        {t('followUp.recommend')}
       </button>
       <input
         value={interval}
         onChange={(e) => setInterval(e.target.value)}
-        placeholder="e.g., 2 weeks"
+        placeholder={t('followUp.placeholder')}
         style={{ marginLeft: '0.5em' }}
       />
       {href && (
         <a href={href} download="follow-up.ics" style={{ marginLeft: '0.5em' }}>
-          Add to calendar
+          {t('suggestion.addToCalendar')}
         </a>
       )}
     </div>

--- a/src/components/Logs.jsx
+++ b/src/components/Logs.jsx
@@ -35,7 +35,7 @@ export default function Logs() {
           localStorage.removeItem('token');
           window.location.href = '/';
         } else {
-          setError(err.message);
+          setError(t('logs.fetchFailed'));
         }
       } finally {
         setLoading(false);

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -227,7 +227,7 @@ function Settings({ settings, updateSettings }) {
           type="password"
           value={apiKeyInput}
           onChange={(e) => setApiKeyInput(e.target.value)}
-          placeholder="sk-... (e.g., sk-proj-...)"
+          placeholder={t('settings.apiKeyPlaceholder')}
           style={{
             flexGrow: 1,
             padding: '0.5rem',

--- a/src/components/__tests__/FollowUpScheduler.test.jsx
+++ b/src/components/__tests__/FollowUpScheduler.test.jsx
@@ -3,6 +3,7 @@ import { render, fireEvent, waitFor, cleanup } from '@testing-library/react';
 import { vi, expect, test, afterEach } from 'vitest';
 import FollowUpScheduler from '../FollowUpScheduler.jsx';
 import * as api from '../../api.js';
+import i18n from '../../i18n.js';
 
 afterEach(() => {
   cleanup();
@@ -17,10 +18,14 @@ test('fetches recommendation and provides calendar link', async () => {
   const { getByText, getByPlaceholderText } = render(
     <FollowUpScheduler note="note" codes={["E11"]} />
   );
-  fireEvent.click(getByText('Recommend'));
+  fireEvent.click(getByText(i18n.t('followUp.recommend')));
   await waitFor(() =>
-    expect(getByPlaceholderText('e.g., 2 weeks').value).toBe('2 weeks')
+    expect(
+      getByPlaceholderText(i18n.t('followUp.placeholder')).value,
+    ).toBe('2 weeks'),
   );
-  const href = getByText('Add to calendar').getAttribute('href');
+  const href = getByText(i18n.t('suggestion.addToCalendar')).getAttribute(
+    'href',
+  );
   expect(href).toContain('text/calendar');
 });

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,12 +1,14 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
-import en from './locales/en.json';
-import es from './locales/es.json';
+import en from './locales/en.json' assert { type: 'json' };
+import es from './locales/es.json' assert { type: 'json' };
+import fr from './locales/fr.json' assert { type: 'json' };
 
 i18n.use(initReactI18next).init({
   resources: {
     en: { translation: en },
     es: { translation: es },
+    fr: { translation: fr },
   },
   lng: 'en',
   fallbackLng: 'en',

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -75,6 +75,10 @@
     "none": "No drafts saved.",
     "delete": "Delete draft"
   },
+  "followUp": {
+    "recommend": "Recommend",
+    "placeholder": "e.g., 2 weeks"
+  },
   "help": {
     "welcomeTitle": "Welcome to RevenuePilot",
     "intro": "This short guide will walk you through the basics of using the RevenuePilot app. Whether you’re creating your first clinical note or reviewing analytics, the app is designed to assist you at every step.",
@@ -114,7 +118,8 @@
     "title": "Event Log",
     "intro": "This log shows recent actions captured by the app. Use it to verify that events such as note creation, beautification, suggestions, summaries, chart uploads and audio recordings are being logged and processed.",
     "loading": "Loading…",
-    "none": "No events recorded yet."
+    "none": "No events recorded yet.",
+    "fetchFailed": "Failed to load events"
   },
   "auditLog": {
     "title": "Audit Log",
@@ -123,7 +128,8 @@
     "action": "Action",
     "details": "Details",
     "loading": "Loading…",
-    "none": "No audit entries"
+    "none": "No audit entries",
+    "fetchError": "Failed to load audit log"
   },
   "noteEditor": {
     "stopRecording": "Stop Recording",
@@ -148,6 +154,7 @@
     "apiKeyHelp": "Enter your OpenAI API key here. The key will be stored securely on your machine and used by the backend to call the language model. You can update it at any time.",
     "saveKey": "Save Key",
     "invalidApiKey": "Invalid API key format",
+    "apiKeyPlaceholder": "sk-... (e.g., sk-proj-...)",
     "theme": "Theme",
     "modern": "Modern Minimal",
     "dark": "Dark Elegance",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -75,6 +75,10 @@
     "none": "No hay borradores guardados.",
     "delete": "Eliminar borrador"
   },
+  "followUp": {
+    "recommend": "Recomendar",
+    "placeholder": "p. ej., 2 semanas"
+  },
   "help": {
     "welcomeTitle": "Bienvenido a RevenuePilot",
     "intro": "Esta guía rápida le mostrará los fundamentos del uso de la aplicación RevenuePilot. Ya sea que esté creando su primera nota clínica o revisando analíticas, la aplicación está diseñada para asistirle en cada paso.",
@@ -114,7 +118,8 @@
     "title": "Registro de eventos",
     "intro": "Este registro muestra acciones recientes capturadas por la aplicación. Úselo para verificar que eventos como creación de notas, embellecimiento, sugerencias, resúmenes, cargas de gráficos y grabaciones de audio se están registrando y procesando.",
     "loading": "Cargando…",
-    "none": "No se han registrado eventos."
+    "none": "No se han registrado eventos.",
+    "fetchFailed": "Error al cargar los eventos"
   },
   "auditLog": {
     "title": "Registro de auditoría",
@@ -123,7 +128,8 @@
     "action": "Acción",
     "details": "Detalles",
     "loading": "Cargando…",
-    "none": "Sin entradas de auditoría"
+    "none": "Sin entradas de auditoría",
+    "fetchError": "Error al cargar el registro de auditoría"
   },
   "noteEditor": {
     "stopRecording": "Detener grabación",
@@ -148,6 +154,7 @@
     "apiKeyHelp": "Introduzca aquí su clave de API de OpenAI. La clave se almacenará de forma segura en su máquina y será utilizada por el backend para llamar al modelo de lenguaje. Puede actualizarla en cualquier momento.",
     "saveKey": "Guardar clave",
     "invalidApiKey": "Formato de clave de API inválido",
+    "apiKeyPlaceholder": "sk-... (p. ej., sk-proj-...)",
     "theme": "Tema",
     "modern": "Minimal moderno",
     "dark": "Elegancia oscura",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1,0 +1,23 @@
+{
+  "followUp": {
+    "recommend": "Recommander",
+    "placeholder": "ex. : 2 semaines"
+  },
+  "auditLog": {
+    "fetchError": "Échec du chargement du journal d'audit"
+  },
+  "logs": {
+    "fetchFailed": "Échec du chargement des événements"
+  },
+  "settings": {
+    "apiKeyPlaceholder": "sk-... (p. ex., sk-proj-...)",
+    "english": "Anglais",
+    "spanish": "Espagnol",
+    "french": "Français",
+    "german": "Allemand"
+  },
+  "suggestion": {
+    "addToCalendar": "Ajouter au calendrier",
+    "followUpAppointment": "Rendez-vous de suivi"
+  }
+}


### PR DESCRIPTION
## Summary
- localise follow-up scheduler, audit log and logs components
- load French translations and expose them through i18n
- add French prompt templates and examples

## Testing
- `npm run lint`
- `npm test`
- `node -e "import('./src/i18n.js').then(m=>console.log(Object.keys(m.default.options.resources)))"`
- `python - <<'PY'
from backend.prompts import _get_custom_instruction
print(_get_custom_instruction('suggest','fr',None,None))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6893b85865e083249a4c265b648b8eb1