### PR TITLE
chore(ci): enable coverage and unify lint/test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,27 +2,20 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  backend:
+  tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - run: pip install -r backend/requirements.txt pytest pytest-cov pytest-asyncio httpx ruff
-      - run: python -m spacy download en_core_web_sm
-      - run: ruff check backend
-      - run: pytest
-  frontend:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: '18'
+      - run: pip install -r backend/requirements_dev.txt
+      - run: python -m spacy download en_core_web_sm
       - run: npm ci
-      - run: npm run lint
-      - run: npm test
+      - run: ./ci.sh
   electron:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ backend/venv/
 backend/requirements.lock
 # Logs and coverage
 *.log
-coverage/
 
 # Electron icons
 assets/*.icns

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # RevenuePilot App Skeleton
 
+![Python Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/revenuepilot/revenuepilot/main/coverage/python-coverage.json)
+![JS Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/revenuepilot/revenuepilot/main/coverage/js-coverage.json)
+
 This directory contains a **minimal scaffold** for the RevenuePilot desktop application.
 It is designed to reflect the approved wireframes (note editor with tabbed draft/beautified views
 and a suggestion panel) and uses a clean, high‑contrast colour palette.  The scaffold is not

--- a/backend/requirements_dev.txt
+++ b/backend/requirements_dev.txt
@@ -1,0 +1,6 @@
+-r requirements.txt
+pytest
+pytest-cov
+pytest-asyncio
+httpx
+ruff

--- a/ci.sh
+++ b/ci.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ruff check backend
+pytest
+npm run lint
+npx vitest run --coverage

--- a/coverage/js-coverage.json
+++ b/coverage/js-coverage.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"js coverage","message":"0%","color":"lightgrey"}

--- a/coverage/python-coverage.json
+++ b/coverage/python-coverage.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"python coverage","message":"0%","color":"lightgrey"}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --cov=backend --cov-report=term-missing --cov-fail-under=30
+addopts = --cov=backend --cov-report=term-missing --cov-report=xml --cov-fail-under=85

--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+describe('api helper error handling', () => {
+  it('throws detailed error on failed login', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ detail: 'bad credentials' })
+    }));
+    const { login } = await import('../api.js');
+    await expect(login('user', 'pass')).rejects.toThrow('bad credentials');
+  });
+
+  it('throws detailed error on failed password reset', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ message: 'nope' })
+    }));
+    const { resetPassword } = await import('../api.js');
+    await expect(resetPassword('user', 'pass', 'newpass')).rejects.toThrow('nope');
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
     exclude: [...defaultExclude, 'e2e/**', 'src/components/__tests__/NoteEditor.test.jsx'],
     coverage: {
       enabled: true,
-      reporter: ['text'],
+      reporter: ['text', 'json-summary'],
       include: [
         'src/components/ClipboardExportButtons.jsx',
         'src/components/Dashboard.jsx',
@@ -18,10 +18,10 @@ export default defineConfig({
         'src/components/SuggestionPanel.jsx',
         'src/components/TemplatesModal.jsx'
       ],
-      lines: 70,
-      functions: 50,
-      branches: 50,
-      statements: 70,
+      lines: 90,
+      functions: 90,
+      branches: 80,
+      statements: 80,
     },
   },
 });


### PR DESCRIPTION
## Summary
- add dev requirements with pytest-cov and ruff
- run tests and linters through new ci.sh
- raise Vitest coverage thresholds and add API error tests

## Testing
- `npx vitest --run`
- `pytest` *(fails: Required test coverage of 85% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68942a8149048324aca85ed42314cff8