### PR TITLE
Add one-step setup and build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ app into an Electron shell for desktop deployment.
 
 ## Running locally
 
+### Quick start
+
+To install all dependencies and produce a packaged desktop build in one step, run:
+
+```bash
+./setup.sh        # macOS/Linux
+# or
+.\setup.ps1       # Windows PowerShell
+```
+
+This script invokes the installer and then runs `npm run electron:build`. Built artifacts will be placed in the `dist/` directory. If you prefer to execute the steps manually, follow the instructions below.
+
 1. Install [Node.js](https://nodejs.org/) (version 14 or later).
 2. Navigate to this folder and install dependencies:
 

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,0 +1,7 @@
+Write-Host "Setting up RevenuePilot and building package..."
+
+& "$PSScriptRoot/install.ps1"
+
+npm run electron:build
+
+Write-Host "Build complete. Artifacts are in the dist/ directory."

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Master setup script to install dependencies and build the RevenuePilot desktop package.
+
+set -e
+
+# Determine project root and switch to it
+SCRIPT_DIR="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+cd "$SCRIPT_DIR"
+
+# Install prerequisites and project dependencies
+./install.sh
+
+# Build the packaged Electron application
+npm run electron:build
+
+echo "Build complete. Artifacts are in the dist/ directory."


### PR DESCRIPTION
## Summary
- add `setup.sh` and `setup.ps1` to install dependencies and build Electron package
- document quick start script in README for packaging from a single command

## Testing
- `npm test`
- `source backend/venv/bin/activate && pip install -r backend/requirements.txt` *(fails: No matching distribution found for en-core-web-sm)*
- `source backend/venv/bin/activate && pytest` *(fails: unrecognized arguments: --cov=backend --cov-report=term-missing --cov-report=xml --cov-fail-under=85)*

------
https://chatgpt.com/codex/tasks/task_e_6894b13b5a5c8324ba835f101a72d29f