### PR TITLE
Ensure spaCy model installed during setup

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,7 +13,6 @@ presidio-anonymizer
 pyyaml
 philter
 spacy
-en-core-web-sm
 pyannote.audio
 torchaudio
 passlib[bcrypt]

--- a/install.sh
+++ b/install.sh
@@ -48,6 +48,7 @@ cd backend
 python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
+python -m spacy download en_core_web_sm
 deactivate
 
 echo "Installation complete."


### PR DESCRIPTION
## Summary
- Avoid pip failure by removing `en-core-web-sm` from backend requirements
- Download the spaCy `en_core_web_sm` model during install

## Testing
- `npm test`
- `pytest` *(fails: unrecognized arguments --cov=backend --cov-report=term-missing --cov-report=xml --cov-fail-under=85)*

------
https://chatgpt.com/codex/tasks/task_e_6894cbf3991c83249c739edc39582c89