### PR TITLE
Fix Python 3.9 annotation error and pin numpy

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -8,6 +8,8 @@ sending it to an AI model via ``call_openai``. If the model call fails,
 each endpoint returns a sensible fallback.
 """
 
+from __future__ import annotations
+
 import logging
 import os
 import re

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,7 @@
 fastapi
 uvicorn
 pydantic
+numpy<2
 openai
 keyring
 platformdirs


### PR DESCRIPTION
## Summary
- ensure FastAPI backend supports Python 3.9's type hints
- pin numpy to <2 to avoid incompatibility with compiled dependencies

## Testing
- `pytest` *(fails: unrecognized arguments: --cov=backend --cov-report=term-missing --cov-report=xml --cov-fail-under=85)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894d7e9389c8324a8d29abdc24af878