### PR TITLE
fix: handle existing venv directory in backend prebuild script

### DIFF
--- a/scripts/backend-prebuild.js
+++ b/scripts/backend-prebuild.js
@@ -30,8 +30,15 @@ async function main() {
   const backendDir = path.join(__dirname, '..', 'backend');
   const venvDir = path.join(backendDir, 'venv');
 
+  // Remove any existing virtual environment before creating a new one. Using
+  // `fs.rmSync` is more robust than relying on Python's `--clear` flag which
+  // can fail if certain packages (e.g. torch) contain read-only files or
+  // nested directories that `venv` struggles to delete. This prevents errors
+  // like "[Errno 66] Directory not empty" during prebuild.
+  fs.rmSync(venvDir, { recursive: true, force: true });
+
   const python = resolvePython();
-  await run(python, ['-m', 'venv', '--copies', '--clear', venvDir]);
+  await run(python, ['-m', 'venv', '--copies', venvDir]);
 
   const pipPath = path.join(
     venvDir,


### PR DESCRIPTION
## Summary
- avoid venv `Directory not empty: 'torch'` error by deleting venv before recreating it
- create venv without `--clear` flag

## Testing
- `npm test`
- `npm run backend:prebuild` *(fails: `Installing build dependencies: finished with status 'canceled'`)*
- `npm run lint` *(fails: `NoteEditor.jsx:113:5  error  'role' is assigned a value but never used`)*


------
https://chatgpt.com/codex/tasks/task_e_6894e4003d788324a4ee8d3e005a1d44