### PR TITLE
Add template management and analysis endpoints

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -74,7 +74,14 @@ from backend.migrations import (  # type: ignore
     ensure_templates_table,
     ensure_events_table,
 )
-from backend.templates import TemplateModel, load_builtin_templates  # type: ignore
+from backend.templates import (
+    TemplateModel,
+    load_builtin_templates,
+    list_user_templates,
+    create_user_template,
+    update_user_template,
+    delete_user_template,
+)  # type: ignore
 from backend.scheduling import DEFAULT_EVENT_SUMMARY, export_ics, recommend_follow_up  # type: ignore
 from backend.scheduling import (  # type: ignore
     create_appointment,
@@ -160,6 +167,9 @@ app = FastAPI(title="RevenuePilot API", lifespan=lifespan)
 
 # Record process start time for uptime calculations
 START_TIME = time.time()
+
+# Simple in-memory storage for note versions keyed by note ID.
+NOTE_VERSIONS: Dict[str, List[Dict[str, str]]] = defaultdict(list)
 
 # Health/readiness endpoint used by the desktop app to know when the backend is up.
 # Returns basic process / db status without requiring auth.
@@ -1187,6 +1197,7 @@ def save_prompt_templates(
 
 
 @app.get("/templates", response_model=List[TemplateModel])
+@app.get("/api/templates/list", response_model=List[TemplateModel])
 def get_templates(
     specialty: Optional[str] = None,
     payer: Optional[str] = None,
@@ -1194,134 +1205,88 @@ def get_templates(
 ) -> List[TemplateModel]:
     """Return templates for the current user and clinic, optionally filtered by specialty or payer."""
 
-    clinic = user.get("clinic")
-    cursor = db_conn.cursor()
-    base_query = (
-        "SELECT id, name, content, specialty, payer FROM templates "
-        "WHERE (user=? OR (user IS NULL AND clinic=?))"
+    return list_user_templates(
+        db_conn, user["sub"], user.get("clinic"), specialty, payer
     )
-    params: List[Any] = [user["sub"], clinic]
-    if specialty:
-        base_query += " AND specialty=?"
-        params.append(specialty)
-    if payer:
-        base_query += " AND payer=?"
-        params.append(payer)
-    rows = cursor.execute(base_query, params).fetchall()
-
-    templates = [
-        TemplateModel(
-            id=row["id"],
-            name=row["name"],
-            content=row["content"],
-            specialty=row["specialty"],
-            payer=row["payer"],
-        )
-        for row in rows
-    ]
-
-    for tpl in load_builtin_templates():
-        if specialty and tpl.specialty != specialty:
-            continue
-        if payer and tpl.payer != payer:
-            continue
-        templates.append(tpl)
-
-    return templates
 
 
 @app.post("/templates", response_model=TemplateModel)
+@app.post("/api/templates", response_model=TemplateModel)
 def create_template(
     tpl: TemplateModel, user=Depends(require_role("user"))
 ) -> TemplateModel:
     """Create a new template for the user or clinic."""
 
-    clinic = user.get("clinic")
-    owner = None if user.get("role") == "admin" else user["sub"]
-    cursor = db_conn.cursor()
-    cursor.execute(
-        "INSERT INTO templates (user, clinic, specialty, payer, name, content) VALUES (?, ?, ?, ?, ?, ?)",
-        (owner, clinic, tpl.specialty, tpl.payer, tpl.name, tpl.content),
-    )
-    db_conn.commit()
-    tpl_id = cursor.lastrowid
-    return TemplateModel(
-        id=tpl_id,
-        name=tpl.name,
-        content=tpl.content,
-        specialty=tpl.specialty,
-        payer=tpl.payer,
+    return create_user_template(
+        db_conn,
+        user["sub"],
+        user.get("clinic"),
+        tpl,
+        user.get("role") == "admin",
     )
 
 
 @app.put("/templates/{template_id}", response_model=TemplateModel)
+@app.put("/api/templates/{template_id}", response_model=TemplateModel)
 def update_template(
     template_id: int, tpl: TemplateModel, user=Depends(require_role("user"))
 ) -> TemplateModel:
     """Update an existing template owned by the user or clinic."""
 
-    clinic = user.get("clinic")
-    cursor = db_conn.cursor()
-    if user.get("role") == "admin":
-        cursor.execute(
-            "UPDATE templates SET name=?, content=?, specialty=?, payer=? "
-            "WHERE id=? AND (user=? OR (user IS NULL AND clinic=?))",
-            (
-                tpl.name,
-                tpl.content,
-                tpl.specialty,
-                tpl.payer,
-                template_id,
-                user["sub"],
-                clinic,
-            ),
-        )
-    else:
-        cursor.execute(
-            "UPDATE templates SET name=?, content=?, specialty=?, payer=? WHERE id=? AND user=?",
-            (
-                tpl.name,
-                tpl.content,
-                tpl.specialty,
-                tpl.payer,
-                template_id,
-                user["sub"],
-            ),
-        )
-    db_conn.commit()
-    if cursor.rowcount == 0:
-        raise HTTPException(status_code=404, detail="Template not found")
-    return TemplateModel(
-        id=template_id,
-        name=tpl.name,
-        content=tpl.content,
-        specialty=tpl.specialty,
-        payer=tpl.payer,
+    return update_user_template(
+        db_conn,
+        user["sub"],
+        user.get("clinic"),
+        template_id,
+        tpl,
+        user.get("role") == "admin",
     )
 
 
 @app.delete("/templates/{template_id}")
+@app.delete("/api/templates/{template_id}")
 def delete_template(
     template_id: int, user=Depends(require_role("user"))
 ) -> Dict[str, str]:
     """Delete a template owned by the user or clinic."""
 
-    clinic = user.get("clinic")
-    cursor = db_conn.cursor()
-    if user.get("role") == "admin":
-        cursor.execute(
-            "DELETE FROM templates WHERE id=? AND (user=? OR (user IS NULL AND clinic=?))",
-            (template_id, user["sub"], clinic),
-        )
-    else:
-        cursor.execute(
-            "DELETE FROM templates WHERE id=? AND user=?",
-            (template_id, user["sub"]),
-        )
-    db_conn.commit()
-    if cursor.rowcount == 0:
-        raise HTTPException(status_code=404, detail="Template not found")
+    delete_user_template(
+        db_conn,
+        user["sub"],
+        user.get("clinic"),
+        template_id,
+        user.get("role") == "admin",
+    )
     return {"status": "deleted"}
+
+
+class AutoSaveRequest(BaseModel):
+    noteId: str
+    content: str
+
+
+@app.post("/api/notes/auto-save")
+def auto_save_note(
+    req: AutoSaveRequest, user=Depends(require_role("user"))
+) -> Dict[str, Any]:
+    """Persist note content in-memory for versioning."""
+
+    versions = NOTE_VERSIONS[req.noteId]
+    versions.append(
+        {"timestamp": datetime.now(timezone.utc).isoformat(), "content": req.content}
+    )
+    if len(versions) > 20:
+        versions.pop(0)
+    return {"status": "saved", "version": len(versions)}
+
+
+@app.get("/api/notes/versions/{note_id}")
+def get_note_versions(
+    note_id: str, user=Depends(require_role("user"))
+) -> List[Dict[str, str]]:
+    """Return previously auto-saved versions for a note."""
+
+    return NOTE_VERSIONS.get(note_id, [])
 
 
 class ExportRequest(BaseModel):
@@ -2427,6 +2392,38 @@ async def suggest(
             differentials=diffs,
             followUp=follow_up,
         )
+
+
+class AnalyzeRequest(BaseModel):
+    text: str
+    model: Optional[str] = None
+
+
+@app.post("/api/ai/analyze")
+async def analyze_note(
+    req: AnalyzeRequest, user=Depends(require_role("user"))
+) -> Dict[str, Any]:
+    """Extract structured content from a note via the LLM."""
+
+    cleaned = deidentify(req.text or "")
+    if USE_OFFLINE_MODEL:
+        return {"analysis": {}}
+    messages = [
+        {
+            "role": "system",
+            "content": "Extract key medical facts as JSON with any fields you find relevant.",
+        },
+        {"role": "user", "content": cleaned},
+    ]
+    try:
+        result = call_openai(messages, model=req.model or "gpt-4o")
+        try:
+            return json.loads(result)
+        except Exception:
+            return {"analysis": result}
+    except Exception as exc:  # pragma: no cover - network/LLM errors
+        logging.error("Error during analyze LLM call: %s", exc)
+        return {"analysis": {}}
 
 
 @app.post("/followup", response_model=ScheduleResponse)

--- a/backend/templates.py
+++ b/backend/templates.py
@@ -1,5 +1,7 @@
-from typing import Optional, List
+from typing import Optional, List, Any
 from pydantic import BaseModel
+import sqlite3
+from fastapi import HTTPException
 
 from backend import prompts as prompt_utils
 
@@ -90,4 +92,148 @@ def load_builtin_templates() -> List[TemplateModel]:
 # reference them without repeatedly parsing the JSON file.
 
 DEFAULT_TEMPLATES: List[TemplateModel] = load_builtin_templates()
+
+
+def list_user_templates(
+    conn: sqlite3.Connection,
+    username: str,
+    clinic: str | None,
+    specialty: Optional[str] = None,
+    payer: Optional[str] = None,
+) -> List[TemplateModel]:
+    """Return templates for a user/clinic including built-ins."""
+
+    cursor = conn.cursor()
+    base_query = (
+        "SELECT id, name, content, specialty, payer FROM templates "
+        "WHERE (user=? OR (user IS NULL AND clinic=?))"
+    )
+    params: List[Any] = [username, clinic]
+    if specialty:
+        base_query += " AND specialty=?"
+        params.append(specialty)
+    if payer:
+        base_query += " AND payer=?"
+        params.append(payer)
+    rows = cursor.execute(base_query, params).fetchall()
+
+    templates = [
+        TemplateModel(
+            id=row["id"],
+            name=row["name"],
+            content=row["content"],
+            specialty=row["specialty"],
+            payer=row["payer"],
+        )
+        for row in rows
+    ]
+
+    for tpl in load_builtin_templates():
+        if specialty and tpl.specialty != specialty:
+            continue
+        if payer and tpl.payer != payer:
+            continue
+        templates.append(tpl)
+
+    return templates
+
+
+def create_user_template(
+    conn: sqlite3.Connection,
+    username: str,
+    clinic: str | None,
+    tpl: TemplateModel,
+    is_admin: bool = False,
+) -> TemplateModel:
+    """Insert a template for a user or clinic."""
+
+    owner = None if is_admin else username
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT INTO templates (user, clinic, specialty, payer, name, content) VALUES (?, ?, ?, ?, ?, ?)",
+        (owner, clinic, tpl.specialty, tpl.payer, tpl.name, tpl.content),
+    )
+    conn.commit()
+    tpl_id = cursor.lastrowid
+    return TemplateModel(
+        id=tpl_id,
+        name=tpl.name,
+        content=tpl.content,
+        specialty=tpl.specialty,
+        payer=tpl.payer,
+    )
+
+
+def update_user_template(
+    conn: sqlite3.Connection,
+    username: str,
+    clinic: str | None,
+    template_id: int,
+    tpl: TemplateModel,
+    is_admin: bool = False,
+) -> TemplateModel:
+    """Update an existing template owned by the user or clinic."""
+
+    cursor = conn.cursor()
+    if is_admin:
+        cursor.execute(
+            "UPDATE templates SET name=?, content=?, specialty=?, payer=? "
+            "WHERE id=? AND (user=? OR (user IS NULL AND clinic=?))",
+            (
+                tpl.name,
+                tpl.content,
+                tpl.specialty,
+                tpl.payer,
+                template_id,
+                username,
+                clinic,
+            ),
+        )
+    else:
+        cursor.execute(
+            "UPDATE templates SET name=?, content=?, specialty=?, payer=? WHERE id=? AND user=?",
+            (
+                tpl.name,
+                tpl.content,
+                tpl.specialty,
+                tpl.payer,
+                template_id,
+                username,
+            ),
+        )
+    conn.commit()
+    if cursor.rowcount == 0:
+        raise HTTPException(status_code=404, detail="Template not found")
+    return TemplateModel(
+        id=template_id,
+        name=tpl.name,
+        content=tpl.content,
+        specialty=tpl.specialty,
+        payer=tpl.payer,
+    )
+
+
+def delete_user_template(
+    conn: sqlite3.Connection,
+    username: str,
+    clinic: str | None,
+    template_id: int,
+    is_admin: bool = False,
+) -> None:
+    """Remove a template owned by the user or clinic."""
+
+    cursor = conn.cursor()
+    if is_admin:
+        cursor.execute(
+            "DELETE FROM templates WHERE id=? AND (user=? OR (user IS NULL AND clinic=?))",
+            (template_id, username, clinic),
+        )
+    else:
+        cursor.execute(
+            "DELETE FROM templates WHERE id=? AND user=?",
+            (template_id, username),
+        )
+    conn.commit()
+    if cursor.rowcount == 0:
+        raise HTTPException(status_code=404, detail="Template not found")
 


### PR DESCRIPTION
## Summary
- add database helpers for template CRUD
- expose template CRUD under /api/templates and listing via /api/templates/list
- provide in-memory note autosave and version retrieval
- add AI analysis endpoint for structured note extraction

## Testing
- `pip install pytest-cov`
- `pytest` *(fails: linux code signing link missing, KeyError: 'top_compliance', KeyError: 'beautify')*

------
https://chatgpt.com/codex/tasks/task_e_68c49db322108324985d9441d5f5c301