### PR TITLE
Track EHR exports and expose formatting rules

### DIFF
--- a/backend/migrations.py
+++ b/backend/migrations.py
@@ -139,3 +139,19 @@ def ensure_events_table(conn: sqlite3.Connection) -> None:
         conn.execute("ALTER TABLE events ADD COLUMN satisfaction INTEGER")
 
     conn.commit()
+
+
+def ensure_exports_table(conn: sqlite3.Connection) -> None:
+    """Ensure the exports table exists for tracking EHR exports."""
+
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS exports ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "timestamp REAL NOT NULL,"
+        "ehr TEXT,"
+        "note TEXT,"
+        "status TEXT,"
+        "detail TEXT"
+        ")"
+    )
+    conn.commit()

--- a/package.json
+++ b/package.json
@@ -100,7 +100,9 @@
         "AppImage",
         "deb"
       ],
-      "category": "Utility"
+      "category": "Utility",
+      "cscLink": "${env.LINUX_CSC_LINK}",
+      "cscKeyPassword": "${env.LINUX_CSC_KEY_PASSWORD}"
     },
     "publish": [
       {


### PR DESCRIPTION
## Summary
- expose `/api/ai/beautify` alias for AI beautification endpoint
- add `/api/formatting/rules` for organisation-specific note rules
- implement `/api/export/ehr` with export tracking table and status polling
- declare Linux signing placeholders in build config

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c49dbbd68c8324a0d576b40713ab22