### PR TITLE
Add code metadata and billing endpoints

### DIFF
--- a/backend/codes_data.py
+++ b/backend/codes_data.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+"""Cached code metadata and reimbursement information.
+
+This module provides lightweight in-memory tables for common CPT,
+ICD-10 and HCPCS codes used throughout the tests.  In a real system
+this data would likely come from an external database or reference
+files.  For the purposes of the demo API we keep a very small subset of
+codes with the fields needed by the frontend.
+"""
+
+from functools import lru_cache
+from typing import Dict, Any, List, Tuple
+
+# ---------------------------------------------------------------------------
+# Code metadata
+# ---------------------------------------------------------------------------
+
+_CPT: Dict[str, Dict[str, Any]] = {
+    "99213": {
+        "type": "CPT",
+        "category": "codes",
+        "description": "Office or other outpatient visit for the evaluation and management of an established patient",
+        "rvu": 1.29,
+        "reimbursement": 75.32,
+    },
+    "99214": {
+        "type": "CPT",
+        "category": "codes",
+        "description": "Office or other outpatient visit for the evaluation and management of an established patient, 25 minutes",
+        "rvu": 1.92,
+        "reimbursement": 109.46,
+    },
+}
+
+_ICD10: Dict[str, Dict[str, Any]] = {
+    "E11.9": {
+        "type": "ICD-10",
+        "category": "diagnoses",
+        "description": "Type 2 diabetes mellitus without complications",
+        "rvu": 0.0,
+        "reimbursement": 0.0,
+    },
+    "I10": {
+        "type": "ICD-10",
+        "category": "diagnoses",
+        "description": "Essential (primary) hypertension",
+        "rvu": 0.0,
+        "reimbursement": 0.0,
+    },
+}
+
+_HCPCS: Dict[str, Dict[str, Any]] = {
+    "J3490": {
+        "type": "HCPCS",
+        "category": "codes",
+        "description": "Unclassified drugs",
+        "rvu": 0.0,
+        "reimbursement": 10.00,
+    }
+}
+
+@lru_cache()
+def load_code_metadata() -> Dict[str, Dict[str, Any]]:
+    """Return a combined mapping of code -> metadata.
+
+    ``lru_cache`` keeps this dictionary in memory for the life of the
+    process which is sufficient for the small demo dataset.  Real
+    implementations could load from a database or external service and
+    refresh periodically.
+    """
+
+    data = {}
+    data.update(_CPT)
+    data.update(_ICD10)
+    data.update(_HCPCS)
+    return data
+
+# ---------------------------------------------------------------------------
+# Code conflicts
+# ---------------------------------------------------------------------------
+
+# Simple conflict table used by validation.  Each tuple represents a
+# mutually exclusive combination along with a short reason.
+_CONFLICTS: List[Tuple[str, str, str]] = [
+    ("99213", "99214", "Evaluation and management visit levels cannot be billed together"),
+]
+
+@lru_cache()
+def load_conflicts() -> List[Tuple[str, str, str]]:
+    return _CONFLICTS
+

--- a/backend/main.py
+++ b/backend/main.py
@@ -82,6 +82,7 @@ from backend.scheduling import (  # type: ignore
     export_appointment_ics,
     get_appointment,
 )
+from backend.codes_data import load_code_metadata, load_conflicts  # type: ignore
 from backend.auth import (  # type: ignore
     authenticate_user,
     hash_password,
@@ -2489,3 +2490,97 @@ async def export_schedule_appointment(req: ScheduleExportRequest, user=Depends(r
         raise HTTPException(status_code=404, detail="appointment not found")
     return {"ics": export_appointment_ics(appt)}
 # ---------------------------------------------------------------------------
+
+# ------------------------- Coding & Billing APIs ---------------------------
+
+
+class CodesRequest(BaseModel):
+    codes: List[str]
+
+
+class BillingRequest(CodesRequest):
+    payerType: Optional[str] = None
+    location: Optional[str] = None
+
+
+@app.post("/api/codes/details/batch")
+async def code_details_batch(
+    req: CodesRequest, user=Depends(require_role("user"))
+) -> List[Dict[str, Any]]:
+    """Return metadata for a batch of billing/clinical codes."""
+
+    metadata = load_code_metadata()
+    details: List[Dict[str, Any]] = []
+    for code in req.codes:
+        info = metadata.get(code)
+        if info:
+            details.append(
+                {
+                    "code": code,
+                    "type": info["type"],
+                    "category": info["category"],
+                    "description": info["description"],
+                    "rationale": "Selected by user",
+                    "confidence": 100,
+                    "reimbursement": info.get("reimbursement"),
+                    "rvu": info.get("rvu"),
+                }
+            )
+        else:
+            details.append(
+                {
+                    "code": code,
+                    "type": "unknown",
+                    "category": "codes",
+                    "description": "Unknown code",
+                    "rationale": "Not found",
+                    "confidence": 0,
+                    "reimbursement": 0.0,
+                    "rvu": 0.0,
+                }
+            )
+    return details
+
+
+@app.post("/api/billing/calculate")
+async def billing_calculate(
+    req: BillingRequest, user=Depends(require_role("user"))
+) -> Dict[str, Any]:
+    """Calculate total reimbursement and RVUs for provided codes."""
+
+    metadata = load_code_metadata()
+    breakdown: List[Dict[str, Any]] = []
+    total_amount = 0.0
+    total_rvu = 0.0
+    for code in req.codes:
+        info = metadata.get(code)
+        amount = float(info.get("reimbursement", 0.0)) if info else 0.0
+        rvu = float(info.get("rvu", 0.0)) if info else 0.0
+        breakdown.append({"code": code, "amount": amount, "rvu": rvu})
+        total_amount += amount
+        total_rvu += rvu
+    return {
+        "totalEstimated": round(total_amount, 2),
+        "totalRvu": round(total_rvu, 2),
+        "breakdown": breakdown,
+    }
+
+
+@app.post("/api/codes/validate/combination")
+async def validate_code_combination(
+    req: CodesRequest, user=Depends(require_role("user"))
+) -> Dict[str, Any]:
+    """Check a set of codes for known conflicts."""
+
+    conflicts: List[Dict[str, str]] = []
+    conflict_defs = load_conflicts()
+    codes_set = set(req.codes)
+    for c1, c2, reason in conflict_defs:
+        if c1 in codes_set and c2 in codes_set:
+            conflicts.append({"code1": c1, "code2": c2, "reason": reason})
+    return {
+        "validCombinations": not conflicts,
+        "conflicts": conflicts,
+        "warnings": [],
+    }
+

--- a/tests/test_codes_billing.py
+++ b/tests/test_codes_billing.py
@@ -1,0 +1,74 @@
+import sqlite3
+import pytest
+from fastapi.testclient import TestClient
+
+from backend import main, migrations
+from backend.main import _init_core_tables
+
+
+@pytest.fixture
+def client(monkeypatch):
+    main.db_conn = sqlite3.connect(':memory:', check_same_thread=False)
+    main.db_conn.row_factory = sqlite3.Row
+    _init_core_tables(main.db_conn)
+    migrations.ensure_settings_table(main.db_conn)
+    pwd = main.hash_password("pw")
+    main.db_conn.execute(
+        "INSERT INTO users (username, password_hash, role) VALUES (?, ?, ?)",
+        ("user", pwd, "user"),
+    )
+    main.db_conn.commit()
+    monkeypatch.setattr(main, "db_conn", main.db_conn)
+    return TestClient(main.app)
+
+
+def auth_header(token: str):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def get_token(client: TestClient) -> str:
+    resp = client.post("/login", json={"username": "user", "password": "pw"})
+    assert resp.status_code == 200
+    return resp.json()["access_token"]
+
+
+def test_code_details_batch(client):
+    token = get_token(client)
+    resp = client.post(
+        "/api/codes/details/batch",
+        json={"codes": ["99213", "E11.9", "UNKNOWN"]},
+        headers=auth_header(token),
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 3
+    assert any(d["code"] == "99213" and d["rvu"] > 0 for d in data)
+    assert any(d["code"] == "E11.9" and d["type"] == "ICD-10" for d in data)
+
+
+def test_billing_calculate(client):
+    token = get_token(client)
+    resp = client.post(
+        "/api/billing/calculate",
+        json={"codes": ["99213", "J3490"]},
+        headers=auth_header(token),
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["totalEstimated"] == pytest.approx(85.32, rel=1e-2)
+    assert data["totalRvu"] == pytest.approx(1.29, rel=1e-2)
+    assert len(data["breakdown"]) == 2
+
+
+def test_validate_combination(client):
+    token = get_token(client)
+    resp = client.post(
+        "/api/codes/validate/combination",
+        json={"codes": ["99213", "99214"]},
+        headers=auth_header(token),
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["conflicts"]
+    assert not data["validCombinations"]
+


### PR DESCRIPTION
## Summary
- add cached CPT/ICD-10/HCPCS metadata with reimbursement and conflict tables
- implement `/api/codes/details/batch`, `/api/billing/calculate`, and `/api/codes/validate/combination`
- cover new functionality with tests

## Testing
- `pytest tests/test_codes_billing.py::test_billing_calculate -q --cov-fail-under=0`
- `pytest tests/test_blockers.py::test_electron_packaging_configuration_present tests/test_metrics.py::test_metrics_empty_returns_zeros tests/test_metrics.py::test_metrics_timeseries_and_range -q --cov-fail-under=0` *(fails: linux code signing link missing; KeyError: 'top_compliance'; KeyError: 'beautify')*

------
https://chatgpt.com/codex/tasks/task_e_68c49dc33f44832486b49ecf6ac25aaa