### PR TITLE
Add layout preference endpoints and centralized error logging

### DIFF
--- a/backend/migrations.py
+++ b/backend/migrations.py
@@ -24,6 +24,7 @@ def ensure_settings_table(conn: sqlite3.Connection) -> None:
         "use_local_models INTEGER NOT NULL DEFAULT 0,"
         "agencies TEXT NOT NULL DEFAULT '[]',"
         "use_offline_mode INTEGER NOT NULL DEFAULT 0,"
+        "layout_prefs TEXT NOT NULL DEFAULT '{}',"
         "FOREIGN KEY(user_id) REFERENCES users(id)"
         ")"
     )
@@ -74,6 +75,10 @@ def ensure_settings_table(conn: sqlite3.Connection) -> None:
     if "use_offline_mode" not in columns:
         conn.execute(
             "ALTER TABLE settings ADD COLUMN use_offline_mode INTEGER NOT NULL DEFAULT 0"
+        )
+    if "layout_prefs" not in columns:
+        conn.execute(
+            "ALTER TABLE settings ADD COLUMN layout_prefs TEXT NOT NULL DEFAULT '{}'"
         )
 
 
@@ -138,4 +143,18 @@ def ensure_events_table(conn: sqlite3.Connection) -> None:
     if "satisfaction" not in columns:
         conn.execute("ALTER TABLE events ADD COLUMN satisfaction INTEGER")
 
+    conn.commit()
+
+
+def ensure_error_log_table(conn: sqlite3.Connection) -> None:
+    """Ensure the error_log table exists for centralized error capture."""
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS error_log ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "timestamp REAL NOT NULL,"
+        "username TEXT,"
+        "message TEXT NOT NULL,"
+        "stack TEXT"
+        ")"
+    )
     conn.commit()

--- a/package.json
+++ b/package.json
@@ -100,7 +100,9 @@
         "AppImage",
         "deb"
       ],
-      "category": "Utility"
+      "category": "Utility",
+      "cscLink": "${env.LINUX_CSC_LINK}",
+      "cscKeyPassword": "${env.LINUX_CSC_KEY_PASSWORD}"
     },
     "publish": [
       {

--- a/tests/test_error_logging.py
+++ b/tests/test_error_logging.py
@@ -1,0 +1,37 @@
+import sqlite3
+import sqlite3
+from fastapi.testclient import TestClient
+
+import backend.main as main
+from backend import auth
+
+
+def setup_module(module):
+    main.db_conn = sqlite3.connect(":memory:", check_same_thread=False)
+    main.db_conn.row_factory = sqlite3.Row
+    main.db_conn.execute(
+        "CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT, eventType TEXT, timestamp REAL, details TEXT, revenue REAL, time_to_close REAL, codes TEXT, compliance_flags TEXT, public_health INTEGER, satisfaction INTEGER)"
+    )
+    main.db_conn.execute(
+        "CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password_hash TEXT, role TEXT)"
+    )
+    main.db_conn.execute(
+        "CREATE TABLE audit_log (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp REAL, username TEXT, action TEXT, details TEXT)"
+    )
+    main.ensure_settings_table(main.db_conn)
+    main.ensure_error_log_table(main.db_conn)
+    auth.register_user(main.db_conn, "alice", "pw")
+
+
+def test_error_logging_with_user():
+    client = TestClient(main.app)
+    token = client.post("/login", json={"username": "alice", "password": "pw"}).json()["access_token"]
+    resp = client.post(
+        "/api/errors/log",
+        json={"message": "boom", "stack": "trace"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    row = main.db_conn.execute("SELECT username, message FROM error_log").fetchone()
+    assert row["username"] == "alice"
+    assert row["message"] == "boom"

--- a/tests/test_layout_preferences.py
+++ b/tests/test_layout_preferences.py
@@ -1,0 +1,45 @@
+import sqlite3
+from fastapi.testclient import TestClient
+
+import backend.main as main
+from backend import auth
+
+
+def setup_module(module):
+    # Set up in-memory database and required tables
+    main.db_conn = sqlite3.connect(":memory:", check_same_thread=False)
+    main.db_conn.row_factory = sqlite3.Row
+    main.db_conn.execute(
+        "CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT, eventType TEXT, timestamp REAL, details TEXT, revenue REAL, time_to_close REAL, codes TEXT, compliance_flags TEXT, public_health INTEGER, satisfaction INTEGER)"
+    )
+    main.db_conn.execute(
+        "CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password_hash TEXT, role TEXT)"
+    )
+    main.db_conn.execute(
+        "CREATE TABLE audit_log (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp REAL, username TEXT, action TEXT, details TEXT)"
+    )
+    main.ensure_settings_table(main.db_conn)
+    main.ensure_error_log_table(main.db_conn)
+    auth.register_user(main.db_conn, "alice", "pw")
+
+
+def _token():
+    client = TestClient(main.app)
+    return client.post("/login", json={"username": "alice", "password": "pw"}).json()["access_token"]
+
+
+def test_layout_preferences_roundtrip():
+    client = TestClient(main.app)
+    token = _token()
+    headers = {"Authorization": f"Bearer {token}"}
+    # Initially empty
+    resp = client.get("/api/user/layout-preferences", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json() == {}
+    payload = {"panels": [{"id": "a", "visible": True}]}
+    resp = client.put("/api/user/layout-preferences", json=payload, headers=headers)
+    assert resp.status_code == 200
+    assert resp.json() == payload
+    resp = client.get("/api/user/layout-preferences", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json() == payload

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -22,5 +22,6 @@ def test_ensure_settings_table_adds_columns():
         "region",
         "use_local_models",
         "agencies",
+        "layout_prefs",
     } <= cols
     conn.close()


### PR DESCRIPTION
## Summary
- persist per-user layout preferences through `/api/user/layout-preferences`
- capture client errors via `/api/errors/log` and new `error_log` table
- expose `/ws/notifications` websocket for system notifications
- add Linux code-signing placeholders to Electron build config

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c49dc748248324813e57f3b931f313