### PR TITLE
feat: add note finalization endpoints

### DIFF
--- a/BACKEND_DATA_INTEGRATION_ANALYSIS.md
+++ b/BACKEND_DATA_INTEGRATION_ANALYSIS.md
@@ -27,7 +27,7 @@ This document identifies every UI element in the RevenuePilot application that r
 | **Speech-to-Text Transcription** | `{ transcript: string, confidence: number, isInterim: boolean, timestamp: number, speakerLabel?: "doctor" \| "patient" }` (streaming) | `/api/transcribe/stream` | While recording active | ⚠️ **NEEDS IMPLEMENTATION** - Mock data simulation |
 | **Real-time Compliance Analysis** | `Array<ComplianceIssue>` (see ComplianceIssue interface) | `/api/compliance/analyze` | Note content change, real-time analysis | ⚠️ **NEEDS IMPLEMENTATION** - Static demo data |
 | **Note Auto-save** | `{ noteId: string, content: string, lastSaved: string, version: number, conflicts?: boolean }` | `/api/notes/auto-save` | Every 30 seconds during active session | ⚠️ **NEEDS IMPLEMENTATION** - No persistence |
-| **Finalization Workflow** | `{ canFinalize: boolean, requiredFields: Array<string>, missingDocumentation: Array<string>, estimatedReimbursement: number }` | `/api/notes/finalize-check` | Before finalization | ⚠️ **NEEDS IMPLEMENTATION** - Basic client validation only |
+| **Finalization Workflow** | `{ canFinalize: boolean, requiredFields: Array<string>, missingDocumentation: Array<string>, estimatedReimbursement: number }` | `/api/notes/pre-finalize-check` | Before finalization | ✅ **IMPLEMENTED** - Server-side validation available |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -100,7 +100,9 @@
         "AppImage",
         "deb"
       ],
-      "category": "Utility"
+      "category": "Utility",
+      "cscLink": "${env.CSC_LINK}",
+      "cscKeyPassword": "${env.CSC_KEY_PASSWORD}"
     },
     "publish": [
       {


### PR DESCRIPTION
## Summary
- add pre-finalize check and finalize note endpoints with validation and reimbursement summaries
- mark finalization workflow implemented in data integration docs
- add linux code signing placeholders to package.json
- cover new endpoints with tests and expose compliance metrics improvements

## Testing
- `pytest >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68c4e972a4248324826493c702780d5c