### PR TITLE
Add patient management endpoints and database tables

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -73,6 +73,9 @@ from backend.migrations import (  # type: ignore
     ensure_settings_table,
     ensure_templates_table,
     ensure_events_table,
+    ensure_patients_table,
+    ensure_encounters_table,
+    ensure_visit_sessions_table,
 )
 from backend.templates import TemplateModel, load_builtin_templates  # type: ignore
 from backend.scheduling import DEFAULT_EVENT_SUMMARY, export_ics, recommend_follow_up  # type: ignore
@@ -296,6 +299,7 @@ transcript_history: Dict[str, deque] = defaultdict(
 data_dir = user_data_dir(APP_NAME, APP_NAME)
 os.makedirs(data_dir, exist_ok=True)
 DB_PATH = os.path.join(data_dir, "analytics.db")
+UPLOAD_DIR = Path(os.getenv("CHART_UPLOAD_DIR", os.path.join(data_dir, "uploaded_charts")))
 
 # Migrate previous database file from the repository directory if it exists
 old_db_path = os.path.join(os.path.dirname(__file__), "analytics.db")
@@ -363,6 +367,9 @@ def _init_core_tables(conn):  # pragma: no cover - invoked in tests indirectly
     ensure_settings_table(conn)
     ensure_templates_table(conn)
     ensure_events_table(conn)
+    ensure_patients_table(conn)
+    ensure_encounters_table(conn)
+    ensure_visit_sessions_table(conn)
     conn.commit()
 
 
@@ -391,6 +398,11 @@ ensure_settings_table(db_conn)
 
 # Table storing user and clinic specific note templates.
 ensure_templates_table(db_conn)
+
+# Core clinical data tables.
+ensure_patients_table(db_conn)
+ensure_encounters_table(db_conn)
+ensure_visit_sessions_table(db_conn)
 
 # Configure the database connection to return rows as dictionaries.  This
 # makes it easier to access columns by name when querying events for
@@ -1465,8 +1477,8 @@ async def get_metrics(
         totals_query = f"""
             SELECT
                 SUM(CASE WHEN eventType IN ('note_started','note_saved') THEN 1 ELSE 0 END) AS total_notes,
-                SUM(CASE WHEN eventType='beautify' THEN 1 ELSE 0 END)        AS total_beautify,
-                SUM(CASE WHEN eventType='suggest' THEN 1 ELSE 0 END)         AS total_suggest,
+                SUM(CASE WHEN eventType='beautify' THEN 1 ELSE 0 END)        AS beautify,
+                SUM(CASE WHEN eventType='suggest' THEN 1 ELSE 0 END)         AS suggest,
                 SUM(CASE WHEN eventType='summary' THEN 1 ELSE 0 END)         AS total_summary,
                 SUM(CASE WHEN eventType='chart_upload' THEN 1 ELSE 0 END)    AS total_chart_upload,
                 SUM(CASE WHEN eventType='audio_recorded' THEN 1 ELSE 0 END)  AS total_audio,
@@ -1483,8 +1495,8 @@ async def get_metrics(
         totals = dict(row) if row else {}
         metrics: Dict[str, Any] = {
             "total_notes": totals.get("total_notes", 0) or 0,
-            "total_beautify": totals.get("total_beautify", 0) or 0,
-            "total_suggest": totals.get("total_suggest", 0) or 0,
+            "beautify": totals.get("beautify", 0) or 0,
+            "suggest": totals.get("suggest", 0) or 0,
             "total_summary": totals.get("total_summary", 0) or 0,
             "total_chart_upload": totals.get("total_chart_upload", 0) or 0,
             "total_audio": totals.get("total_audio", 0) or 0,
@@ -1660,8 +1672,8 @@ async def get_metrics(
             SELECT
                 date(datetime(timestamp, 'unixepoch')) AS date,
                 SUM(CASE WHEN eventType IN ('note_started','note_saved') THEN 1 ELSE 0 END) AS notes,
-                SUM(CASE WHEN eventType='beautify' THEN 1 ELSE 0 END)   AS total_beautify,
-                SUM(CASE WHEN eventType='suggest' THEN 1 ELSE 0 END)    AS total_suggest,
+                SUM(CASE WHEN eventType='beautify' THEN 1 ELSE 0 END)   AS beautify,
+                SUM(CASE WHEN eventType='suggest' THEN 1 ELSE 0 END)    AS suggest,
                 SUM(CASE WHEN eventType='summary' THEN 1 ELSE 0 END)    AS total_summary,
                 SUM(CASE WHEN eventType='chart_upload' THEN 1 ELSE 0 END) AS total_chart_upload,
                 SUM(CASE WHEN eventType='audio_recorded' THEN 1 ELSE 0 END) AS total_audio,
@@ -1794,8 +1806,8 @@ async def get_metrics(
 
     keys = [
         "total_notes",
-        "total_beautify",
-        "total_suggest",
+        "beautify",
+        "suggest",
         "total_summary",
         "total_chart_upload",
         "total_audio",
@@ -1812,6 +1824,13 @@ async def get_metrics(
         for k in keys
     }
 
+    top_compliance = [
+        k
+        for k, _ in sorted(
+            compliance_counts.items(), key=lambda kv: kv[1], reverse=True
+        )[:5]
+    ]
+
     return {
         "baseline": baseline_metrics,
         "current": current_metrics,
@@ -1819,6 +1838,7 @@ async def get_metrics(
         "coding_distribution": coding_distribution,
         "denial_rates": denial_rates,
         "compliance_counts": compliance_counts,
+        "top_compliance": top_compliance,
         "public_health_rate": public_health_rate,
         "avg_satisfaction": avg_satisfaction,
         "template_usage": {
@@ -2489,3 +2509,110 @@ async def export_schedule_appointment(req: ScheduleExportRequest, user=Depends(r
         raise HTTPException(status_code=404, detail="appointment not found")
     return {"ics": export_appointment_ics(appt)}
 # ---------------------------------------------------------------------------
+
+
+class VisitSessionCreate(BaseModel):
+    encounter_id: int
+
+
+class VisitSessionUpdate(BaseModel):
+    session_id: int
+    action: str
+
+
+@app.get("/api/patients/search")
+async def search_patients(q: str, user=Depends(require_role("user"))):
+    like = f"%{q}%"
+    rows = db_conn.execute(
+        "SELECT id, first_name, last_name, dob, mrn FROM patients WHERE first_name LIKE ? OR last_name LIKE ? OR mrn LIKE ? LIMIT 10",
+        (like, like, like),
+    ).fetchall()
+    return [
+        {
+            "patientId": r["id"],
+            "name": f"{r['first_name']} {r['last_name']}",
+            "dob": r["dob"],
+            "mrn": r["mrn"],
+        }
+        for r in rows
+    ]
+
+
+@app.get("/api/patients/{patient_id}")
+async def get_patient(patient_id: int, user=Depends(require_role("user"))):
+    row = db_conn.execute("SELECT * FROM patients WHERE id=?", (patient_id,)).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="patient not found")
+    return {
+        "demographics": {
+            "patientId": row["id"],
+            "name": f"{row['first_name']} {row['last_name']}",
+            "dob": row["dob"],
+            "gender": row["gender"],
+        },
+        "allergies": json.loads(row["allergies"] or "[]"),
+        "medications": json.loads(row["medications"] or "[]"),
+        "lastVisit": row["last_visit"],
+        "insurance": row["insurance"],
+    }
+
+
+@app.get("/api/encounters/validate/{encounter_id}")
+async def validate_encounter(encounter_id: int, user=Depends(require_role("user"))):
+    row = db_conn.execute("SELECT * FROM encounters WHERE id=?", (encounter_id,)).fetchone()
+    if not row:
+        return {"valid": False, "error": "Encounter not found"}
+    return {
+        "valid": True,
+        "patientId": row["patient_id"],
+        "date": row["date"],
+        "type": row["type"],
+        "provider": row["provider"],
+    }
+
+
+@app.post("/api/visits/session")
+async def start_visit_session(model: VisitSessionCreate, user=Depends(require_role("user"))):
+    now = datetime.utcnow().isoformat()
+    cursor = db_conn.cursor()
+    cursor.execute(
+        "INSERT INTO visit_sessions (encounter_id, status, start_time) VALUES (?, ?, ?)",
+        (model.encounter_id, "started", now),
+    )
+    session_id = cursor.lastrowid
+    db_conn.commit()
+    return {"sessionId": session_id, "status": "started", "startTime": now}
+
+
+@app.put("/api/visits/session")
+async def update_visit_session(model: VisitSessionUpdate, user=Depends(require_role("user"))):
+    row = db_conn.execute("SELECT * FROM visit_sessions WHERE id=?", (model.session_id,)).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="session not found")
+    end_time = row["end_time"]
+    status = model.action
+    if model.action == "complete":
+        end_time = datetime.utcnow().isoformat()
+    db_conn.execute(
+        "UPDATE visit_sessions SET status=?, end_time=? WHERE id=?",
+        (status, end_time, model.session_id),
+    )
+    db_conn.commit()
+    updated = db_conn.execute("SELECT * FROM visit_sessions WHERE id=?", (model.session_id,)).fetchone()
+    return {
+        "sessionId": updated["id"],
+        "status": updated["status"],
+        "startTime": updated["start_time"],
+        "endTime": updated["end_time"],
+    }
+
+
+@app.post("/api/charts/upload")
+async def upload_chart(file: UploadFile = File(...), user=Depends(require_role("user"))):
+    UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+    contents = await file.read()
+    dest = UPLOAD_DIR / file.filename
+    with open(dest, "wb") as f:
+        f.write(contents)
+    return {"filename": file.filename, "size": len(contents)}
+

--- a/backend/migrations.py
+++ b/backend/migrations.py
@@ -139,3 +139,55 @@ def ensure_events_table(conn: sqlite3.Connection) -> None:
         conn.execute("ALTER TABLE events ADD COLUMN satisfaction INTEGER")
 
     conn.commit()
+
+
+def ensure_patients_table(conn: sqlite3.Connection) -> None:
+    """Ensure the patients table exists for storing patient demographics."""
+
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS patients ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "first_name TEXT,"
+        "last_name TEXT,"
+        "dob TEXT,"
+        "mrn TEXT,"
+        "gender TEXT,"
+        "insurance TEXT,"
+        "last_visit TEXT,"
+        "allergies TEXT,"
+        "medications TEXT"
+        ")"
+    )
+    conn.commit()
+
+
+def ensure_encounters_table(conn: sqlite3.Connection) -> None:
+    """Ensure the encounters table exists for tracking patient encounters."""
+
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS encounters ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "patient_id INTEGER NOT NULL,"
+        "date TEXT,"
+        "type TEXT,"
+        "provider TEXT,"
+        "FOREIGN KEY(patient_id) REFERENCES patients(id)"
+        ")"
+    )
+    conn.commit()
+
+
+def ensure_visit_sessions_table(conn: sqlite3.Connection) -> None:
+    """Ensure the visit_sessions table exists for visit timing data."""
+
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS visit_sessions ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "encounter_id INTEGER NOT NULL,"
+        "status TEXT NOT NULL,"
+        "start_time TEXT,"
+        "end_time TEXT,"
+        "FOREIGN KEY(encounter_id) REFERENCES encounters(id)"
+        ")"
+    )
+    conn.commit()

--- a/package.json
+++ b/package.json
@@ -100,7 +100,9 @@
         "AppImage",
         "deb"
       ],
-      "category": "Utility"
+      "category": "Utility",
+      "cscLink": "${env.LINUX_CSC_LINK}",
+      "cscKeyPassword": "${env.LINUX_CSC_PASSWORD}"
     },
     "publish": [
       {

--- a/tests/test_patient_endpoints.py
+++ b/tests/test_patient_endpoints.py
@@ -1,0 +1,120 @@
+import json
+import sqlite3
+from collections import defaultdict, deque
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend import main, migrations
+from backend.main import _init_core_tables
+
+
+def auth_header(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    main.db_conn = sqlite3.connect(':memory:', check_same_thread=False)
+    main.db_conn.row_factory = sqlite3.Row
+    _init_core_tables(main.db_conn)
+    migrations.ensure_patients_table(main.db_conn)
+    migrations.ensure_encounters_table(main.db_conn)
+    migrations.ensure_visit_sessions_table(main.db_conn)
+    pwd = main.hash_password("pw")
+    main.db_conn.execute(
+        "INSERT INTO users (username, password_hash, role) VALUES (?, ?, ?)",
+        ("user", pwd, "user"),
+    )
+    main.db_conn.commit()
+    monkeypatch.setattr(main, 'db_conn', main.db_conn)
+    monkeypatch.setattr(main, 'events', [])
+    monkeypatch.setattr(
+        main,
+        'transcript_history',
+        defaultdict(lambda: deque(maxlen=main.TRANSCRIPT_HISTORY_LIMIT)),
+    )
+    upload_dir = tmp_path / 'uploads'
+    monkeypatch.setattr(main, 'UPLOAD_DIR', upload_dir)
+    return TestClient(main.app)
+
+
+def test_patient_encounter_flow(client):
+    db = main.db_conn
+    # insert patients
+    db.execute(
+        "INSERT INTO patients (first_name, last_name, dob, mrn, gender, insurance, last_visit, allergies, medications) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            'John',
+            'Doe',
+            '1980-01-01',
+            'MRN123',
+            'M',
+            'Blue',
+            '2024-01-01',
+            json.dumps(['peanuts']),
+            json.dumps(['aspirin']),
+        ),
+    )
+    john_id = db.execute("SELECT last_insert_rowid()").fetchone()[0]
+    db.execute(
+        "INSERT INTO patients (first_name, last_name, dob, mrn, gender, insurance, last_visit, allergies, medications) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            'Jane',
+            'Smith',
+            '1990-02-02',
+            'MRN456',
+            'F',
+            'Aetna',
+            '2024-02-02',
+            '[]',
+            '[]',
+        ),
+    )
+    jane_id = db.execute("SELECT last_insert_rowid()").fetchone()[0]
+    # insert encounter
+    db.execute(
+        "INSERT INTO encounters (patient_id, date, type, provider) VALUES (?, ?, ?, ?)",
+        (john_id, '2024-03-01', 'checkup', 'Dr. House'),
+    )
+    encounter_id = db.execute("SELECT last_insert_rowid()").fetchone()[0]
+    db.commit()
+
+    token = client.post('/login', json={'username': 'user', 'password': 'pw'}).json()['access_token']
+
+    # search patients
+    resp = client.get('/api/patients/search', params={'q': 'Jane'}, headers=auth_header(token))
+    assert resp.status_code == 200
+    results = resp.json()
+    assert any(r['patientId'] == jane_id for r in results)
+
+    # patient details
+    resp = client.get(f'/api/patients/{john_id}', headers=auth_header(token))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['demographics']['name'] == 'John Doe'
+    assert data['allergies'] == ['peanuts']
+
+    # encounter validation
+    resp = client.get(f'/api/encounters/validate/{encounter_id}', headers=auth_header(token))
+    assert resp.status_code == 200
+    assert resp.json()['valid'] is True
+    resp = client.get('/api/encounters/validate/999', headers=auth_header(token))
+    assert resp.status_code == 200
+    assert resp.json()['valid'] is False
+
+    # visit session start and complete
+    resp = client.post('/api/visits/session', json={'encounter_id': encounter_id}, headers=auth_header(token))
+    assert resp.status_code == 200
+    session_id = resp.json()['sessionId']
+    resp = client.put('/api/visits/session', json={'session_id': session_id, 'action': 'complete'}, headers=auth_header(token))
+    assert resp.status_code == 200
+    assert resp.json()['status'] == 'complete'
+
+    # chart upload
+    resp = client.post('/api/charts/upload', files={'file': ('chart.txt', b'123')}, headers=auth_header(token))
+    assert resp.status_code == 200
+    info = resp.json()
+    assert info['filename'] == 'chart.txt'
+    assert info['size'] == 3
+    assert (main.UPLOAD_DIR / 'chart.txt').exists()


### PR DESCRIPTION
## Summary
- add migrations and models for patients, encounters and visit sessions
- implement patient search/detail, encounter validation, visit session, and chart upload endpoints
- expose beautify/suggest metrics and top compliance list
- configure Linux code-signing fields for electron builds

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4e97694e08324894e2ee351412845