### PR TITLE
Add medical code validation, sanitize inputs, and secure websockets

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -122,6 +122,7 @@ from backend.auth import (  # type: ignore
     verify_password,
 )
 from backend import deid as deid_module  # type: ignore
+from backend.sanitizer import sanitize_text
 
 # When ``USE_OFFLINE_MODEL`` is set, endpoints will return deterministic
 # placeholder responses without calling external AI services.  This is useful
@@ -624,6 +625,22 @@ def require_role(role: str):
     return checker
 
 
+async def ws_require_role(websocket: WebSocket, role: str) -> Dict[str, Any]:
+    """Authenticate a websocket connection against a required role."""
+
+    auth = websocket.headers.get("Authorization")
+    if not auth or not auth.lower().startswith("bearer "):
+        await websocket.close(code=1008)
+        raise WebSocketDisconnect()
+    token = auth.split()[1]
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+    try:
+        return get_current_user(credentials, required_role=role)
+    except HTTPException:
+        await websocket.close(code=1008)
+        raise WebSocketDisconnect()
+
+
 # Model for setting API key via API endpoint
 class ApiKeyModel(BaseModel):
     key: str
@@ -1121,11 +1138,7 @@ async def log_client_error(model: ErrorLogModel, request: Request) -> Dict[str, 
     return {"status": "logged"}
 
 
-@app.websocket("/ws/notifications")
-async def notifications_ws(ws: WebSocket):
-    await ws.accept()
-    notification_clients.add(ws)
-    try:
+# Removed obsolete websocket handler
 
 @app.get("/api/formatting/rules")
 async def get_formatting_rules(user=Depends(require_role("user"))) -> Dict[str, Any]:
@@ -1245,26 +1258,20 @@ async def get_notification_count(
 
 
 @app.websocket("/ws/notifications")
-async def notifications_ws(websocket: WebSocket, token: str):
-    try:
-        data = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
-        username = data["sub"]
-    except jwt.PyJWTError:
-        await websocket.close(code=1008)
-        return
+async def notifications_ws(websocket: WebSocket):
+    user = await ws_require_role(websocket, "user")
+    username = user["sub"]
     await websocket.accept()
+    notification_clients.add(websocket)
     notification_subscribers[username].append(websocket)
     try:
         await websocket.send_json({"count": notification_counts[username]})
-
         while True:
             await asyncio.sleep(60)
     except WebSocketDisconnect:
         pass
     finally:
-
-        notification_clients.discard(ws)
-
+        notification_clients.discard(websocket)
         if websocket in notification_subscribers[username]:
             notification_subscribers[username].remove(websocket)
 
@@ -1280,7 +1287,7 @@ class NoteRequest(BaseModel):
     fields are appended to the note before sending to the AI model.
     """
 
-    text: str
+    text: str = Field(..., max_length=10000)
     chart: Optional[str] = None
     rules: Optional[List[str]] = None
     audio: Optional[str] = None
@@ -1300,28 +1307,48 @@ class NoteRequest(BaseModel):
     class Config:
         populate_by_name = True
 
+    @field_validator("text")
+    @classmethod
+    def sanitize_text_field(cls, v: str) -> str:  # noqa: D401,N805
+        return sanitize_text(v)
+
 
 
 class CodesSuggestRequest(BaseModel):
-    content: str
+    content: str = Field(..., max_length=10000)
     patientData: Optional[Dict[str, Any]] = None
     useLocalModels: Optional[bool] = False
     useOfflineMode: Optional[bool] = False
 
+    @field_validator("content")
+    @classmethod
+    def sanitize_content(cls, v: str) -> str:  # noqa: D401,N805
+        return sanitize_text(v)
+
 
 class ComplianceCheckRequest(BaseModel):
-    content: str
+    content: str = Field(..., max_length=10000)
     codes: Optional[List[str]] = None
     useLocalModels: Optional[bool] = False
     useOfflineMode: Optional[bool] = False
 
+    @field_validator("content")
+    @classmethod
+    def sanitize_content(cls, v: str) -> str:  # noqa: D401,N805
+        return sanitize_text(v)
+
 
 class DifferentialsGenerateRequest(BaseModel):
-    content: str
+    content: str = Field(..., max_length=10000)
     symptoms: Optional[List[str]] = None
     patientData: Optional[Dict[str, Any]] = None
     useLocalModels: Optional[bool] = False
     useOfflineMode: Optional[bool] = False
+
+    @field_validator("content")
+    @classmethod
+    def sanitize_content(cls, v: str) -> str:  # noqa: D401,N805
+        return sanitize_text(v)
 
 
 class PreventionSuggestRequest(BaseModel):
@@ -1332,10 +1359,15 @@ class PreventionSuggestRequest(BaseModel):
 
 
 class RealtimeAnalyzeRequest(BaseModel):
-    content: str
+    content: str = Field(..., max_length=10000)
     patientContext: Optional[Dict[str, Any]] = None
     useLocalModels: Optional[bool] = False
     useOfflineMode: Optional[bool] = False
+
+    @field_validator("content")
+    @classmethod
+    def sanitize_content(cls, v: str) -> str:  # noqa: D401,N805
+        return sanitize_text(v)
 
 class VisitSessionModel(BaseModel):  # pragma: no cover - simple schema
     id: Optional[int] = None
@@ -1345,13 +1377,31 @@ class VisitSessionModel(BaseModel):  # pragma: no cover - simple schema
 
 class AutoSaveModel(BaseModel):  # pragma: no cover - simple schema
     note_id: Optional[int] = None
-    content: str
+    content: str = Field(..., max_length=10000)
     beautifyModel: Optional[str] = None
     suggestModel: Optional[str] = None
     summarizeModel: Optional[str] = None
 
     class Config:
         populate_by_name = True
+
+    @field_validator("content")
+    @classmethod
+    def sanitize_content(cls, v: str) -> str:  # noqa: D401,N805
+        return sanitize_text(v)
+
+
+# Regular expressions for validating medical code formats
+CPT_CODE_RE = re.compile(r"^\d{5}$")
+ICD10_CODE_RE = re.compile(r"^[A-TV-Z][0-9][A-Z0-9](?:\.[A-Z0-9]{1,4})?$")
+HCPCS_CODE_RE = re.compile(r"^[A-Z]\d{4}$")
+
+
+def _validate_code(value: str) -> str:
+    """Validate that *value* matches a CPT, ICD-10 or HCPCS pattern."""
+    if any(r.match(value) for r in (CPT_CODE_RE, ICD10_CODE_RE, HCPCS_CODE_RE)):
+        return value
+    raise ValueError("invalid code format")
 
 
 
@@ -1362,6 +1412,11 @@ class CodeSuggestion(BaseModel):
     rationale: Optional[str] = None
     upgrade_to: Optional[str] = None
     upgradePath: Optional[str] = Field(None, alias="upgrade_path")
+
+    @field_validator("code")
+    @classmethod
+    def validate_code(cls, v: str) -> str:  # noqa: D401,N805
+        return _validate_code(v)
 
 
 class PublicHealthSuggestion(BaseModel):
@@ -1403,8 +1458,13 @@ class CodeSuggestItem(BaseModel):
     code: str
     type: Optional[str] = None
     description: Optional[str] = None
-    confidence: Optional[float] = None
+    confidence: Optional[float] = Field(None, ge=0.0, le=1.0)
     reasoning: Optional[str] = None
+
+    @field_validator("code")
+    @classmethod
+    def validate_code(cls, v: str) -> str:  # noqa: D401,N805
+        return _validate_code(v)
 
 
 class CodesSuggestResponse(BaseModel):
@@ -1415,7 +1475,7 @@ class ComplianceAlert(BaseModel):
     text: str
     category: Optional[str] = None
     priority: Optional[str] = None
-    confidence: Optional[float] = None
+    confidence: Optional[float] = Field(None, ge=0.0, le=1.0)
     reasoning: Optional[str] = None
 
 
@@ -1425,7 +1485,7 @@ class ComplianceCheckResponse(BaseModel):
 
 class DifferentialItem(BaseModel):
     diagnosis: str
-    confidence: Optional[float] = None
+    confidence: Optional[float] = Field(None, ge=0.0, le=1.0)
     reasoning: Optional[str] = None
     supportingFactors: Optional[List[str]] = None
     contradictingFactors: Optional[List[str]] = None
@@ -1440,7 +1500,7 @@ class PreventionItem(BaseModel):
     recommendation: str
     priority: Optional[str] = None
     source: Optional[str] = None
-    confidence: Optional[float] = None
+    confidence: Optional[float] = Field(None, ge=0.0, le=1.0)
     reasoning: Optional[str] = None
     ageRelevant: Optional[bool] = None
 
@@ -1454,7 +1514,7 @@ class RealtimeAnalysisResponse(BaseModel):
     extractedSymptoms: List[str]
     medicalHistory: List[str]
     currentMedications: List[str]
-    confidence: Optional[float] = None
+    confidence: Optional[float] = Field(None, ge=0.0, le=1.0)
     reasoning: Optional[str] = None
 
 
@@ -1760,7 +1820,12 @@ def delete_template(
 
 class AutoSaveRequest(BaseModel):
     noteId: str
-    content: str
+    content: str = Field(..., max_length=10000)
+
+    @field_validator("content")
+    @classmethod
+    def sanitize_content(cls, v: str) -> str:  # noqa: D401,N805
+        return sanitize_text(v)
 
 
 @app.post("/api/notes/auto-save")
@@ -1802,12 +1867,22 @@ class ExportRequest(BaseModel):
     When the FHIR server is not configured the generated bundle is returned
     directly instead of being posted so the client can download it manually.
     """
-    note: str
+    note: str = Field(..., max_length=10000)
     codes: List[str] = Field(default_factory=list)
     procedures: List[str] = Field(default_factory=list)
     medications: List[str] = Field(default_factory=list)
     patientID: Optional[str] = None
     encounterID: Optional[str] = None
+
+    @field_validator("note")
+    @classmethod
+    def sanitize_note(cls, v: str) -> str:  # noqa: D401,N805
+        return sanitize_text(v)
+
+    @field_validator("codes", "procedures", "medications")
+    @classmethod
+    def validate_codes(cls, v: List[str]) -> List[str]:  # noqa: D401,N805
+        return [_validate_code(c) for c in v]
     ehrSystem: Optional[str] = None
 
 async def _perform_ehr_export(req: ExportRequest) -> Dict[str, Any]:
@@ -2528,6 +2603,7 @@ async def update_visit_session(
 async def transcribe_stream(websocket: WebSocket):
     """Stream transcription via WebSocket."""
 
+    await ws_require_role(websocket, "user")
     await websocket.accept()
     try:
         while True:
@@ -3083,6 +3159,7 @@ async def codes_suggest(
 
 @app.websocket("/ws/api/ai/codes/suggest")
 async def ws_codes_suggest(websocket: WebSocket):
+    await ws_require_role(websocket, "user")
     await websocket.accept()
     data = await websocket.receive_json()
     resp = await _codes_suggest(CodesSuggestRequest(**data))
@@ -3138,6 +3215,7 @@ async def compliance_check(
 
 @app.websocket("/ws/api/ai/compliance/check")
 async def ws_compliance_check(websocket: WebSocket):
+    await ws_require_role(websocket, "user")
     await websocket.accept()
     data = await websocket.receive_json()
     resp = await _compliance_check(ComplianceCheckRequest(**data))
@@ -3196,6 +3274,7 @@ async def differentials_generate(
 
 @app.websocket("/ws/api/ai/differentials/generate")
 async def ws_differentials_generate(websocket: WebSocket):
+    await ws_require_role(websocket, "user")
     await websocket.accept()
     data = await websocket.receive_json()
     resp = await _differentials_generate(DifferentialsGenerateRequest(**data))
@@ -3253,6 +3332,7 @@ async def prevention_suggest(
 
 @app.websocket("/ws/api/ai/prevention/suggest")
 async def ws_prevention_suggest(websocket: WebSocket):
+    await ws_require_role(websocket, "user")
     await websocket.accept()
     data = await websocket.receive_json()
     resp = await _prevention_suggest(PreventionSuggestRequest(**data))
@@ -3312,6 +3392,7 @@ async def realtime_analyze(
 
 @app.websocket("/ws/api/ai/analyze/realtime")
 async def ws_realtime_analyze(websocket: WebSocket):
+    await ws_require_role(websocket, "user")
     await websocket.accept()
     data = await websocket.receive_json()
     resp = await _realtime_analyze(RealtimeAnalyzeRequest(**data))
@@ -3384,6 +3465,19 @@ async def finalize_check(req: NoteRequest, user=Depends(require_role("user"))):
         {
             "role": "system",
             "content": "Return JSON {\"ok\": bool, \"issues\": []} indicating remaining problems.",
+        },
+        {"role": "user", "content": cleaned},
+    ]
+    try:
+        response_content = call_openai(messages)
+        data = json.loads(response_content)
+        ok = bool(data.get("ok", True))
+        issues = [str(x) for x in data.get("issues", [])]
+    except Exception:
+        ok = True
+        issues = []
+    return {"ok": ok, "issues": issues}
+
 
 class AnalyzeRequest(BaseModel):
     text: str
@@ -3407,15 +3501,11 @@ async def analyze_note(
         {"role": "user", "content": cleaned},
     ]
     try:
-
         response_content = call_openai(messages)
         data = json.loads(response_content)
-        ok = bool(data.get("ok", True))
-        issues = [str(x) for x in data.get("issues", [])]
     except Exception:
-        ok = True
-        issues = []
-    return {"ok": ok, "issues": issues}
+        data = {}
+    return {"analysis": data}
 
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,4 +20,5 @@ passlib[bcrypt]
 llama-cpp-python
 requests-mock
 cryptography
+bleach
 

--- a/backend/sanitizer.py
+++ b/backend/sanitizer.py
@@ -1,0 +1,8 @@
+import bleach
+
+def sanitize_text(value: str) -> str:
+    """Return a sanitized version of *value* with HTML stripped.
+
+    This removes any HTML tags to mitigate XSS attacks.
+    """
+    return bleach.clean(value, tags=[], attributes={}, strip=True)

--- a/backend/templates.py
+++ b/backend/templates.py
@@ -1,19 +1,26 @@
 from typing import Optional, List, Any
-from pydantic import BaseModel
 import sqlite3
+
 from fastapi import HTTPException
+from pydantic import BaseModel, Field, field_validator
 
 from backend import prompts as prompt_utils
+from backend.sanitizer import sanitize_text
 
 
 class TemplateModel(BaseModel):
     """Schema for note templates that can be filtered by specialty or payer."""
 
     id: Optional[int] = None
-    name: str
-    content: str
+    name: str = Field(..., max_length=100)
+    content: str = Field(..., max_length=5000)
     specialty: Optional[str] = None
     payer: Optional[str] = None
+
+    @field_validator("name", "content")
+    @classmethod
+    def sanitize_fields(cls, v: str) -> str:  # noqa: D401,N805
+        return sanitize_text(v)
 
 
 # Built-in templates shipped with the application.  Negative identifiers are


### PR DESCRIPTION
## Summary
- add sanitizer utility and apply HTML stripping with length limits on notes and templates
- validate CPT/ICD-10/HCPCS code formats and clamp confidence scores between 0 and 1
- enforce role-based auth for websocket endpoints via shared helper

## Testing
- `pytest` *(fails: SyntaxError: invalid syntax in backend/migrations.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c8153287dc83249dd074151ce000af