### PR TITLE
Add compliance monitoring endpoints and persistence

### DIFF
--- a/backend/compliance.py
+++ b/backend/compliance.py
@@ -1,0 +1,353 @@
+"""Compliance rule engine and knowledge base helpers.
+
+This module exposes a lightweight rule engine used by the REST endpoints in
+``backend.main``.  Rules are represented as dictionaries so they can be easily
+serialised and surfaced in the UI.  The engine focuses on deterministic and
+transparent checks so it can run without external dependencies or network
+access.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from typing import Any, Dict, Iterable, List, Optional
+from uuid import uuid4
+
+# ---------------------------------------------------------------------------
+# Rule catalogue
+# ---------------------------------------------------------------------------
+
+_DEFAULT_RULES: List[Dict[str, Any]] = [
+    {
+        "id": "documentation-chief-complaint",
+        "name": "Document the chief complaint",
+        "description": (
+            "Evaluation and Management documentation requires a clearly "
+            "documented chief complaint. Include the patient's presenting "
+            "concern near the top of the note."
+        ),
+        "category": "documentation",
+        "severity": "high",
+        "type": "absence",
+        "keywords": ["chief complaint", "cc:"],
+        "recommendedAction": "Add a section describing the patient's chief complaint.",
+        "references": [
+            {
+                "title": "1995/1997 E&M Documentation Guidelines",
+                "url": "https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/Downloads/eval-mgmt-serv-guide-ICN006764.pdf",
+            }
+        ],
+    },
+    {
+        "id": "documentation-review-of-systems",
+        "name": "Include a Review of Systems",
+        "description": (
+            "Higher level visits typically require at least one system to be "
+            "reviewed. Document positive and pertinent negatives for clarity."
+        ),
+        "category": "documentation",
+        "severity": "medium",
+        "type": "absence",
+        "keywords": ["review of systems", "ros"],
+        "recommendedAction": "Document the Review of Systems with any pertinent findings.",
+        "references": [
+            {
+                "title": "Medicare E\u0026M Services Guide",
+                "url": "https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/downloads/eval-mgmt-serv-guide-ICN006764.pdf",
+            }
+        ],
+    },
+    {
+        "id": "documentation-hpi-elements",
+        "name": "Capture key HPI elements",
+        "description": (
+            "Level 4/5 visits require four or more history of present illness "
+            "elements such as location, duration, severity, timing or modifying "
+            "factors."
+        ),
+        "category": "billing",
+        "severity": "high",
+        "type": "count",
+        "threshold": 4,
+        "keywords": [
+            "location",
+            "duration",
+            "severity",
+            "timing",
+            "context",
+            "modifying factors",
+            "associated signs",
+            "associated symptoms",
+        ],
+        "recommendedAction": "Document at least four distinct HPI elements to support coding.",
+        "references": [
+            {
+                "title": "E\u0026M HPI Elements",
+                "url": "https://www.aapc.com/resources/medical-coding/em-documentation.aspx",
+            }
+        ],
+    },
+    {
+        "id": "telehealth-consent",
+        "name": "Telehealth consent documented",
+        "description": (
+            "When the visit type is telehealth, consent must be obtained and "
+            "recorded in the encounter documentation."
+        ),
+        "category": "regulatory",
+        "severity": "high",
+        "type": "conditional_absence",
+        "metadata_key": "visitType",
+        "metadata_values": ["telehealth", "virtual", "remote"],
+        "keywords": ["telehealth consent", "verbal consent", "informed consent"],
+        "recommendedAction": "Record that the patient provided consent for the telehealth visit.",
+        "references": [
+            {
+                "title": "CMS Telehealth Guidance",
+                "url": "https://www.cms.gov/newsroom/fact-sheets/medicare-telemedicine-health-care-provider-fact-sheet",
+            }
+        ],
+    },
+    {
+        "id": "privacy-sensitive-identifiers",
+        "name": "Remove sensitive identifiers",
+        "description": (
+            "Clinical documentation should avoid storing Social Security numbers "
+            "or full financial account numbers to remain HIPAA compliant."
+        ),
+        "category": "privacy",
+        "severity": "critical",
+        "type": "presence",
+        "keywords": ["social security", "ssn", "credit card", "123-45-6789"],
+        "recommendedAction": "Remove sensitive identifiers before saving or transmitting the note.",
+        "references": [
+            {
+                "title": "HIPAA Privacy Rule",
+                "url": "https://www.hhs.gov/hipaa/for-professionals/privacy/index.html",
+            }
+        ],
+    },
+]
+
+
+_RESOURCE_LIBRARY: List[Dict[str, Any]] = [
+    {
+        "title": "CMS Documentation Requirements for E\u0026M Services",
+        "url": "https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/Downloads/eval-mgmt-serv-guide-ICN006764.pdf",
+        "category": "documentation",
+        "agency": "CMS",
+        "regions": ["us"],
+        "summary": "Official guidance covering required elements for Medicare encounters.",
+    },
+    {
+        "title": "HIPAA Privacy Rule Summary",
+        "url": "https://www.hhs.gov/hipaa/for-professionals/privacy/index.html",
+        "category": "privacy",
+        "agency": "HHS",
+        "regions": ["us"],
+        "summary": "Safeguards and permitted uses of protected health information.",
+    },
+    {
+        "title": "Telehealth Best Practices",
+        "url": "https://www.ama-assn.org/practice-management/digital/ama-telehealth-quick-guide",
+        "category": "regulatory",
+        "agency": "AMA",
+        "regions": ["us"],
+        "summary": "Checklist for documenting remote encounters and patient consent.",
+    },
+    {
+        "title": "General Data Protection Regulation (GDPR) guide",
+        "url": "https://ec.europa.eu/info/law/law-topic/data-protection/eu-data-protection-rules_en",
+        "category": "privacy",
+        "agency": "EU",
+        "regions": ["eu"],
+        "summary": "Overview of GDPR obligations for providers seeing EU residents.",
+    },
+]
+
+
+_RISK_WEIGHTS = {
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+    "critical": 4,
+}
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+def get_rules(rule_ids: Optional[Iterable[str]] = None) -> List[Dict[str, Any]]:
+    """Return the configured compliance rules."""
+
+    if rule_ids is None:
+        return [dict(rule) for rule in _DEFAULT_RULES]
+    wanted = {rid.lower() for rid in rule_ids}
+    return [dict(rule) for rule in _DEFAULT_RULES if rule["id"].lower() in wanted]
+
+
+def get_resources(region: Optional[str] = None, category: Optional[str] = None) -> List[Dict[str, Any]]:
+    """Return compliance resources filtered by region/category when provided."""
+
+    region_norm = region.lower() if region else None
+    category_norm = category.lower() if category else None
+    resources: List[Dict[str, Any]] = []
+    for item in _RESOURCE_LIBRARY:
+        if region_norm and item.get("regions"):
+            if region_norm not in {r.lower() for r in item.get("regions", [])}:
+                continue
+        if category_norm and item.get("category"):
+            if item["category"].lower() != category_norm:
+                continue
+        resources.append(dict(item))
+    return resources
+
+
+def evaluate_note(
+    note: str,
+    metadata: Optional[Dict[str, Any]] = None,
+    rule_ids: Optional[Iterable[str]] = None,
+) -> Dict[str, Any]:
+    """Evaluate ``note`` against configured rules and return structured issues."""
+
+    metadata = metadata or {}
+    rules = get_rules(rule_ids)
+    note_lower = note.lower()
+    issues: List[Dict[str, Any]] = []
+
+    for rule in rules:
+        triggered, details = _evaluate_rule(rule, note, note_lower, metadata)
+        if not triggered:
+            continue
+        issue_id = str(uuid4())
+        severity = (rule.get("severity") or "medium").lower()
+        issue: Dict[str, Any] = {
+            "issueId": issue_id,
+            "ruleId": rule.get("id"),
+            "title": rule.get("name"),
+            "severity": severity,
+            "category": rule.get("category"),
+            "summary": rule.get("description"),
+            "recommendation": rule.get("recommendedAction"),
+            "references": rule.get("references", []),
+            "status": "open",
+            "details": details or {},
+            "createdAt": time.time(),
+        }
+        snippet = details.get("noteExcerpt") or details.get("snippet")
+        if not snippet:
+            snippets = details.get("snippets")
+            if isinstance(snippets, list) and snippets:
+                snippet = snippets[0]
+        if isinstance(snippet, str) and snippet.strip():
+            issue["noteExcerpt"] = snippet.strip()
+        issues.append(issue)
+
+    applied_rules = [rule.get("id") for rule in rules]
+    high_count = sum(1 for item in issues if (item.get("severity") or "").lower() in {"high", "critical"})
+    risk_score = sum(_RISK_WEIGHTS.get((item.get("severity") or "medium").lower(), 1) for item in issues)
+    summary = {
+        "issuesFound": len(issues),
+        "highSeverity": high_count,
+        "riskScore": risk_score,
+        "timestamp": time.time(),
+    }
+    return {
+        "issues": issues,
+        "summary": summary,
+        "rulesEvaluated": len(rules),
+        "appliedRules": applied_rules,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _evaluate_rule(
+    rule: Dict[str, Any],
+    note_original: str,
+    note_lower: str,
+    metadata: Dict[str, Any],
+) -> tuple[bool, Dict[str, Any]]:
+    rule_type = (rule.get("type") or "absence").lower()
+    keywords = [kw.lower() for kw in rule.get("keywords", []) if isinstance(kw, str) and kw.strip()]
+    details: Dict[str, Any] = {"ruleType": rule_type}
+
+    if rule_type == "presence":
+        matches = _find_keyword_matches(note_original, note_lower, keywords)
+        if matches:
+            details.update(matches)
+            return True, details
+        return False, {}
+
+    if rule_type == "absence":
+        matches = _find_keyword_matches(note_original, note_lower, keywords)
+        if matches.get("matchedKeywords"):
+            return False, {}
+        details["missingKeywords"] = keywords
+        return True, details
+
+    if rule_type == "count":
+        matches = _find_keyword_matches(note_original, note_lower, keywords)
+        threshold = int(rule.get("threshold") or len(keywords))
+        matched = matches.get("matchedKeywords", [])
+        if len(matched) < threshold:
+            details.update(matches)
+            details["threshold"] = threshold
+            return True, details
+        return False, {}
+
+    if rule_type == "conditional_absence":
+        metadata_key = (rule.get("metadata_key") or "").strip()
+        allowed_values = [str(v).lower() for v in rule.get("metadata_values", []) if str(v).strip()]
+        if metadata_key:
+            current_value = str(metadata.get(metadata_key, "")).lower()
+            details["metadataKey"] = metadata_key
+            details["metadataValue"] = current_value or None
+            if allowed_values and current_value not in allowed_values:
+                return False, {}
+        matches = _find_keyword_matches(note_original, note_lower, keywords)
+        if matches.get("matchedKeywords"):
+            return False, {}
+        details["missingKeywords"] = keywords
+        return True, details
+
+    return False, {}
+
+
+def _find_keyword_matches(
+    note_original: str,
+    note_lower: str,
+    keywords: List[str],
+) -> Dict[str, Any]:
+    matched: List[str] = []
+    snippets: List[str] = []
+    for keyword in keywords:
+        if keyword in note_lower:
+            matched.append(keyword)
+            snippet = _extract_snippet(note_original, keyword)
+            if snippet:
+                snippets.append(snippet)
+    details: Dict[str, Any] = {}
+    if matched:
+        details["matchedKeywords"] = matched
+    if snippets:
+        details["snippets"] = snippets
+    return details
+
+
+def _extract_snippet(note: str, keyword: str, window: int = 40) -> Optional[str]:
+    try:
+        pattern = re.compile(re.escape(keyword), re.IGNORECASE)
+    except re.error:
+        return None
+    match = pattern.search(note)
+    if not match:
+        return None
+    start = max(match.start() - window, 0)
+    end = min(match.end() + window, len(note))
+    snippet = note[start:end].strip()
+    return snippet or None

--- a/backend/main.py
+++ b/backend/main.py
@@ -104,6 +104,7 @@ from backend.migrations import (  # type: ignore
     ensure_user_profile_table,
     ensure_session_state_table,
     ensure_event_aggregates_table,
+    ensure_compliance_issues_table,
 )
 from backend.templates import (
     TemplateModel,
@@ -132,6 +133,7 @@ from backend.auth import (  # type: ignore
     verify_password,
 )
 from backend import deid as deid_module  # type: ignore
+from backend import compliance as compliance_engine  # type: ignore
 from backend.sanitizer import sanitize_text
 from backend import worker  # type: ignore
 
@@ -408,6 +410,9 @@ transcript_history: Dict[str, deque] = defaultdict(
 notification_counts: Dict[str, int] = defaultdict(int)
 notification_subscribers: Dict[str, List[WebSocket]] = defaultdict(list)
 
+COMPLIANCE_SEVERITIES = {"low", "medium", "high", "critical"}
+COMPLIANCE_STATUSES = {"open", "in_progress", "resolved", "dismissed"}
+
 
 async def _broadcast_notification_count(username: str) -> None:
     """Send updated notification count to all websocket subscribers."""
@@ -446,6 +451,7 @@ ensure_encounters_table(db_conn)
 ensure_visit_sessions_table(db_conn)
 ensure_note_auto_saves_table(db_conn)
 ensure_event_aggregates_table(db_conn)
+ensure_compliance_issues_table(db_conn)
 
 
 # Create helpful indexes for metrics queries (idempotent)
@@ -513,6 +519,7 @@ def _init_core_tables(conn):  # pragma: no cover - invoked in tests indirectly
     ensure_visit_sessions_table(conn)
     ensure_note_auto_saves_table(conn)
     ensure_session_state_table(conn)
+    ensure_compliance_issues_table(conn)
     conn.commit()
 
 
@@ -546,6 +553,7 @@ ensure_encounters_table(db_conn)
 ensure_visit_sessions_table(db_conn)
 ensure_note_auto_saves_table(db_conn)
 ensure_session_state_table(db_conn)
+ensure_compliance_issues_table(db_conn)
 
 # User profile details including current view and UI preferences.
 ensure_user_profile_table(db_conn)
@@ -618,6 +626,149 @@ def _insert_audit_log(
         logger.exception("Failed to write audit log entry")
 
 
+def _normalise_severity(value: str | None) -> str:
+    if not value:
+        return "medium"
+    value_norm = value.lower()
+    if value_norm not in COMPLIANCE_SEVERITIES:
+        return "medium"
+    return value_norm
+
+
+def _normalise_status(value: str | None) -> str:
+    if not value:
+        return "open"
+    value_norm = value.lower()
+    if value_norm not in COMPLIANCE_STATUSES:
+        return "open"
+    return value_norm
+
+
+def _row_to_compliance_issue(row: sqlite3.Row | None) -> Dict[str, Any]:
+    if row is None:
+        return {}
+    data = dict(row)
+    metadata_payload = data.get("metadata")
+    metadata: Dict[str, Any] | None = None
+    if metadata_payload:
+        try:
+            metadata = json.loads(metadata_payload)
+        except Exception:
+            metadata = {"raw": metadata_payload}
+    return {
+        "issueId": data.get("issue_id"),
+        "ruleId": data.get("rule_id"),
+        "title": data.get("title"),
+        "severity": _normalise_severity(data.get("severity")),
+        "category": data.get("category"),
+        "status": _normalise_status(data.get("status")),
+        "noteExcerpt": data.get("note_excerpt"),
+        "metadata": metadata,
+        "createdAt": data.get("created_at"),
+        "updatedAt": data.get("updated_at"),
+        "createdBy": data.get("created_by"),
+        "assignee": data.get("assignee"),
+    }
+
+
+def _serialise_metadata(metadata: Dict[str, Any] | None) -> str | None:
+    if not metadata:
+        return None
+
+    def _convert(value: Any) -> Any:
+        if isinstance(value, dict):
+            return {str(k): _convert(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [_convert(v) for v in value]
+        if isinstance(value, (str, int, float, bool)) or value is None:
+            return value
+        return str(value)
+
+    safe_payload = _convert(metadata)
+    try:
+        return json.dumps(safe_payload, ensure_ascii=False)
+    except Exception:
+        return json.dumps(str(safe_payload), ensure_ascii=False)
+
+
+def _persist_compliance_issue(
+    *,
+    issue_id: str | None,
+    rule_id: str | None,
+    title: str,
+    severity: str | None,
+    category: str | None,
+    status: str | None,
+    note_excerpt: str | None,
+    metadata: Dict[str, Any] | None,
+    created_by: str | None,
+    assignee: str | None,
+) -> Dict[str, Any]:
+    issue_id = issue_id or str(uuid4())
+    severity_norm = _normalise_severity(severity)
+    status_norm = _normalise_status(status)
+    note_excerpt_clean = sanitize_text(note_excerpt) if note_excerpt else None
+    metadata_json = _serialise_metadata(metadata)
+    now = time.time()
+    try:
+        db_conn.execute(
+            """
+            INSERT INTO compliance_issues (
+                issue_id, rule_id, title, severity, category, status,
+                note_excerpt, metadata, created_at, updated_at, created_by, assignee
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                issue_id,
+                rule_id,
+                title,
+                severity_norm,
+                category,
+                status_norm,
+                note_excerpt_clean,
+                metadata_json,
+                now,
+                now,
+                created_by,
+                assignee,
+            ),
+        )
+    except sqlite3.IntegrityError:
+        db_conn.execute(
+            """
+            UPDATE compliance_issues
+               SET rule_id = ?,
+                   title = ?,
+                   severity = ?,
+                   category = ?,
+                   status = ?,
+                   note_excerpt = ?,
+                   metadata = ?,
+                   updated_at = ?,
+                   assignee = ?,
+                   created_by = COALESCE(created_by, ?)
+             WHERE issue_id = ?
+            """,
+            (
+                rule_id,
+                title,
+                severity_norm,
+                category,
+                status_norm,
+                note_excerpt_clean,
+                metadata_json,
+                now,
+                assignee,
+                created_by,
+                issue_id,
+            ),
+        )
+    db_conn.commit()
+    row = db_conn.execute(
+        "SELECT * FROM compliance_issues WHERE issue_id = ?",
+        (issue_id,),
+    ).fetchone()
+    return _row_to_compliance_issue(row)
 def _audit_details_from_request(request: Request) -> Dict[str, Any]:
     """Capture structured request metadata for audit logging."""
 
@@ -1952,6 +2103,117 @@ class ComplianceAlert(BaseModel):
 
 class ComplianceCheckResponse(BaseModel):
     alerts: List[ComplianceAlert]
+
+
+class ComplianceMonitorIssue(BaseModel):
+    issueId: str
+    ruleId: Optional[str] = None
+    title: str
+    severity: str
+    category: Optional[str] = None
+    summary: Optional[str] = None
+    recommendation: Optional[str] = None
+    references: Optional[List[Dict[str, Any]]] = None
+    status: Optional[str] = None
+    noteExcerpt: Optional[str] = None
+    details: Optional[Dict[str, Any]] = None
+    createdAt: Optional[float] = None
+
+
+class ComplianceMonitorRequest(BaseModel):
+    note: str = Field(..., max_length=10000)
+    metadata: Optional[Dict[str, Any]] = None
+    ruleIds: Optional[List[str]] = None
+    persistFindings: Optional[bool] = False
+
+    class Config:
+        populate_by_name = True
+
+    @field_validator("note")
+    @classmethod
+    def sanitize_note(cls, value: str) -> str:  # noqa: D401,N805
+        return sanitize_text(value)
+
+    @field_validator("ruleIds")
+    @classmethod
+    def unique_rules(cls, value: Optional[List[str]]) -> Optional[List[str]]:  # noqa: D401,N805
+        if not value:
+            return value
+        seen: Set[str] = set()
+        unique: List[str] = []
+        for item in value:
+            if not isinstance(item, str):
+                continue
+            lowered = item.strip()
+            if not lowered:
+                continue
+            lowered_norm = lowered.lower()
+            if lowered_norm in seen:
+                continue
+            seen.add(lowered_norm)
+            unique.append(lowered)
+        return unique
+
+
+class ComplianceMonitorResponse(BaseModel):
+    issues: List[ComplianceMonitorIssue]
+    summary: Dict[str, Any]
+    rulesEvaluated: int
+    appliedRules: List[str]
+    persistedIssueIds: Optional[List[str]] = None
+
+
+class ComplianceIssueCreateRequest(BaseModel):
+    title: str
+    severity: str
+    ruleId: Optional[str] = None
+    category: Optional[str] = None
+    status: Optional[str] = None
+    noteExcerpt: Optional[str] = Field(None, max_length=2000)
+    metadata: Optional[Dict[str, Any]] = None
+    assignee: Optional[str] = None
+    issueId: Optional[str] = None
+    createdBy: Optional[str] = None
+
+    @field_validator("severity")
+    @classmethod
+    def validate_severity(cls, value: str) -> str:  # noqa: D401,N805
+        if not value:
+            raise ValueError("Severity is required")
+        normalised = value.lower()
+        if normalised not in COMPLIANCE_SEVERITIES:
+            raise ValueError("Invalid severity")
+        return normalised
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, value: Optional[str]) -> Optional[str]:  # noqa: D401,N805
+        if value is None:
+            return value
+        normalised = value.lower()
+        if normalised not in COMPLIANCE_STATUSES:
+            raise ValueError("Invalid status")
+        return normalised
+
+    @field_validator("noteExcerpt")
+    @classmethod
+    def sanitize_excerpt(cls, value: Optional[str]) -> Optional[str]:  # noqa: D401,N805
+        return sanitize_text(value) if value else value
+
+
+class ComplianceIssueRecord(BaseModel):
+    issueId: str
+    ruleId: Optional[str] = None
+    title: str
+    severity: str
+    category: Optional[str] = None
+    status: str
+    noteExcerpt: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+    createdAt: float
+    updatedAt: float
+    createdBy: Optional[str] = None
+    assignee: Optional[str] = None
 
 
 class DifferentialItem(BaseModel):
@@ -4335,6 +4597,96 @@ async def ws_compliance_check(websocket: WebSocket):
     resp = await _compliance_check(ComplianceCheckRequest(**data))
     await websocket.send_json(resp.model_dump())
     await websocket.close()
+
+
+@app.post("/api/compliance/monitor", response_model=ComplianceMonitorResponse)
+async def compliance_monitor(
+    req: ComplianceMonitorRequest, user=Depends(require_role("user"))
+) -> ComplianceMonitorResponse:
+    metadata = req.metadata if isinstance(req.metadata, dict) else {}
+    result = compliance_engine.evaluate_note(
+        note=req.note,
+        metadata=metadata,
+        rule_ids=req.ruleIds,
+    )
+    issues = [ComplianceMonitorIssue(**item) for item in result.get("issues", [])]
+    persisted_ids: List[str] = []
+    if req.persistFindings and issues:
+        for issue in issues:
+            metadata_payload: Dict[str, Any] = {}
+            if issue.details:
+                metadata_payload["details"] = issue.details
+            if metadata:
+                metadata_payload["context"] = metadata
+            if issue.recommendation:
+                metadata_payload["recommendation"] = issue.recommendation
+            if issue.references:
+                metadata_payload["references"] = issue.references
+            if issue.summary:
+                metadata_payload["summary"] = issue.summary
+            record = _persist_compliance_issue(
+                issue_id=issue.issueId,
+                rule_id=issue.ruleId,
+                title=issue.title,
+                severity=issue.severity,
+                category=issue.category,
+                status=issue.status or "open",
+                note_excerpt=issue.noteExcerpt,
+                metadata=metadata_payload or None,
+                created_by=user.get("sub"),
+                assignee=None,
+            )
+            if record.get("issueId"):
+                persisted_ids.append(record["issueId"])
+    response = ComplianceMonitorResponse(
+        issues=issues,
+        summary=result.get("summary", {}),
+        rulesEvaluated=result.get("rulesEvaluated", 0),
+        appliedRules=result.get("appliedRules", []),
+        persistedIssueIds=persisted_ids or None,
+    )
+    return response
+
+
+@app.get("/api/compliance/rules")
+async def compliance_rules(user=Depends(require_role("user"))) -> Dict[str, Any]:
+    rules = compliance_engine.get_rules()
+    return {"rules": rules, "count": len(rules)}
+
+
+@app.post("/api/compliance/issue-tracking", response_model=ComplianceIssueRecord)
+async def compliance_issue_tracking(
+    req: ComplianceIssueCreateRequest, user=Depends(require_role("user"))
+) -> ComplianceIssueRecord:
+    metadata_payload: Dict[str, Any] = {}
+    if isinstance(req.metadata, dict):
+        metadata_payload.update(req.metadata)
+    metadata_payload["manual"] = True
+    record = _persist_compliance_issue(
+        issue_id=req.issueId,
+        rule_id=req.ruleId,
+        title=sanitize_text(req.title),
+        severity=req.severity,
+        category=req.category,
+        status=req.status or "open",
+        note_excerpt=req.noteExcerpt,
+        metadata=metadata_payload or None,
+        created_by=req.createdBy or user.get("sub"),
+        assignee=req.assignee,
+    )
+    if not record:
+        raise HTTPException(status_code=500, detail="Failed to persist issue")
+    return ComplianceIssueRecord(**record)
+
+
+@app.get("/api/compliance/resources")
+async def compliance_resources(
+    region: Optional[str] = None,
+    category: Optional[str] = None,
+    user=Depends(require_role("user")),
+) -> Dict[str, Any]:
+    resources = compliance_engine.get_resources(region=region, category=category)
+    return {"resources": resources, "count": len(resources)}
 
 
 async def _differentials_generate(

--- a/backend/migrations.py
+++ b/backend/migrations.py
@@ -200,6 +200,44 @@ def ensure_event_aggregates_table(conn: sqlite3.Connection) -> None:
     conn.commit()
 
 
+def ensure_compliance_issues_table(conn: sqlite3.Connection) -> None:
+    """Ensure the compliance_issues table exists for manual tracking."""
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS compliance_issues (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            issue_id TEXT UNIQUE NOT NULL,
+            rule_id TEXT,
+            title TEXT NOT NULL,
+            severity TEXT NOT NULL,
+            category TEXT,
+            status TEXT NOT NULL,
+            note_excerpt TEXT,
+            metadata TEXT,
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            created_by TEXT,
+            assignee TEXT
+        )
+        """
+    )
+
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(compliance_issues)")}
+    if "assignee" not in columns:
+        conn.execute("ALTER TABLE compliance_issues ADD COLUMN assignee TEXT")
+    if "created_by" not in columns:
+        conn.execute("ALTER TABLE compliance_issues ADD COLUMN created_by TEXT")
+    if "note_excerpt" not in columns:
+        conn.execute("ALTER TABLE compliance_issues ADD COLUMN note_excerpt TEXT")
+    if "metadata" not in columns:
+        conn.execute("ALTER TABLE compliance_issues ADD COLUMN metadata TEXT")
+    if "status" not in columns:
+        conn.execute("ALTER TABLE compliance_issues ADD COLUMN status TEXT NOT NULL DEFAULT 'open'")
+
+    conn.commit()
+
+
 
 def ensure_patients_table(conn: sqlite3.Connection) -> None:
     """Ensure the patients table exists for storing patient demographics."""


### PR DESCRIPTION
## Summary
- introduce a lightweight compliance rule engine module used by new compliance APIs
- ensure a dedicated `compliance_issues` table exists for tracking stored issues
- add REST endpoints for compliance monitoring, rule discovery, resources, and persistent issue tracking backed by the new engine

## Testing
- pytest tests/test_migrations.py tests/test_new_api_endpoints.py *(fails: coverage 85% threshold not met)*


------
https://chatgpt.com/codex/tasks/task_e_68c8468ba26483248646fec97898d5e9