### PR TITLE
Add API activity log endpoint and deprecate legacy alias

### DIFF
--- a/BACKEND_DATA_INTEGRATION_ANALYSIS.md
+++ b/BACKEND_DATA_INTEGRATION_ANALYSIS.md
@@ -498,7 +498,7 @@ This enhanced analysis provides comprehensive backend integration requirements f
 | `/api/compliance/rules` | GET | Regulatory rule engine | `Response: { rules, lastUpdated, jurisdiction, payerRules }` | **HIGH** |
 | `/api/compliance/issue-tracking` | POST | Issue tracking/learning | `Request: { issueId, userAction, reasoning }` | **MEDIUM** |
 | `/api/activity/log` | GET | Activity log retrieval | `Query: { dateRange, category, user }` → `Response: Array<ActivityEntry>` | **HIGH** |
-| `/api/activity/log` | POST | Activity logging | `Request: { action, category, details }` | **HIGH** |
+| `/api/activity/log` | POST | Activity logging | `Request: EventModel { eventType, details?, timestamp?, codes?, revenue?, timeToClose?, compliance?, publicHealth?, satisfaction? }` → `Response: { status: "logged" }` (Legacy alias: `POST /event` — deprecated) | **HIGH** |
 | `/api/export/ehr` | POST | EHR export | `Request: { noteId, ehrSystem }` → `Response: { status, exportId, progress }` | **MEDIUM** |
 
 ### 🌐 **REAL-TIME & STREAMING**

--- a/backend/main.py
+++ b/backend/main.py
@@ -2951,7 +2951,7 @@ async def get_events(user=Depends(require_role("admin"))) -> List[Dict[str, Any]
 # call this endpoint whenever a notable action occurs (e.g., starting
 # a note, beautifying a note, requesting suggestions).  Events are
 # stored in the global `events` list.  Returns a simple status.
-@app.post("/event")
+@app.post("/event", deprecated=True)
 async def log_event(
     event: EventModel, user=Depends(require_role("user"))
 ) -> Dict[str, str]:
@@ -3027,6 +3027,15 @@ async def log_event(
     except Exception as exc:
         logging.error("Error inserting event into database: %s", exc)
     return {"status": "logged"}
+
+
+@app.post("/api/activity/log")
+async def log_activity_event(
+    event: EventModel, user=Depends(require_role("user"))
+) -> Dict[str, str]:
+    """Canonical activity logging endpoint that forwards to ``/event`` handler."""
+
+    return await log_event(event, user)
 
 
 @app.post("/survey")


### PR DESCRIPTION
## Summary
- add the `/api/activity/log` endpoint that forwards requests to the existing event logging handler
- mark the legacy `/event` route as deprecated for backwards compatibility
- document the canonical analytics logging endpoint and legacy alias in the backend integration analysis

## Testing
- pytest tests/test_analytics_endpoints.py *(fails: repository coverage threshold of 85% not met when running the focused test module)*

------
https://chatgpt.com/codex/tasks/task_e_68c862ad20fc8324ae2aecf86fda4f58