### PR TITLE
Add schedule bulk operations endpoint

### DIFF
--- a/tests/test_new_api_endpoints.py
+++ b/tests/test_new_api_endpoints.py
@@ -62,6 +62,74 @@ def test_schedule_appointments(client):
     assert len(resp.json()["appointments"]) >= 1
 
 
+def test_schedule_bulk_operations(client):
+    token = login(client)
+    create_resp = client.post(
+        "/schedule",
+        json={"patient": "2", "reason": "consult", "start": "2024-01-02T09:00:00"},
+        headers=auth_header(token),
+    )
+    assert create_resp.status_code == 200
+    appt_id = create_resp.json()["id"]
+
+    provider = "Dr. Adams"
+    resp = client.post(
+        "/api/schedule/bulk-operations",
+        json={
+            "provider": provider,
+            "updates": [{"id": appt_id, "action": "check-in"}],
+        },
+        headers=auth_header(token),
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["succeeded"] == 1
+    assert body["failed"] == 0
+
+    resp = client.get("/api/schedule/appointments", headers=auth_header(token))
+    assert resp.status_code == 200
+    appointments = resp.json()["appointments"]
+    match = next(item for item in appointments if item["id"] == appt_id)
+    assert match["status"] == "in-progress"
+    assert match["provider"] == provider
+
+    new_start = "2024-01-02T10:00:00"
+    resp = client.post(
+        "/api/schedule/bulk-operations",
+        json={
+            "provider": provider,
+            "updates": [
+                {"id": appt_id, "action": "reschedule", "time": new_start},
+            ],
+        },
+        headers=auth_header(token),
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["succeeded"] == 1
+    assert body["failed"] == 0
+
+    resp = client.get("/api/schedule/appointments", headers=auth_header(token))
+    assert resp.status_code == 200
+    appointments = resp.json()["appointments"]
+    match = next(item for item in appointments if item["id"] == appt_id)
+    assert match["start"].startswith(new_start)
+    assert match["status"] == "scheduled"
+
+    resp = client.post(
+        "/api/schedule/bulk-operations",
+        json={
+            "provider": provider,
+            "updates": [{"id": 99999, "action": "complete"}],
+        },
+        headers=auth_header(token),
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["succeeded"] == 0
+    assert body["failed"] == 1
+
+
 def test_visits_manage(client):
     token = login(client)
     resp = client.post(


### PR DESCRIPTION
## Summary
- extend the scheduling module with provider-aware records and a bulk update helper that supports status changes and rescheduling
- expose the helper via a new `/api/schedule/bulk-operations` FastAPI endpoint and include status/provider fields in appointment responses
- cover the new workflow with API tests for successful updates, rescheduling, and failure cases

## Testing
- pytest --cov-fail-under=0 tests/test_new_api_endpoints.py

------
https://chatgpt.com/codex/tasks/task_e_68c862d57af8832484ae4027f8039b79