### PR TITLE
Implement worker refresh jobs and tests

### DIFF
--- a/backend/worker.py
+++ b/backend/worker.py
@@ -1,6 +1,13 @@
 import asyncio
 import logging
-from typing import Awaitable, Callable, List, Optional
+import os
+import sys
+from collections.abc import Mapping, Sequence
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+
+import requests
+
+from backend import code_tables, codes_data, compliance
 
 logger = logging.getLogger(__name__)
 
@@ -13,14 +20,282 @@ _background_tasks: List[asyncio.Task] = []
 _aggregate_callback: Optional[Callable[[], Awaitable[None]]] = None
 
 
+CODE_DATA_URL_ENV = "CODE_DATA_URL"
+CPT_DATA_URL_ENV = "CPT_DATA_URL"
+ICD10_DATA_URL_ENV = "ICD10_DATA_URL"
+HCPCS_DATA_URL_ENV = "HCPCS_DATA_URL"
+COMPLIANCE_RULES_URL_ENV = "COMPLIANCE_RULES_URL"
+
+HTTP_TIMEOUT_SECONDS = 20
+
+CODE_REFRESH_INTERVAL = 24 * 60 * 60  # daily
+COMPLIANCE_REFRESH_INTERVAL = 4 * 60 * 60  # every four hours
+ANALYTICS_REFRESH_INTERVAL = 24 * 60 * 60
+MODEL_REFRESH_INTERVAL = 24 * 60 * 60
+AUDIT_REFRESH_INTERVAL = 24 * 60 * 60
+
+
+def _normalize_key(value: str) -> str:
+    return value.lower().replace("-", "").replace("_", "")
+
+
+def _coerce_float(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _normalize_dataset(entries: Any) -> Dict[str, Dict[str, Any]]:
+    """Return a mapping of code -> metadata from ``entries``."""
+
+    result: Dict[str, Dict[str, Any]] = {}
+
+    if isinstance(entries, Mapping):
+        iterable = entries.items()
+    elif isinstance(entries, Sequence):
+        iterable = []
+        for item in entries:
+            if isinstance(item, Mapping):
+                code = item.get("code")
+                if code is None:
+                    continue
+                info = {k: v for k, v in item.items() if k != "code"}
+                iterable.append((code, info))
+    else:
+        return result
+
+    for code, info in iterable:
+        code_str = str(code or "").strip().upper()
+        if not code_str:
+            continue
+        if not isinstance(info, Mapping):
+            continue
+        result[code_str] = dict(info)
+
+    return result
+
+
+def _update_codes_payload(payload: Mapping[str, Any]) -> Dict[str, Optional[int]]:
+    """Update in-memory code datasets using ``payload``."""
+
+    normalized: Dict[str, Any] = {}
+    for key, value in payload.items():
+        if isinstance(key, str):
+            normalized[_normalize_key(key)] = value
+
+    counts: Dict[str, Optional[int]] = {"cpt": None, "icd10": None, "hcpcs": None}
+
+    if "cpt" in normalized:
+        cpt_entries = _normalize_dataset(normalized["cpt"])
+        codes_data._CPT.clear()
+        for code, info in cpt_entries.items():
+            base: Dict[str, Any] = {
+                "type": "CPT",
+                "category": info.get("category") or "codes",
+                "description": info.get("description") or info.get("name") or "",
+                "rvu": _coerce_float(info.get("rvu")),
+                "reimbursement": _coerce_float(info.get("reimbursement")),
+            }
+            base.update(
+                {
+                    k: v
+                    for k, v in info.items()
+                    if k not in {"category", "description", "name", "rvu", "reimbursement"}
+                }
+            )
+            codes_data._CPT[code] = base
+
+        code_tables.CPT_CODES.clear()
+        for code, info in cpt_entries.items():
+            entry = dict(info)
+            entry.setdefault("description", info.get("description") or info.get("name") or "")
+            entry["rvu"] = _coerce_float(entry.get("rvu"))
+            entry["reimbursement"] = _coerce_float(entry.get("reimbursement"))
+            entry.setdefault("documentation", {"required": [], "recommended": [], "examples": []})
+            entry.setdefault("icd10_prefixes", [])
+            entry.setdefault("demographics", {})
+            entry.setdefault("encounterTypes", [])
+            entry.setdefault("specialties", [])
+            code_tables.CPT_CODES[code] = entry
+
+        codes_data.load_code_metadata.cache_clear()
+
+        main_module = sys.modules.get("backend.main")
+        if main_module is not None:
+            try:
+                main_module.CPT_REVENUE = {
+                    code: _coerce_float(info.get("reimbursement")) for code, info in cpt_entries.items()
+                }
+            except Exception:  # pragma: no cover - defensive
+                logger.exception("Failed to update CPT revenue table")
+
+        counts["cpt"] = len(cpt_entries)
+
+    if "icd10" in normalized:
+        icd_entries = _normalize_dataset(normalized["icd10"])
+        codes_data._ICD10.clear()
+        for code, info in icd_entries.items():
+            base = {
+                "type": "ICD-10",
+                "category": info.get("category") or "diagnoses",
+                "description": info.get("description") or info.get("name") or "",
+                "rvu": _coerce_float(info.get("rvu")),
+                "reimbursement": _coerce_float(info.get("reimbursement")),
+            }
+            base.update(
+                {
+                    k: v
+                    for k, v in info.items()
+                    if k not in {"category", "description", "name", "rvu", "reimbursement"}
+                }
+            )
+            codes_data._ICD10[code] = base
+
+        code_tables.ICD10_CODES.clear()
+        for code, info in icd_entries.items():
+            entry = dict(info)
+            entry.setdefault("description", info.get("description") or info.get("name") or "")
+            entry.setdefault("clinicalContext", info.get("clinicalContext") or "")
+            entry.setdefault("documentation", {"required": [], "recommended": [], "examples": []})
+            entry.setdefault("contraindications", [])
+            entry.setdefault("demographics", {})
+            entry.setdefault("encounterTypes", [])
+            entry.setdefault("specialties", [])
+            entry["rvu"] = _coerce_float(entry.get("rvu"))
+            entry["reimbursement"] = _coerce_float(entry.get("reimbursement"))
+            code_tables.ICD10_CODES[code] = entry
+
+        codes_data.load_code_metadata.cache_clear()
+        counts["icd10"] = len(icd_entries)
+
+    if "hcpcs" in normalized:
+        hcpcs_entries = _normalize_dataset(normalized["hcpcs"])
+        codes_data._HCPCS.clear()
+        for code, info in hcpcs_entries.items():
+            base = {
+                "type": "HCPCS",
+                "category": info.get("category") or "codes",
+                "description": info.get("description") or info.get("name") or "",
+                "rvu": _coerce_float(info.get("rvu")),
+                "reimbursement": _coerce_float(info.get("reimbursement")),
+            }
+            base.update(
+                {
+                    k: v
+                    for k, v in info.items()
+                    if k not in {"category", "description", "name", "rvu", "reimbursement"}
+                }
+            )
+            codes_data._HCPCS[code] = base
+
+        codes_data.load_code_metadata.cache_clear()
+        counts["hcpcs"] = len(hcpcs_entries)
+
+    return counts
+
+
+def _update_compliance_payload(payload: Mapping[str, Any]) -> Dict[str, Optional[int]]:
+    counts: Dict[str, Optional[int]] = {"rules": None, "resources": None}
+
+    if "rules" in payload:
+        rules_raw = payload.get("rules")
+        if not isinstance(rules_raw, Sequence):
+            raise ValueError("rules payload must be a sequence")
+        rules = [dict(item) for item in rules_raw if isinstance(item, Mapping)]
+        compliance._DEFAULT_RULES = rules
+        counts["rules"] = len(rules)
+
+    if "resources" in payload:
+        resources_raw = payload.get("resources")
+        if not isinstance(resources_raw, Sequence):
+            raise ValueError("resources payload must be a sequence")
+        resources = [dict(item) for item in resources_raw if isinstance(item, Mapping)]
+        compliance._RESOURCE_LIBRARY = resources
+        counts["resources"] = len(resources)
+
+    return counts
+
+
+def _download_json(url: str) -> Any:
+    response = requests.get(url, timeout=HTTP_TIMEOUT_SECONDS)
+    response.raise_for_status()
+    return response.json()
+
+
+async def _fetch_json(url: str) -> Any:
+    return await asyncio.to_thread(_download_json, url)
+
+
 async def update_code_databases() -> None:
-    """Placeholder task to refresh code databases."""
-    logger.info("Updating code databases")
+    """Fetch and reload CPT/ICD-10/HCPCS datasets."""
+
+    logger.info("Refreshing code datasets")
+
+    code_data_url = os.getenv(CODE_DATA_URL_ENV)
+    sources = {
+        "combined": code_data_url,
+        "cpt": os.getenv(CPT_DATA_URL_ENV),
+        "icd10": os.getenv(ICD10_DATA_URL_ENV),
+        "hcpcs": os.getenv(HCPCS_DATA_URL_ENV),
+    }
+
+    if not any(sources.values()):
+        logger.debug("No code dataset URLs configured; skipping refresh")
+        return
+
+    try:
+        if sources["combined"]:
+            payload = await _fetch_json(sources["combined"] or "")
+            if not isinstance(payload, Mapping):
+                raise ValueError("Combined code dataset must be a mapping")
+            counts = _update_codes_payload(payload)
+        else:
+            payload: Dict[str, Any] = {}
+            for key in ("cpt", "icd10", "hcpcs"):
+                url = sources.get(key)
+                if not url:
+                    continue
+                payload[key] = await _fetch_json(url)
+            if not payload:
+                logger.debug("No individual code dataset URLs resolved; skipping refresh")
+                return
+            counts = _update_codes_payload(payload)
+    except Exception:
+        logger.exception("Failed to refresh code datasets")
+        return
+
+    counts_display = ", ".join(
+        f"{name.upper()}={(counts[name] if counts[name] is not None else 'unchanged')}"
+        for name in ("cpt", "icd10", "hcpcs")
+    )
+    logger.info("Code datasets refreshed (%s)", counts_display)
 
 
 async def check_compliance_rules() -> None:
-    """Placeholder task to check compliance rules."""
-    logger.info("Checking compliance rules")
+    """Pull the latest compliance rules and resources."""
+
+    logger.info("Refreshing compliance catalogue")
+
+    url = os.getenv(COMPLIANCE_RULES_URL_ENV)
+    if not url:
+        logger.debug("No compliance rules URL configured; skipping refresh")
+        return
+
+    try:
+        payload = await _fetch_json(url)
+        if not isinstance(payload, Mapping):
+            raise ValueError("Compliance payload must be a mapping")
+        counts = _update_compliance_payload(payload)
+    except Exception:
+        logger.exception("Failed to refresh compliance rules from %s", url)
+        return
+
+    counts_display = ", ".join(
+        f"{name}={(counts[name] if counts[name] is not None else 'unchanged')}"
+        for name in ("rules", "resources")
+    )
+    logger.info("Compliance catalogue refreshed (%s)", counts_display)
 
 
 async def aggregate_analytics_and_backup() -> None:
@@ -73,11 +348,13 @@ def start_scheduler() -> None:
     """Start background scheduler and worker loop."""
     _background_tasks.extend(
         [
-            asyncio.create_task(_run_periodic(24 * 60 * 60, update_code_databases)),
-            asyncio.create_task(_run_periodic(4 * 60 * 60, check_compliance_rules)),
-            asyncio.create_task(_run_periodic(24 * 60 * 60, aggregate_analytics_and_backup)),
-            asyncio.create_task(_run_periodic(24 * 60 * 60, queue_model_retraining)),
-            asyncio.create_task(_run_periodic(24 * 60 * 60, queue_audit_trail_generation)),
+            asyncio.create_task(_run_periodic(CODE_REFRESH_INTERVAL, update_code_databases)),
+            asyncio.create_task(_run_periodic(COMPLIANCE_REFRESH_INTERVAL, check_compliance_rules)),
+            asyncio.create_task(
+                _run_periodic(ANALYTICS_REFRESH_INTERVAL, aggregate_analytics_and_backup)
+            ),
+            asyncio.create_task(_run_periodic(MODEL_REFRESH_INTERVAL, queue_model_retraining)),
+            asyncio.create_task(_run_periodic(AUDIT_REFRESH_INTERVAL, queue_audit_trail_generation)),
             asyncio.create_task(_worker()),
         ]
     )

--- a/tests/test_worker_jobs.py
+++ b/tests/test_worker_jobs.py
@@ -1,0 +1,221 @@
+import asyncio
+from copy import deepcopy
+from typing import Any, Dict, List
+
+import pytest
+
+from backend import code_tables, codes_data, compliance, worker
+import backend.main as main_module
+
+
+class _DummyResponse:
+    def __init__(self, payload: Any, status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self) -> Any:
+        return self._payload
+
+
+@pytest.mark.asyncio
+async def test_update_code_databases_refreshes_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Worker refresh should replace CPT/ICD-10/HCPCS datasets in-memory."""
+
+    original_cpt = deepcopy(codes_data._CPT)
+    original_icd10 = deepcopy(codes_data._ICD10)
+    original_hcpcs = deepcopy(codes_data._HCPCS)
+    original_cpt_tables = deepcopy(code_tables.CPT_CODES)
+    original_icd_tables = deepcopy(code_tables.ICD10_CODES)
+    original_revenue = dict(main_module.CPT_REVENUE)
+
+    payload: Dict[str, List[Dict[str, Any]]] = {
+        "cpt": [
+            {
+                "code": "12345",
+                "description": "Telemedicine consult",
+                "rvu": 2.5,
+                "reimbursement": 200.0,
+                "documentation": {
+                    "required": ["consent"],
+                    "recommended": ["video quality noted"],
+                    "examples": ["Virtual follow-up"],
+                },
+                "icd10_prefixes": ["J06"],
+                "demographics": {"minAge": 0},
+                "encounterTypes": ["telehealth"],
+                "specialties": ["family medicine"],
+            }
+        ],
+        "icd10": [
+            {
+                "code": "J06.90",
+                "description": "Acute upper respiratory infection",
+                "clinicalContext": "URI",
+                "documentation": {
+                    "required": ["symptoms"],
+                    "recommended": ["vital signs"],
+                    "examples": ["cough and congestion"],
+                },
+                "demographics": {"minAge": 0},
+                "encounterTypes": ["telehealth"],
+                "specialties": ["primary care"],
+            }
+        ],
+        "hcpcs": [
+            {
+                "code": "J1234",
+                "description": "Unclassified injectable",
+                "rvu": 0.0,
+                "reimbursement": 12.5,
+            }
+        ],
+    }
+
+    calls: List[str] = []
+
+    def fake_get(url: str, timeout: int = 0) -> _DummyResponse:  # pragma: no cover - patched in test
+        calls.append(url)
+        return _DummyResponse(payload)
+
+    monkeypatch.setenv(worker.CODE_DATA_URL_ENV, "https://example.com/codes")
+    monkeypatch.setattr(worker.requests, "get", fake_get)
+
+    try:
+        codes_data.load_code_metadata.cache_clear()
+        await worker.update_code_databases()
+
+        metadata = codes_data.load_code_metadata()
+        assert "12345" in metadata
+        assert metadata["12345"]["description"] == "Telemedicine consult"
+        assert metadata["J06.90"]["type"] == "ICD-10"
+        assert metadata["J1234"]["reimbursement"] == pytest.approx(12.5)
+
+        assert code_tables.CPT_CODES["12345"]["documentation"]["required"] == ["consent"]
+        assert code_tables.ICD10_CODES["J06.90"]["clinicalContext"] == "URI"
+        assert main_module.CPT_REVENUE["12345"] == pytest.approx(200.0)
+
+        assert calls == ["https://example.com/codes"]
+    finally:
+        codes_data._CPT.clear()
+        codes_data._CPT.update(original_cpt)
+        codes_data._ICD10.clear()
+        codes_data._ICD10.update(original_icd10)
+        codes_data._HCPCS.clear()
+        codes_data._HCPCS.update(original_hcpcs)
+        codes_data.load_code_metadata.cache_clear()
+        code_tables.CPT_CODES.clear()
+        code_tables.CPT_CODES.update(original_cpt_tables)
+        code_tables.ICD10_CODES.clear()
+        code_tables.ICD10_CODES.update(original_icd_tables)
+        main_module.CPT_REVENUE = original_revenue
+
+
+@pytest.mark.asyncio
+async def test_check_compliance_rules_refreshes_catalog(monkeypatch: pytest.MonkeyPatch) -> None:
+    original_rules = deepcopy(compliance._DEFAULT_RULES)
+    original_resources = deepcopy(compliance._RESOURCE_LIBRARY)
+
+    payload = {
+        "rules": [
+            {
+                "id": "telehealth-consent",
+                "name": "Record telehealth consent",
+                "description": "Telehealth visits must document patient consent.",
+                "category": "documentation",
+                "severity": "high",
+                "type": "absence",
+                "keywords": ["telehealth consent"],
+            }
+        ],
+        "resources": [
+            {
+                "title": "CMS Telehealth Guidance",
+                "url": "https://cms.gov/telehealth",
+                "category": "regulatory",
+                "agency": "CMS",
+                "regions": ["us"],
+                "summary": "Documentation requirements for virtual visits.",
+            }
+        ],
+    }
+
+    monkeypatch.setenv(worker.COMPLIANCE_RULES_URL_ENV, "https://example.com/compliance")
+    monkeypatch.setattr(worker.requests, "get", lambda url, timeout=0: _DummyResponse(payload))
+
+    try:
+        await worker.check_compliance_rules()
+
+        rules = compliance.get_rules()
+        assert any(rule["id"] == "telehealth-consent" for rule in rules)
+
+        resources = compliance.get_resources()
+        assert resources and resources[0]["title"] == "CMS Telehealth Guidance"
+    finally:
+        compliance._DEFAULT_RULES = original_rules
+        compliance._RESOURCE_LIBRARY = original_resources
+
+
+@pytest.mark.asyncio
+async def test_scheduler_runs_configured_jobs(monkeypatch: pytest.MonkeyPatch) -> None:
+    call_order: List[str] = []
+    task_queue: asyncio.Queue = asyncio.Queue()
+
+    monkeypatch.setattr(worker, "_task_queue", task_queue, raising=False)
+    monkeypatch.setattr(worker, "_background_tasks", [], raising=False)
+
+    codes_counter = {"count": 0}
+
+    async def fake_codes() -> None:
+        codes_counter["count"] += 1
+        if codes_counter["count"] == 1:
+            raise RuntimeError("transient failure")
+        call_order.append("codes")
+
+    async def fake_compliance() -> None:
+        call_order.append("compliance")
+
+    async def fake_aggregate() -> None:
+        call_order.append("aggregate")
+
+    async def fake_retrain_job() -> None:
+        call_order.append("retrain_job")
+
+    async def fake_audit_job() -> None:
+        call_order.append("audit_job")
+
+    async def fake_queue_model() -> None:
+        call_order.append("queue_model")
+        await worker._task_queue.put(fake_retrain_job)
+
+    async def fake_queue_audit() -> None:
+        call_order.append("queue_audit")
+        await worker._task_queue.put(fake_audit_job)
+
+    monkeypatch.setattr(worker, "update_code_databases", fake_codes)
+    monkeypatch.setattr(worker, "check_compliance_rules", fake_compliance)
+    monkeypatch.setattr(worker, "aggregate_analytics_and_backup", fake_aggregate)
+    monkeypatch.setattr(worker, "queue_model_retraining", lambda: fake_queue_model())
+    monkeypatch.setattr(worker, "queue_audit_trail_generation", lambda: fake_queue_audit())
+
+    monkeypatch.setattr(worker, "CODE_REFRESH_INTERVAL", 0.05, raising=False)
+    monkeypatch.setattr(worker, "COMPLIANCE_REFRESH_INTERVAL", 0.05, raising=False)
+    monkeypatch.setattr(worker, "ANALYTICS_REFRESH_INTERVAL", 0.05, raising=False)
+    monkeypatch.setattr(worker, "MODEL_REFRESH_INTERVAL", 0.05, raising=False)
+    monkeypatch.setattr(worker, "AUDIT_REFRESH_INTERVAL", 0.05, raising=False)
+
+    worker.start_scheduler()
+    try:
+        await asyncio.sleep(0.2)
+    finally:
+        await worker.stop_scheduler()
+
+    assert codes_counter["count"] >= 2  # retried after initial failure
+    assert "codes" in call_order
+    assert "compliance" in call_order
+    assert "queue_model" in call_order and "retrain_job" in call_order
+    assert "queue_audit" in call_order and "audit_job" in call_order
+    assert "aggregate" in call_order


### PR DESCRIPTION
## Summary
- fetch CPT/ICD-10/HCPCS datasets via configurable endpoints and reload in-memory tables
- pull compliance rule/catalog updates and centralise scheduler intervals in the worker
- add integration tests covering dataset refreshes and periodic job execution

## Testing
- pytest tests/test_worker_jobs.py --cov-fail-under=0

------
https://chatgpt.com/codex/tasks/task_e_68c862beb12c8324a0aa117d7a207a3b