### PR TITLE
Implement database-driven patient lookup with enhanced search

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -683,6 +683,7 @@ ensure_note_auto_saves_table(db_conn)
 ensure_event_aggregates_table(db_conn)
 ensure_compliance_issues_table(db_conn)
 ensure_confidence_scores_table(db_conn)
+patients.configure_database(db_conn)
 
 
 # Create helpful indexes for metrics queries (idempotent)
@@ -753,6 +754,7 @@ def _init_core_tables(conn):  # pragma: no cover - invoked in tests indirectly
     ensure_compliance_issues_table(conn)
     ensure_confidence_scores_table(conn)
     conn.commit()
+    patients.configure_database(conn)
 
 
 # Proper users table creation (replacing previously malformed snippet)
@@ -4989,59 +4991,6 @@ async def get_last_transcript(user=Depends(require_role("user"))) -> Dict[str, A
     return {"history": history}
 
 
-@app.get("/api/patients/search")  # pragma: no cover - not exercised in tests
-async def search_patients(q: str, user=Depends(require_role("user"))):
-    """Search patients by name."""
-
-    cursor = db_conn.execute(
-        "SELECT id, name, dob FROM patients WHERE name LIKE ?",
-        (f"%{q}%",),
-    )
-    rows = [dict(r) for r in cursor.fetchall()]
-    return {"patients": rows}
-
-
-@app.get("/api/encounters/validate/{encounter_id}")  # pragma: no cover - not exercised in tests
-async def validate_encounter(encounter_id: int, user=Depends(require_role("user"))):
-    """Validate that an encounter exists."""
-
-    cur = db_conn.execute(
-        "SELECT 1 FROM encounters WHERE id = ?",
-        (encounter_id,),
-    )
-    return {"id": encounter_id, "valid": cur.fetchone() is not None}
-
-
-@app.post("/api/visits/session")  # pragma: no cover - not exercised in tests
-async def create_visit_session(
-    session: VisitSessionModel, user=Depends(require_role("user"))
-):
-    """Create a new visit session."""
-
-    cur = db_conn.execute(
-        "INSERT INTO visit_sessions (encounter_id, data, updated_at) VALUES (?, ?, ?)",
-        (session.encounter_id, session.data or "", time.time()),
-    )
-    db_conn.commit()
-    return {"id": cur.lastrowid}
-
-
-@app.put("/api/visits/session")  # pragma: no cover - not exercised in tests
-async def update_visit_session(
-    session: VisitSessionModel, user=Depends(require_role("user"))
-):
-    """Update an existing visit session."""
-
-    if session.id is None:
-        raise HTTPException(status.HTTP_400_BAD_REQUEST, "id required")
-    db_conn.execute(
-        "UPDATE visit_sessions SET encounter_id = ?, data = ?, updated_at = ? WHERE id = ?",
-        (session.encounter_id, session.data or "", time.time(), session.id),
-    )
-    db_conn.commit()
-    return {"status": "ok"}
-
-
 @app.websocket("/api/transcribe/stream")  # pragma: no cover - not exercised in tests
 async def transcribe_stream(websocket: WebSocket):
     """Stream transcription via WebSocket."""
@@ -6238,25 +6187,6 @@ async def schedule_bulk_operations(
 # ------------------- Additional API endpoints ------------------------------
 
 
-class Patient(BaseModel):
-    patientId: str
-    name: str
-    age: int
-    gender: str
-    insurance: str
-    lastVisit: str
-    allergies: List[str]
-    medications: List[str]
-
-
-@app.get("/api/patients/{patient_id}", response_model=Patient)
-async def get_patient_api(patient_id: str, user=Depends(require_role("user"))):
-    rec = patients.get_patient(patient_id)
-    if not rec:
-        raise HTTPException(status_code=404, detail="patient not found")
-    return Patient(**rec)
-
-
 @app.get("/api/schedule/appointments", response_model=AppointmentList)
 async def api_list_appointments(user=Depends(require_role("user"))):
     items = list_appointments()
@@ -6298,15 +6228,6 @@ async def manage_visit_state(
     return VisitState(**state)
 
 
-@app.post("/api/charts/upload")
-async def upload_chart(
-    background_tasks: BackgroundTasks,
-    file: UploadFile = File(...),
-    user=Depends(require_role("user")),
-):
-    data = await file.read()
-    background_tasks.add_task(process_chart, file.filename, data)
-    return {"status": "processing"}
 # ---------------------------------------------------------------------------
 # ---------------------- Code validation & billing -------------------------
           
@@ -6559,54 +6480,54 @@ class VisitSessionUpdate(BaseModel):
 
 
 @app.get("/api/patients/search")
-async def search_patients(q: str, user=Depends(require_role("user"))):
-    like = f"%{q}%"
-    rows = db_conn.execute(
-        "SELECT id, first_name, last_name, dob, mrn FROM patients WHERE first_name LIKE ? OR last_name LIKE ? OR mrn LIKE ? LIMIT 10",
-        (like, like, like),
-    ).fetchall()
-    return [
-        {
-            "patientId": r["id"],
-            "name": f"{r['first_name']} {r['last_name']}",
-            "dob": r["dob"],
-            "mrn": r["mrn"],
-        }
-        for r in rows
-    ]
+async def search_patients_v2(
+    q: str = Query(..., min_length=1),
+    limit: int = Query(25, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    user=Depends(require_role("user")),
+):
+    return patients.search_patients(q, limit=limit, offset=offset)
 
 
 @app.get("/api/patients/{patient_id}")
 async def get_patient(patient_id: int, user=Depends(require_role("user"))):
-    row = db_conn.execute("SELECT * FROM patients WHERE id=?", (patient_id,)).fetchone()
-    if not row:
+    record = patients.get_patient(patient_id)
+    if not record:
         raise HTTPException(status_code=404, detail="patient not found")
+    demographics = {
+        "patientId": record.get("patientId"),
+        "mrn": record.get("mrn"),
+        "name": record.get("name"),
+        "firstName": record.get("firstName"),
+        "lastName": record.get("lastName"),
+        "dob": record.get("dob"),
+        "age": record.get("age"),
+        "gender": record.get("gender"),
+        "insurance": record.get("insurance"),
+        "lastVisit": record.get("lastVisit"),
+    }
     return {
-        "demographics": {
-            "patientId": row["id"],
-            "name": f"{row['first_name']} {row['last_name']}",
-            "dob": row["dob"],
-            "gender": row["gender"],
-        },
-        "allergies": json.loads(row["allergies"] or "[]"),
-        "medications": json.loads(row["medications"] or "[]"),
-        "lastVisit": row["last_visit"],
-        "insurance": row["insurance"],
+        "demographics": demographics,
+        "allergies": record.get("allergies", []),
+        "medications": record.get("medications", []),
+        "encounters": record.get("encounters", []),
     }
 
 
 @app.get("/api/encounters/validate/{encounter_id}")
-async def validate_encounter(encounter_id: int, user=Depends(require_role("user"))):
-    row = db_conn.execute("SELECT * FROM encounters WHERE id=?", (encounter_id,)).fetchone()
-    if not row:
-        return {"valid": False, "error": "Encounter not found"}
-    return {
-        "valid": True,
-        "patientId": row["patient_id"],
-        "date": row["date"],
-        "type": row["type"],
-        "provider": row["provider"],
-    }
+async def validate_encounter_v2(
+    encounter_id: int, user=Depends(require_role("user"))
+):
+    encounter = patients.get_encounter(encounter_id)
+    if encounter is None:
+        return {"valid": False, "errors": ["Encounter not found"], "encounterId": encounter_id}
+    if "patient" not in encounter or not encounter["patient"].get("patientId"):
+        return {
+            "valid": False,
+            "errors": ["Encounter is missing an associated patient"],
+            "encounter": encounter,
+        }
+    return {"valid": True, "encounter": encounter}
 
 
 @app.post("/api/visits/session")

--- a/backend/migrations.py
+++ b/backend/migrations.py
@@ -376,6 +376,15 @@ def ensure_patients_table(conn: sqlite3.Connection) -> None:  # pragma: no cover
         "medications TEXT"
         ")"
     )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_patients_last_first ON patients(last_name, first_name)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_patients_mrn ON patients(mrn)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_patients_dob ON patients(dob)"
+    )
     conn.commit()
 
 
@@ -394,6 +403,12 @@ def ensure_encounters_table(conn: sqlite3.Connection) -> None:
         "description TEXT,"
         "FOREIGN KEY(patient_id) REFERENCES patients(id)"
         ")"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_encounters_patient ON encounters(patient_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_encounters_date ON encounters(date)"
     )
     conn.commit()
 

--- a/backend/patients.py
+++ b/backend/patients.py
@@ -1,41 +1,425 @@
-from __future__ import annotations
+"""Patient data access helpers.
 
-"""Simple in-memory patient store used by API endpoints.
+This module previously exposed a static in-memory map of mock patients for
+demo purposes.  The tests and API endpoints now require access to the real
+SQLite-backed dataset that powers the rest of the application, with optional
+fallback to an external EHR API when configured via environment variables.
 
-This module exposes a ``get_patient`` helper returning mock patient
-records.  In a real deployment this would query an EHR system or
-external service.  The lightweight store keeps data deterministic for
-unit tests and examples.
+The helpers below centralise patient search and retrieval logic so the HTTP
+handlers can remain thin while unit tests may inject an in-memory connection.
 """
 
-from typing import Dict, Optional
+from __future__ import annotations
 
-# Minimal static patient records for demonstration and tests.
-_PATIENTS: Dict[str, Dict[str, object]] = {
-    "1": {
-        "patientId": "1",
-        "name": "Jane Doe",
-        "age": 29,
-        "gender": "female",
-        "insurance": "Acme Health",
-        "lastVisit": "2024-05-01",
-        "allergies": ["penicillin"],
-        "medications": ["ibuprofen"],
-    },
-    "2": {
-        "patientId": "2",
-        "name": "John Smith",
-        "age": 41,
-        "gender": "male",
-        "insurance": "Universal Care",
-        "lastVisit": "2024-04-15",
-        "allergies": [],
-        "medications": ["lisinopril"],
-    },
-}
+import json
+import logging
+import os
+import sqlite3
+from datetime import date, datetime
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+from urllib.parse import urljoin
+
+import requests
+
+logger = logging.getLogger(__name__)
 
 
-def get_patient(patient_id: str) -> Optional[Dict[str, object]]:
-    """Return a patient record if available."""
+_DB_CONN: Optional[sqlite3.Connection] = None
 
-    return _PATIENTS.get(str(patient_id))
+EHR_PATIENT_API_URL = os.getenv("EHR_PATIENT_API_URL")
+EHR_PATIENT_SEARCH_ENDPOINT = os.getenv("EHR_PATIENT_SEARCH_ENDPOINT", "/patients/search")
+EHR_PATIENT_DETAIL_ENDPOINT = os.getenv("EHR_PATIENT_DETAIL_ENDPOINT", "/patients/{patientId}")
+EHR_PATIENT_TIMEOUT = float(os.getenv("EHR_PATIENT_TIMEOUT", "5"))
+EHR_PATIENT_API_KEY = os.getenv("EHR_PATIENT_API_KEY")
+EHR_PATIENT_AUTH_HEADER = os.getenv("EHR_PATIENT_AUTH_HEADER", "Authorization")
+
+
+def configure_database(conn: sqlite3.Connection) -> None:
+    """Remember ``conn`` so helpers can be used without passing it explicitly."""
+
+    global _DB_CONN
+    _DB_CONN = conn
+
+
+def _resolve_connection(conn: Optional[sqlite3.Connection] = None) -> Optional[sqlite3.Connection]:
+    """Return a SQLite connection to use for queries."""
+
+    if conn is not None:
+        return conn
+    if _DB_CONN is not None:
+        return _DB_CONN
+    try:  # Late import to avoid circular dependency during module import.
+        from backend import main  # type: ignore
+
+        return getattr(main, "db_conn", None)
+    except Exception:
+        return None
+
+
+def _deserialize_json_list(value: Any) -> List[str]:
+    """Return ``value`` coerced into a list of strings."""
+
+    if value in (None, "", b""):
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value if item is not None]
+    if isinstance(value, (bytes, bytearray)):
+        try:
+            value = value.decode("utf-8")
+        except Exception:
+            value = value.decode("utf-8", errors="ignore")
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return []
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            parsed = text
+        if isinstance(parsed, list):
+            return [str(item) for item in parsed if item is not None]
+        if isinstance(parsed, str):
+            stripped = parsed.strip()
+            return [stripped] if stripped else []
+    return []
+
+
+def _calculate_age(dob_str: Optional[str]) -> Optional[int]:
+    """Return the approximate age in years for the given ISO date string."""
+
+    if not dob_str:
+        return None
+    try:
+        dob = datetime.strptime(dob_str, "%Y-%m-%d").date()
+    except ValueError:
+        return None
+    today = date.today()
+    years = today.year - dob.year - ((today.month, today.day) < (dob.month, dob.day))
+    return max(years, 0)
+
+
+def _format_patient_row(row: Mapping[str, Any]) -> Dict[str, Any]:
+    """Normalise a patient row from SQLite into the API response format."""
+
+    data = dict(row)
+    patient_id = data.get("id") or data.get("patient_id")
+    first = (data.get("first_name") or "").strip()
+    last = (data.get("last_name") or "").strip()
+    mrn = data.get("mrn")
+    name_parts = [part for part in (first, last) if part]
+    name = " ".join(name_parts) if name_parts else (mrn or f"Patient {patient_id}")
+    payload: Dict[str, Any] = {
+        "patientId": str(patient_id) if patient_id is not None else None,
+        "mrn": mrn,
+        "firstName": first,
+        "lastName": last,
+        "name": name,
+        "dob": data.get("dob"),
+        "age": _calculate_age(data.get("dob")),
+        "gender": data.get("gender"),
+        "insurance": data.get("insurance"),
+        "lastVisit": data.get("last_visit"),
+        "allergies": _deserialize_json_list(data.get("allergies")),
+        "medications": _deserialize_json_list(data.get("medications")),
+    }
+    return payload
+
+
+def _ehr_headers() -> Dict[str, str]:
+    """Return headers for talking to the external EHR API."""
+
+    headers: Dict[str, str] = {}
+    if EHR_PATIENT_API_KEY:
+        headers[EHR_PATIENT_AUTH_HEADER] = EHR_PATIENT_API_KEY
+    return headers
+
+
+def _build_ehr_url(endpoint: str) -> str:
+    base = EHR_PATIENT_API_URL
+    if not base:
+        raise RuntimeError("EHR_PATIENT_API_URL is not configured")
+    return urljoin(base.rstrip("/") + "/", endpoint.lstrip("/"))
+
+
+def _normalize_remote_patient(data: Mapping[str, Any]) -> Dict[str, Any]:
+    """Coerce a remote payload into the internal patient representation."""
+
+    patient_id = data.get("patientId") or data.get("id") or data.get("identifier")
+    first = data.get("firstName") or data.get("first_name") or data.get("givenName") or ""
+    last = data.get("lastName") or data.get("last_name") or data.get("familyName") or ""
+    name = data.get("name") or " ".join(part for part in (first, last) if part)
+    payload = {
+        "patientId": str(patient_id) if patient_id is not None else None,
+        "mrn": data.get("mrn") or data.get("identifier"),
+        "firstName": first,
+        "lastName": last,
+        "name": name,
+        "dob": data.get("dob") or data.get("dateOfBirth"),
+        "age": data.get("age"),
+        "gender": data.get("gender"),
+        "insurance": data.get("insurance"),
+        "lastVisit": data.get("lastVisit") or data.get("last_visit"),
+        "allergies": _deserialize_json_list(data.get("allergies")),
+        "medications": _deserialize_json_list(data.get("medications")),
+    }
+    encounters = data.get("encounters")
+    if isinstance(encounters, Iterable) and not isinstance(encounters, (str, bytes, dict)):
+        payload["encounters"] = list(encounters)
+    return payload
+
+
+def _fetch_remote_patient(patient_id: str) -> Optional[Dict[str, Any]]:
+    if not EHR_PATIENT_API_URL:
+        return None
+    endpoint = EHR_PATIENT_DETAIL_ENDPOINT.format(patientId=patient_id, mrn=patient_id)
+    try:
+        resp = requests.get(
+            _build_ehr_url(endpoint),
+            headers=_ehr_headers(),
+            timeout=EHR_PATIENT_TIMEOUT,
+        )
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        payload = resp.json()
+    except Exception:  # pragma: no cover - depends on external service
+        logger.exception("EHR patient lookup failed for id=%s", patient_id)
+        return None
+    if isinstance(payload, Mapping):
+        return _normalize_remote_patient(payload)
+    return None
+
+
+def _fetch_remote_patients(
+    query: str, *, limit: int, offset: int
+) -> Tuple[List[Dict[str, Any]], Optional[Mapping[str, Any]]]:
+    if not EHR_PATIENT_API_URL or not query:
+        return [], None
+    try:
+        resp = requests.get(
+            _build_ehr_url(EHR_PATIENT_SEARCH_ENDPOINT),
+            params={"q": query, "limit": limit, "offset": offset},
+            headers=_ehr_headers(),
+            timeout=EHR_PATIENT_TIMEOUT,
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+    except Exception:  # pragma: no cover - depends on external service
+        logger.exception("EHR patient search failed for query=%s", query)
+        return [], None
+
+    if isinstance(payload, Mapping):
+        raw_results = payload.get("patients") or payload.get("results") or []
+        pagination = payload.get("pagination")
+    elif isinstance(payload, list):
+        raw_results = payload
+        pagination = None
+    else:
+        return [], None
+
+    normalised = [
+        _normalize_remote_patient(item)
+        for item in raw_results
+        if isinstance(item, Mapping)
+    ]
+    return normalised, pagination
+
+
+def get_patient(
+    patient_id: str | int,
+    *,
+    conn: Optional[sqlite3.Connection] = None,
+    include_encounters: bool = True,
+    prefer_remote: bool = False,
+) -> Optional[Dict[str, Any]]:
+    """Return a patient record from the local dataset or EHR."""
+
+    identifier = str(patient_id)
+    connection = _resolve_connection(conn)
+    row = None
+    if connection is not None:
+        try:
+            row = connection.execute(
+                "SELECT * FROM patients WHERE id = ?", (identifier,)
+            ).fetchone()
+        except sqlite3.Error:
+            row = None
+        if row is None:
+            try:
+                row = connection.execute(
+                    "SELECT * FROM patients WHERE mrn = ?", (identifier,)
+                ).fetchone()
+            except sqlite3.Error:
+                row = None
+    if row is not None:
+        patient = _format_patient_row(row)
+        if include_encounters and connection is not None and patient.get("patientId"):
+            patient["encounters"] = list(
+                _load_encounters_for_patient(connection, int(patient["patientId"]))
+            )
+        return patient
+
+    if prefer_remote:
+        return _fetch_remote_patient(identifier)
+    remote = _fetch_remote_patient(identifier)
+    if remote:
+        return remote
+    return None
+
+
+def _load_encounters_for_patient(
+    conn: sqlite3.Connection, patient_id: int
+) -> Iterable[Dict[str, Any]]:
+    cursor = conn.execute(
+        """
+        SELECT id, patient_id, date, type, provider, description
+        FROM encounters
+        WHERE patient_id = ?
+        ORDER BY COALESCE(date, '') DESC, id DESC
+        """,
+        (patient_id,),
+    )
+    for row in cursor.fetchall():
+        yield {
+            "encounterId": row["id"],
+            "patientId": row["patient_id"],
+            "date": row["date"],
+            "type": row["type"],
+            "provider": row["provider"],
+            "description": row["description"],
+        }
+
+
+def search_patients(
+    query: str,
+    *,
+    conn: Optional[sqlite3.Connection] = None,
+    limit: int = 25,
+    offset: int = 0,
+    fields: Optional[Sequence[str]] = None,
+) -> Dict[str, Any]:
+    """Search for patients by multiple fields with pagination support."""
+
+    connection = _resolve_connection(conn)
+    fields = fields or ("first_name", "last_name", "mrn", "dob")
+    like_terms: List[str] = []
+    params: List[str] = []
+
+    tokens = [token.strip() for token in query.split() if token.strip()]
+    if tokens:
+        for token in tokens:
+            like = f"%{token}%"
+            clauses = [f"LOWER({field}) LIKE LOWER(?)" for field in fields]
+            clauses.append("LOWER(first_name || ' ' || last_name) LIKE LOWER(?)")
+            like_terms.append("(" + " OR ".join(clauses) + ")")
+            params.extend([like] * len(fields))
+            params.append(like)
+        where_clause = " WHERE " + " AND ".join(like_terms)
+    else:
+        where_clause = ""
+
+    total = 0
+    patients_local: List[Dict[str, Any]] = []
+    if connection is not None:
+        try:
+            total = connection.execute(
+                f"SELECT COUNT(*) FROM patients{where_clause}", params
+            ).fetchone()[0]
+            rows = connection.execute(
+                """
+                SELECT id, first_name, last_name, dob, mrn, gender, insurance, last_visit, allergies, medications
+                FROM patients
+            """
+                + where_clause
+                + " ORDER BY last_name COLLATE NOCASE, first_name COLLATE NOCASE, id LIMIT ? OFFSET ?",
+                params + [limit, offset],
+            ).fetchall()
+        except sqlite3.Error:
+            rows = []
+        patients_local = [_format_patient_row(row) for row in rows]
+
+    pagination = {
+        "query": query,
+        "limit": limit,
+        "offset": offset,
+        "returned": len(patients_local),
+        "total": total,
+        "hasMore": offset + len(patients_local) < total,
+    }
+
+    result: Dict[str, Any] = {"patients": patients_local, "pagination": pagination}
+
+    remote_patients, remote_pagination = _fetch_remote_patients(
+        query, limit=limit, offset=offset
+    )
+    if remote_patients:
+        result["externalPatients"] = remote_patients
+        if remote_pagination:
+            result["externalPagination"] = dict(remote_pagination)
+
+    return result
+
+
+def get_encounter(
+    encounter_id: int,
+    *,
+    conn: Optional[sqlite3.Connection] = None,
+    include_patient: bool = True,
+) -> Optional[Dict[str, Any]]:
+    """Return encounter metadata along with patient context when available."""
+
+    connection = _resolve_connection(conn)
+    if connection is None:
+        return None
+    try:
+        row = connection.execute(
+            """
+            SELECT
+                e.id AS encounter_id,
+                e.patient_id AS encounter_patient_id,
+                e.date,
+                e.type,
+                e.provider,
+                e.description,
+                p.id AS patient_id,
+                p.first_name,
+                p.last_name,
+                p.dob,
+                p.mrn,
+                p.gender,
+                p.insurance,
+                p.last_visit,
+                p.allergies,
+                p.medications
+            FROM encounters e
+            LEFT JOIN patients p ON e.patient_id = p.id
+            WHERE e.id = ?
+            """,
+            (encounter_id,),
+        ).fetchone()
+    except sqlite3.Error:
+        row = None
+
+    if row is None:
+        return None
+
+    encounter = {
+        "encounterId": row["encounter_id"],
+        "patientId": row["encounter_patient_id"],
+        "date": row["date"],
+        "type": row["type"],
+        "provider": row["provider"],
+        "description": row["description"],
+    }
+    if include_patient and row["patient_id"] is not None:
+        encounter["patient"] = _format_patient_row(row)
+    return encounter
+
+
+__all__ = [
+    "configure_database",
+    "get_patient",
+    "search_patients",
+    "get_encounter",
+]
+

--- a/tests/test_patient_endpoints.py
+++ b/tests/test_patient_endpoints.py
@@ -83,25 +83,49 @@ def test_patient_encounter_flow(client):
     token = client.post('/login', json={'username': 'user', 'password': 'pw'}).json()['access_token']
 
     # search patients
-    resp = client.get('/api/patients/search', params={'q': 'Jane'}, headers=auth_header(token))
+    resp = client.get(
+        '/api/patients/search',
+        params={'q': 'Jane', 'limit': 2},
+        headers=auth_header(token),
+    )
     assert resp.status_code == 200
     results = resp.json()
-    assert any(r['patientId'] == jane_id for r in results)
+    assert results['pagination']['returned'] == 1
+    assert any(str(jane_id) == r['patientId'] for r in results['patients'])
+    assert results['patients'][0]['mrn'] == 'MRN456'
+
+    # search by MRN across fields and paginate
+    resp = client.get(
+        '/api/patients/search',
+        params={'q': 'MRN', 'limit': 1, 'offset': 1},
+        headers=auth_header(token),
+    )
+    assert resp.status_code == 200
+    page = resp.json()
+    assert page['pagination']['offset'] == 1
+    assert page['pagination']['returned'] == 1
+    assert any(result['mrn'] == 'MRN456' for result in page['patients'])
 
     # patient details
     resp = client.get(f'/api/patients/{john_id}', headers=auth_header(token))
     assert resp.status_code == 200
     data = resp.json()
     assert data['demographics']['name'] == 'John Doe'
+    assert data['demographics']['mrn'] == 'MRN123'
     assert data['allergies'] == ['peanuts']
 
     # encounter validation
     resp = client.get(f'/api/encounters/validate/{encounter_id}', headers=auth_header(token))
     assert resp.status_code == 200
-    assert resp.json()['valid'] is True
+    encounter_payload = resp.json()
+    assert encounter_payload['valid'] is True
+    assert encounter_payload['encounter']['encounterId'] == encounter_id
+    assert encounter_payload['encounter']['patient']['patientId'] == str(john_id)
     resp = client.get('/api/encounters/validate/999', headers=auth_header(token))
     assert resp.status_code == 200
-    assert resp.json()['valid'] is False
+    invalid = resp.json()
+    assert invalid['valid'] is False
+    assert 'Encounter not found' in invalid['errors'][0]
 
     # visit session start and complete
     resp = client.post('/api/visits/session', json={'encounter_id': encounter_id}, headers=auth_header(token))
@@ -118,3 +142,28 @@ def test_patient_encounter_flow(client):
     assert info['filename'] == 'chart.txt'
     assert info['size'] == 3
     assert (main.UPLOAD_DIR / 'chart.txt').exists()
+
+
+def test_validate_encounter_missing_patient(client):
+    db = main.db_conn
+    db.execute(
+        "INSERT INTO patients (first_name, last_name, dob, mrn, gender, insurance) VALUES (?, ?, ?, ?, ?, ?)",
+        ('Ghost', 'Patient', '1970-01-01', 'MRNX', 'X', 'None'),
+    )
+    patient_id = db.execute("SELECT last_insert_rowid()").fetchone()[0]
+    db.execute(
+        "INSERT INTO encounters (patient_id, date, type, provider) VALUES (?, ?, ?, ?)",
+        (patient_id, '2024-05-05', 'followup', 'Dr. Strange'),
+    )
+    encounter_id = db.execute("SELECT last_insert_rowid()").fetchone()[0]
+    db.execute("DELETE FROM patients WHERE id=?", (patient_id,))
+    db.commit()
+
+    token = client.post('/login', json={'username': 'user', 'password': 'pw'}).json()['access_token']
+    resp = client.get(f'/api/encounters/validate/{encounter_id}', headers=auth_header(token))
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload['valid'] is False
+    assert 'associated patient' in payload['errors'][0]
+    assert payload['encounter']['encounterId'] == encounter_id
+    assert 'patient' not in payload['encounter']


### PR DESCRIPTION
## Summary
- replace the in-memory patient helper with a database/EHR backed repository that exposes search and encounter helpers
- upgrade the patient search and encounter validation API routes to return richer metadata and support pagination
- add supporting SQLite indexes and expand the patient endpoint tests for the new behaviour

## Testing
- PYTEST_ADDOPTS="--no-cov" pytest tests/test_patient_endpoints.py

------
https://chatgpt.com/codex/tasks/task_e_68c897afa040832491901a82671dbab0