### PR TITLE
feat: persist websocket notifications

### DIFF
--- a/backend/migrations.py
+++ b/backend/migrations.py
@@ -445,6 +445,34 @@ def ensure_note_auto_saves_table(conn: sqlite3.Connection) -> None:  # pragma: n
 
     conn.commit()
 
+
+def ensure_notification_counters_table(conn: sqlite3.Connection) -> None:
+    """Ensure the notification_counters table exists for unread counts."""
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS notification_counters (
+            user_id INTEGER PRIMARY KEY,
+            count INTEGER NOT NULL DEFAULT 0,
+            updated_at REAL NOT NULL,
+            FOREIGN KEY(user_id) REFERENCES users(id)
+        )
+        """
+    )
+
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(notification_counters)")}
+    if "count" not in columns:
+        conn.execute(
+            "ALTER TABLE notification_counters ADD COLUMN count INTEGER NOT NULL DEFAULT 0"
+        )
+    if "updated_at" not in columns:
+        conn.execute(
+            "ALTER TABLE notification_counters ADD COLUMN updated_at REAL NOT NULL DEFAULT (strftime('%s','now'))"
+        )
+
+    conn.commit()
+
+
 def ensure_session_state_table(conn: sqlite3.Connection) -> None:
     """Ensure the session_state table exists."""
     conn.execute(


### PR DESCRIPTION
## Summary
- add a notification_counters table and helper functions to persist unread counts
- expand ConnectionManager to track users, replay history, and push channel metadata
- emit websocket updates from auto-save and compliance actions and seed notification feeds

## Testing
- pytest tests/test_auth.py::test_register_and_login
- pytest tests/test_user_profile_api.py::test_profile_and_notifications -vv

------
https://chatgpt.com/codex/tasks/task_e_68c897b1ef4c83248c9a5ec642b7fba1