### PR TITLE
Add compliance rule persistence and management API

### DIFF
--- a/backend/compliance_models.py
+++ b/backend/compliance_models.py
@@ -1,0 +1,135 @@
+"""SQLAlchemy models for compliance data."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy import Column, DateTime, String, Text
+from sqlalchemy.orm import declarative_base
+
+
+Base = declarative_base()
+
+
+class ComplianceRule(Base):
+    """ORM model representing a compliance rule definition."""
+
+    __tablename__ = "compliance_rules"
+
+    id = Column(String, primary_key=True)
+    name = Column(String, nullable=False)
+    description = Column(Text, nullable=False)
+    category = Column(String, nullable=True)
+    severity = Column(String, nullable=True)
+    rule_type = Column("type", String, nullable=False)
+    metadata_json = Column("metadata", Text, nullable=True)
+    references_json = Column("references", Text, nullable=True)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    updated_at = Column(
+        DateTime,
+        nullable=False,
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+    )
+
+    def metadata_dict(self) -> Dict[str, Any]:
+        """Return the decoded metadata dictionary for the rule."""
+
+        if not self.metadata_json:
+            return {}
+        try:
+            decoded = json.loads(self.metadata_json)
+        except (json.JSONDecodeError, TypeError):
+            return {}
+        if isinstance(decoded, dict):
+            return decoded
+        return {}
+
+    def references_list(self) -> List[Dict[str, Any]]:
+        """Return the decoded references list for the rule."""
+
+        if not self.references_json:
+            return []
+        try:
+            decoded = json.loads(self.references_json)
+        except (json.JSONDecodeError, TypeError):
+            return []
+        if isinstance(decoded, list):
+            return [item for item in decoded if isinstance(item, dict)]
+        return []
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialise the rule to a dictionary including metadata fields."""
+
+        data: Dict[str, Any] = {
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "category": self.category,
+            "severity": self.severity,
+            "type": self.rule_type,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }
+        metadata = self.metadata_dict()
+        if metadata:
+            data["metadata"] = metadata
+            for key, value in metadata.items():
+                data.setdefault(key, value)
+        references = self.references_list()
+        if references:
+            data["references"] = references
+        return data
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ComplianceRule":
+        """Create an instance from an API or seed dictionary."""
+
+        metadata_payload = {}
+        incoming_metadata = data.get("metadata")
+        if isinstance(incoming_metadata, dict):
+            metadata_payload.update(incoming_metadata)
+
+        core_fields = {
+            "id",
+            "name",
+            "description",
+            "category",
+            "severity",
+            "type",
+            "metadata",
+            "references",
+            "created_at",
+            "updated_at",
+            "createdAt",
+            "updatedAt",
+        }
+        for key, value in data.items():
+            if key in core_fields:
+                continue
+            metadata_payload[key] = value
+
+        references_value = data.get("references")
+        references_serialized: Optional[str] = None
+        if isinstance(references_value, list):
+            refs_clean = [item for item in references_value if isinstance(item, dict)]
+            if refs_clean:
+                references_serialized = json.dumps(refs_clean)
+
+        metadata_serialized: Optional[str] = None
+        if metadata_payload:
+            metadata_serialized = json.dumps(metadata_payload)
+
+        return cls(
+            id=str(data.get("id", "")),
+            name=str(data.get("name", "")),
+            description=str(data.get("description", "")),
+            category=data.get("category"),
+            severity=data.get("severity"),
+            rule_type=str(data.get("type", "absence")),
+            metadata_json=metadata_serialized,
+            references_json=references_serialized,
+        )
+

--- a/backend/main.py
+++ b/backend/main.py
@@ -58,6 +58,7 @@ from pydantic import (
     validator,  # legacy import still used elsewhere
     StrictBool,
     field_validator,
+    ConfigDict,
 )
 import json, sqlite3
 from uuid import uuid4
@@ -121,6 +122,7 @@ from backend.migrations import (  # type: ignore
     ensure_session_state_table,
     ensure_event_aggregates_table,
     ensure_compliance_issues_table,
+    ensure_compliance_rules_table,
     ensure_confidence_scores_table,
     ensure_notification_counters_table,
 )
@@ -843,9 +845,13 @@ ensure_note_versions_table(db_conn)
 ensure_notifications_table(db_conn)
 ensure_event_aggregates_table(db_conn)
 ensure_compliance_issues_table(db_conn)
+ensure_compliance_rules_table(db_conn)
 ensure_confidence_scores_table(db_conn)
 ensure_notification_counters_table(db_conn)
 patients.configure_database(db_conn)
+
+# Keep the compliance ORM bound to the active database connection.
+compliance_engine.configure_engine(db_conn)
 
 
 # Create helpful indexes for metrics queries (idempotent)
@@ -914,10 +920,12 @@ def _init_core_tables(conn):  # pragma: no cover - invoked in tests indirectly
     ensure_note_auto_saves_table(conn)
     ensure_session_state_table(conn)
     ensure_compliance_issues_table(conn)
+    ensure_compliance_rules_table(conn)
     ensure_confidence_scores_table(conn)
     ensure_notification_counters_table(conn)
     conn.commit()
     patients.configure_database(conn)
+    compliance_engine.configure_engine(conn)
 
 
 # Proper users table creation (replacing previously malformed snippet)
@@ -951,6 +959,7 @@ ensure_visit_sessions_table(db_conn)
 ensure_note_auto_saves_table(db_conn)
 ensure_session_state_table(db_conn)
 ensure_compliance_issues_table(db_conn)
+ensure_compliance_rules_table(db_conn)
 ensure_confidence_scores_table(db_conn)
 
 # User profile details including current view and UI preferences.
@@ -2951,6 +2960,68 @@ class ComplianceIssueRecord(BaseModel):
     updatedAt: float
     createdBy: Optional[str] = None
     assignee: Optional[str] = None
+
+
+class ComplianceRuleBase(BaseModel):
+    """Shared fields for compliance rule create/update operations."""
+
+    name: Optional[str] = None
+    description: Optional[str] = None
+    category: Optional[str] = None
+    severity: Optional[str] = None
+    type: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+    references: Optional[List[Dict[str, Any]]] = None
+
+    model_config = ConfigDict(extra="allow")
+
+    @field_validator("metadata")
+    @classmethod
+    def validate_metadata(cls, value: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:  # noqa: D401,N805
+        if value is None:
+            return None
+        if not isinstance(value, dict):
+            raise ValueError("metadata must be an object")
+        return value
+
+    @field_validator("references")
+    @classmethod
+    def validate_references(cls, value: Optional[List[Dict[str, Any]]]) -> Optional[List[Dict[str, Any]]]:  # noqa: D401,N805
+        if value is None:
+            return None
+        cleaned = [item for item in value if isinstance(item, dict)]
+        return cleaned or None
+
+
+class ComplianceRuleCreateRequest(ComplianceRuleBase):
+    id: str
+    name: str
+    description: str
+
+    @field_validator("id")
+    @classmethod
+    def validate_id(cls, value: str) -> str:  # noqa: D401,N805
+        if not value or not value.strip():
+            raise ValueError("id is required")
+        return value.strip()
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: str) -> str:  # noqa: D401,N805
+        if not value or not value.strip():
+            raise ValueError("name is required")
+        return value
+
+    @field_validator("description")
+    @classmethod
+    def validate_description(cls, value: str) -> str:  # noqa: D401,N805
+        if not value or not value.strip():
+            raise ValueError("description is required")
+        return value
+
+
+class ComplianceRuleUpdateRequest(ComplianceRuleBase):
+    pass
 
 
 class DifferentialItem(BaseModel):
@@ -6036,10 +6107,81 @@ async def compliance_monitor(
     return response
 
 
+def _rule_payload_to_dict(
+    model: ComplianceRuleBase, include_id: bool = False
+) -> Dict[str, Any]:
+    data = model.model_dump(exclude_none=True)
+    extras = getattr(model, "model_extra", {}) or {}
+    for key, value in extras.items():
+        if key not in data:
+            data[key] = value
+    if not include_id:
+        data.pop("id", None)
+    return data
+
+
+def _sanitize_rule_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+    def _sanitize(value: Any) -> Any:
+        if isinstance(value, str):
+            return sanitize_text(value)
+        if isinstance(value, list):
+            return [_sanitize(item) for item in value]
+        if isinstance(value, dict):
+            return {key: _sanitize(val) for key, val in value.items()}
+        return value
+
+    return {key: _sanitize(value) for key, value in payload.items()}
+
+
 @app.get("/api/compliance/rules")
 async def compliance_rules(user=Depends(require_role("user"))) -> Dict[str, Any]:
     rules = compliance_engine.get_rules()
     return {"rules": rules, "count": len(rules)}
+
+
+@app.post("/api/compliance/rules")
+async def create_compliance_rule(
+    rule: ComplianceRuleCreateRequest, user=Depends(require_role("admin"))
+) -> Dict[str, Any]:
+    payload = _rule_payload_to_dict(rule, include_id=True)
+    sanitized = _sanitize_rule_payload(payload)
+    try:
+        created = compliance_engine.create_rule(sanitized)
+    except ValueError as exc:  # pragma: no cover - validation handled in service
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return {"rule": created}
+
+
+@app.put("/api/compliance/rules/{rule_id}")
+async def update_compliance_rule(
+    rule_id: str,
+    rule: ComplianceRuleUpdateRequest,
+    user=Depends(require_role("admin")),
+) -> Dict[str, Any]:
+    cleaned_id = sanitize_text(rule_id).strip()
+    if not cleaned_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid rule id")
+    payload = _rule_payload_to_dict(rule)
+    sanitized = _sanitize_rule_payload(payload)
+    try:
+        updated = compliance_engine.update_rule(cleaned_id, sanitized)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    if updated is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Rule not found")
+    return {"rule": updated}
+
+
+@app.delete("/api/compliance/rules/{rule_id}")
+async def delete_compliance_rule(
+    rule_id: str, user=Depends(require_role("admin"))
+) -> Dict[str, str]:
+    cleaned_id = sanitize_text(rule_id).strip()
+    if not cleaned_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid rule id")
+    if not compliance_engine.delete_rule(cleaned_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Rule not found")
+    return {"status": "deleted"}
 
 
 @app.post("/api/compliance/issue-tracking", response_model=ComplianceIssueRecord)

--- a/backend/migrations.py
+++ b/backend/migrations.py
@@ -235,6 +235,49 @@ def ensure_confidence_scores_table(conn: sqlite3.Connection) -> None:
     conn.commit()
 
 
+def ensure_compliance_rules_table(conn: sqlite3.Connection) -> None:
+    """Ensure the compliance_rules table exists for storing rule metadata."""
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS compliance_rules (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            description TEXT NOT NULL,
+            category TEXT,
+            severity TEXT,
+            type TEXT NOT NULL,
+            metadata TEXT,
+            "references" TEXT,
+            created_at REAL NOT NULL DEFAULT (strftime('%s','now')),
+            updated_at REAL NOT NULL DEFAULT (strftime('%s','now'))
+        )
+        """
+    )
+
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(compliance_rules)")}
+    if "metadata" not in columns:
+        conn.execute("ALTER TABLE compliance_rules ADD COLUMN metadata TEXT")
+    if "references" not in columns:
+        conn.execute('ALTER TABLE compliance_rules ADD COLUMN "references" TEXT')
+    if "created_at" not in columns:
+        conn.execute(
+            "ALTER TABLE compliance_rules ADD COLUMN created_at REAL NOT NULL DEFAULT (strftime('%s','now'))"
+        )
+    if "updated_at" not in columns:
+        conn.execute(
+            "ALTER TABLE compliance_rules ADD COLUMN updated_at REAL NOT NULL DEFAULT (strftime('%s','now'))"
+        )
+    if "category" not in columns:
+        conn.execute("ALTER TABLE compliance_rules ADD COLUMN category TEXT")
+    if "severity" not in columns:
+        conn.execute("ALTER TABLE compliance_rules ADD COLUMN severity TEXT")
+    if "type" not in columns:
+        conn.execute("ALTER TABLE compliance_rules ADD COLUMN type TEXT NOT NULL DEFAULT 'absence'")
+
+    conn.commit()
+
+
 def ensure_compliance_issues_table(conn: sqlite3.Connection) -> None:
     """Ensure the compliance_issues table exists for manual tracking."""
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,4 +21,5 @@ llama-cpp-python
 requests-mock
 cryptography
 bleach
+SQLAlchemy
 

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -203,8 +203,7 @@ def _update_compliance_payload(payload: Mapping[str, Any]) -> Dict[str, Optional
         if not isinstance(rules_raw, Sequence):
             raise ValueError("rules payload must be a sequence")
         rules = [dict(item) for item in rules_raw if isinstance(item, Mapping)]
-        compliance._DEFAULT_RULES = rules
-        counts["rules"] = len(rules)
+        counts["rules"] = compliance.replace_rules(rules)
 
     if "resources" in payload:
         resources_raw = payload.get("resources")

--- a/tests/test_compliance_rules_api.py
+++ b/tests/test_compliance_rules_api.py
@@ -1,0 +1,117 @@
+import sqlite3
+from collections import defaultdict, deque
+from typing import Dict, Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend import main, compliance as compliance_engine
+from backend.main import _init_core_tables
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    main.db_conn = sqlite3.connect(":memory:", check_same_thread=False)
+    main.db_conn.row_factory = sqlite3.Row
+    _init_core_tables(main.db_conn)
+    password = main.hash_password("pw")
+    main.db_conn.execute(
+        "INSERT INTO users (username, password_hash, role) VALUES (?, ?, ?)",
+        ("admin", password, "admin"),
+    )
+    main.db_conn.commit()
+    monkeypatch.setattr(main, "db_conn", main.db_conn)
+    monkeypatch.setattr(main, "events", [])
+    monkeypatch.setattr(
+        main,
+        "transcript_history",
+        defaultdict(lambda: deque(maxlen=main.TRANSCRIPT_HISTORY_LIMIT)),
+    )
+    compliance_engine.replace_rules([])
+    return TestClient(main.app)
+
+
+def auth_header(token: str) -> Dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def login(client: TestClient) -> str:
+    resp = client.post("/login", json={"username": "admin", "password": "pw"})
+    assert resp.status_code == 200
+    return resp.json()["access_token"]
+
+
+def test_compliance_rule_crud_flow(client: TestClient) -> None:
+    token = login(client)
+
+    initial_rules = compliance_engine.get_rules()
+    initial_count = len(initial_rules)
+
+    rule_payload: Dict[str, Any] = {
+        "id": "documentation-check",
+        "name": "Documentation completeness",
+        "description": "Ensure critical phrases are present.",
+        "category": "documentation",
+        "severity": "low",
+        "type": "presence",
+        "keywords": ["assessment"],
+        "metadata": {"threshold": 1},
+        "references": [{"title": "CMS", "url": "https://example.com"}],
+        "recommendedAction": "Add an assessment section.",
+    }
+
+    create_resp = client.post(
+        "/api/compliance/rules",
+        json=rule_payload,
+        headers=auth_header(token),
+    )
+    assert create_resp.status_code == 200
+    created_rule = create_resp.json()["rule"]
+    assert created_rule["id"] == "documentation-check"
+    assert created_rule["keywords"] == ["assessment"]
+    assert created_rule["metadata"]["threshold"] == 1
+    assert created_rule["references"][0]["title"] == "CMS"
+
+    list_resp = client.get("/api/compliance/rules", headers=auth_header(token))
+    assert list_resp.status_code == 200
+    listed = list_resp.json()
+    assert listed["count"] == initial_count + 1
+    assert any(rule["id"] == "documentation-check" for rule in listed["rules"])
+
+    update_payload = {
+        "name": "Updated completeness",
+        "metadata": {"threshold": None, "severityOverride": "moderate"},
+        "references": [{"title": "Updated", "url": "https://example.org"}],
+        "recommendedAction": "Document updated findings.",
+    }
+    update_resp = client.put(
+        "/api/compliance/rules/documentation-check",
+        json=update_payload,
+        headers=auth_header(token),
+    )
+    assert update_resp.status_code == 200
+    updated_rule = update_resp.json()["rule"]
+    assert updated_rule["name"] == "Updated completeness"
+    assert "threshold" not in updated_rule["metadata"]
+    assert updated_rule["metadata"]["severityOverride"] == "moderate"
+    assert updated_rule["references"][0]["title"] == "Updated"
+    assert updated_rule["recommendedAction"] == "Document updated findings."
+
+    delete_resp = client.delete(
+        "/api/compliance/rules/documentation-check",
+        headers=auth_header(token),
+    )
+    assert delete_resp.status_code == 200
+    assert delete_resp.json()["status"] == "deleted"
+
+    final_resp = client.get("/api/compliance/rules", headers=auth_header(token))
+    assert final_resp.status_code == 200
+    final_rules = final_resp.json()
+    assert final_rules["count"] == initial_count
+
+    missing_delete = client.delete(
+        "/api/compliance/rules/documentation-check",
+        headers=auth_header(token),
+    )
+    assert missing_delete.status_code == 404
+

--- a/tests/test_worker_jobs.py
+++ b/tests/test_worker_jobs.py
@@ -116,7 +116,7 @@ async def test_update_code_databases_refreshes_metadata(monkeypatch: pytest.Monk
 
 @pytest.mark.asyncio
 async def test_check_compliance_rules_refreshes_catalog(monkeypatch: pytest.MonkeyPatch) -> None:
-    original_rules = deepcopy(compliance._DEFAULT_RULES)
+    original_rules = compliance.get_rules()
     original_resources = deepcopy(compliance._RESOURCE_LIBRARY)
 
     payload = {
@@ -155,7 +155,7 @@ async def test_check_compliance_rules_refreshes_catalog(monkeypatch: pytest.Monk
         resources = compliance.get_resources()
         assert resources and resources[0]["title"] == "CMS Telehealth Guidance"
     finally:
-        compliance._DEFAULT_RULES = original_rules
+        compliance.replace_rules(original_rules)
         compliance._RESOURCE_LIBRARY = original_resources
 
 


### PR DESCRIPTION
## Summary
- add an SQLAlchemy ComplianceRule model with session helpers and seed data
- create compliance_rules migration hooks and bind the ORM during startup
- expose CRUD endpoints for compliance rules and update the worker refresh job
- cover the new API with CRUD tests and adapt worker job tests

## Testing
- pytest --override-ini addopts= tests/test_compliance_rules_api.py tests/test_worker_jobs.py


------
https://chatgpt.com/codex/tasks/task_e_68c8a174adf083248e93e9005c629753