### PR TITLE
Add compliance and billing audit history logging

### DIFF
--- a/backend/migrations.py
+++ b/backend/migrations.py
@@ -319,6 +319,111 @@ def ensure_compliance_issues_table(conn: sqlite3.Connection) -> None:
 
 
 
+def ensure_compliance_issue_history_table(conn: sqlite3.Connection) -> None:
+    """Ensure the compliance_issue_history table exists for auditing."""
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS compliance_issue_history (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            issue_id TEXT NOT NULL,
+            code TEXT,
+            payer TEXT,
+            findings TEXT,
+            created_at REAL NOT NULL,
+            user_id TEXT
+        )
+        """
+    )
+
+    columns = {
+        row[1]
+        for row in conn.execute("PRAGMA table_info(compliance_issue_history)")
+    }
+
+    if "code" not in columns:
+        conn.execute(
+            "ALTER TABLE compliance_issue_history ADD COLUMN code TEXT"
+        )
+    if "payer" not in columns:
+        conn.execute(
+            "ALTER TABLE compliance_issue_history ADD COLUMN payer TEXT"
+        )
+    if "findings" not in columns:
+        conn.execute(
+            "ALTER TABLE compliance_issue_history ADD COLUMN findings TEXT"
+        )
+    if "created_at" not in columns:
+        conn.execute(
+            "ALTER TABLE compliance_issue_history ADD COLUMN created_at REAL NOT NULL DEFAULT (strftime('%s','now'))"
+        )
+    if "user_id" not in columns:
+        conn.execute(
+            "ALTER TABLE compliance_issue_history ADD COLUMN user_id TEXT"
+        )
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_compliance_history_issue ON compliance_issue_history(issue_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_compliance_history_code ON compliance_issue_history(code)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_compliance_history_created_at ON compliance_issue_history(created_at)"
+    )
+
+    conn.commit()
+
+
+def ensure_billing_audits_table(conn: sqlite3.Connection) -> None:
+    """Ensure the billing_audits table exists for reimbursement logging."""
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS billing_audits (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            audit_id TEXT NOT NULL,
+            code TEXT,
+            payer TEXT,
+            findings TEXT,
+            created_at REAL NOT NULL,
+            user_id TEXT
+        )
+        """
+    )
+
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(billing_audits)")}
+
+    if "code" not in columns:
+        conn.execute("ALTER TABLE billing_audits ADD COLUMN code TEXT")
+    if "payer" not in columns:
+        conn.execute("ALTER TABLE billing_audits ADD COLUMN payer TEXT")
+    if "findings" not in columns:
+        conn.execute("ALTER TABLE billing_audits ADD COLUMN findings TEXT")
+    if "created_at" not in columns:
+        conn.execute(
+            "ALTER TABLE billing_audits ADD COLUMN created_at REAL NOT NULL DEFAULT (strftime('%s','now'))"
+        )
+    if "user_id" not in columns:
+        conn.execute("ALTER TABLE billing_audits ADD COLUMN user_id TEXT")
+    if "audit_id" not in columns:
+        conn.execute(
+            "ALTER TABLE billing_audits ADD COLUMN audit_id TEXT NOT NULL DEFAULT ''"
+        )
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_billing_audits_audit ON billing_audits(audit_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_billing_audits_code ON billing_audits(code)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_billing_audits_created_at ON billing_audits(created_at)"
+    )
+
+    conn.commit()
+
+
 def ensure_patients_table(conn: sqlite3.Connection) -> None:
     """Ensure the patients table exists for storing patient demographics."""
 

--- a/tests/test_audit_history.py
+++ b/tests/test_audit_history.py
@@ -1,0 +1,152 @@
+import sqlite3
+from collections import defaultdict, deque
+from datetime import datetime
+from typing import Any, Dict
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend import main
+from backend.main import _init_core_tables
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    main.db_conn = sqlite3.connect(":memory:", check_same_thread=False)
+    main.db_conn.row_factory = sqlite3.Row
+    _init_core_tables(main.db_conn)
+    password = main.hash_password("pw")
+    main.db_conn.execute(
+        "INSERT INTO users (username, password_hash, role) VALUES (?, ?, ?)",
+        ("user", password, "user"),
+    )
+    main.db_conn.commit()
+    monkeypatch.setattr(main, "db_conn", main.db_conn)
+    monkeypatch.setattr(main, "events", [])
+    monkeypatch.setattr(
+        main,
+        "transcript_history",
+        defaultdict(lambda: deque(maxlen=main.TRANSCRIPT_HISTORY_LIMIT)),
+    )
+    async def _noop_notify(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(main, "_notify_compliance_issue", _noop_notify)
+    return TestClient(main.app)
+
+
+def auth_header(token: str) -> Dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def login(client: TestClient) -> str:
+    response = client.post(
+        "/login", json={"username": "user", "password": "pw"}
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    return payload["access_token"]
+
+
+def test_compliance_issue_history_records(client: TestClient) -> None:
+    token = login(client)
+    payload: Dict[str, Any] = {
+        "title": "Missing documentation",
+        "severity": "medium",
+        "ruleId": "documentation-check",
+        "status": "open",
+        "metadata": {"payer": "Medicare", "details": {"missing": ["HPI"]}},
+        "createdBy": "auditor-1",
+    }
+
+    resp = client.post(
+        "/api/compliance/issue-tracking",
+        json=payload,
+        headers=auth_header(token),
+    )
+    assert resp.status_code == 200
+    issue_record = resp.json()
+    issue_id = issue_record["issueId"]
+
+    history_resp = client.get(
+        "/api/compliance/issues/history",
+        headers=auth_header(token),
+    )
+    assert history_resp.status_code == 200
+    history_payload = history_resp.json()
+    assert history_payload["count"] >= 1
+    records = history_payload["records"]
+    assert any(entry["issueId"] == issue_id for entry in records)
+    entry = next(item for item in records if item["issueId"] == issue_id)
+    assert entry["code"] == "documentation-check"
+    assert entry["payer"].lower() == "medicare"
+    assert entry["userId"] == "auditor-1"
+    assert entry["findings"]["status"] == "open"
+
+    filtered = client.get(
+        "/api/compliance/issues/history",
+        params={"issueId": issue_id, "payer": "medicare"},
+        headers=auth_header(token),
+    )
+    assert filtered.status_code == 200
+    filtered_payload = filtered.json()
+    assert filtered_payload["count"] == 1
+    filtered_entry = filtered_payload["records"][0]
+    assert filtered_entry["issueId"] == issue_id
+    assert filtered_entry["code"] == "documentation-check"
+
+
+def test_billing_audit_history_records(client: TestClient) -> None:
+    token = login(client)
+    billing_payload = {
+        "codes": ["99213", "J3490"],
+        "payerType": "medicare",
+        "location": "virtual",
+    }
+
+    calc_resp = client.post(
+        "/api/billing/calculate",
+        json=billing_payload,
+        headers=auth_header(token),
+    )
+    assert calc_resp.status_code == 200
+    calculation = calc_resp.json()
+    assert calculation["totalEstimated"] > 0
+
+    audits_resp = client.get(
+        "/api/billing/audits",
+        headers=auth_header(token),
+    )
+    assert audits_resp.status_code == 200
+    audits_payload = audits_resp.json()
+    assert audits_payload["count"] >= 1
+    audit_records = audits_payload["records"]
+    audit_ids = {entry["auditId"] for entry in audit_records}
+    assert len(audit_ids) == 1
+    assert any(entry["code"] == "99213" for entry in audit_records)
+    for entry in audit_records:
+        assert entry["payer"].lower() == "medicare"
+        assert entry["findings"]["totalEstimated"] == pytest.approx(
+            calculation["totalEstimated"], rel=1e-6
+        )
+        datetime.fromisoformat(entry["timestamp"])  # validates ISO format
+
+    code_filtered = client.get(
+        "/api/billing/audits",
+        params={"code": "99213"},
+        headers=auth_header(token),
+    )
+    assert code_filtered.status_code == 200
+    code_payload = code_filtered.json()
+    assert code_payload["count"] == 1
+    assert code_payload["records"][0]["code"] == "99213"
+
+    first_timestamp = datetime.fromisoformat(audit_records[0]["timestamp"]).timestamp()
+    time_filtered = client.get(
+        "/api/billing/audits",
+        params={"start": first_timestamp - 1, "userId": "user"},
+        headers=auth_header(token),
+    )
+    assert time_filtered.status_code == 200
+    time_payload = time_filtered.json()
+    assert time_payload["count"] >= len(audit_records)


### PR DESCRIPTION
## Summary
- add migrations and schema helpers for compliance issue history and billing audit tables
- extend compliance issue persistence to record history and add billing audit logging plus query endpoints
- add tests covering compliance and billing history creation with filtering

## Testing
- pytest tests/test_audit_history.py tests/test_codes_billing.py *(fails coverage threshold requirement in repo config)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b103c11083248dab38dec123d3da