### PR TITLE
Fix frontend package metadata and dependencies

### DIFF
--- a/RevenuePilot New Frontend/package.json
+++ b/RevenuePilot New Frontend/package.json
@@ -1,6 +1,6 @@
 
   {
-      "name": "AI-Powered Clinical Note Editor",
+      "name": "ai-powered-clinical-note-editor",
       "version": "0.1.0",
       "private": true,
       "dependencies": {
@@ -31,12 +31,12 @@
           "@radix-ui/react-toggle-group": "^1.1.2",
           "@radix-ui/react-tooltip": "^1.1.8",
           "class-variance-authority": "^0.7.1",
-          "clsx": "*",
+          "clsx": "^2.1.1",
           "cmdk": "^1.1.1",
           "embla-carousel-react": "^8.6.0",
           "input-otp": "^1.4.2",
           "lucide-react": "^0.487.0",
-          "motion": "*",
+          "motion": "^12.23.12",
           "next-themes": "^0.4.6",
           "react": "^18.3.1",
           "react-day-picker": "^8.10.1",
@@ -45,13 +45,19 @@
           "react-resizable-panels": "^2.1.7",
           "recharts": "^2.15.2",
           "sonner": "^2.0.3",
-          "tailwind-merge": "*",
+          "tailwind-merge": "^3.3.1",
           "vaul": "^1.1.2"
       },
       "devDependencies": {
           "@types/node": "^20.10.0",
+          "@types/react": "^18.3.12",
+          "@types/react-dom": "^18.3.7",
           "@vitejs/plugin-react-swc": "^3.10.2",
-          "vite": "6.3.5"
+          "autoprefixer": "^10.4.21",
+          "postcss": "^8.5.6",
+          "tailwindcss": "^3.4.15",
+          "typescript": "^5.9.2",
+          "vite": "^5.4.10"
       },
       "scripts": {
           "dev": "vite",


### PR DESCRIPTION
## Summary
- rename the RevenuePilot New Frontend package to a valid npm identifier
- pin previously wildcard dependencies and align Vite with a released plugin-compatible version
- add TypeScript and Tailwind build dependencies plus React type packages for the frontend workspace

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8c56dd1d88324b1aba10c5e73f9b0