### PR TITLE
Fix duplicate Vite dependency declaration

### DIFF
--- a/revenuepilot-frontend/package-lock.json
+++ b/revenuepilot-frontend/package-lock.json
@@ -1,0 +1,5171 @@
+{
+      "name": "ai-powered-clinical-note-editor",
+      "version": "0.1.0",
+      "lockfileVersion": 3,
+      "requires": true,
+      "packages": {
+            "": {
+                  "name": "ai-powered-clinical-note-editor",
+                  "version": "0.1.0",
+                  "dependencies": {
+                        "@radix-ui/react-accordion": "^1.2.3",
+                        "@radix-ui/react-alert-dialog": "^1.1.6",
+                        "@radix-ui/react-aspect-ratio": "^1.1.2",
+                        "@radix-ui/react-avatar": "^1.1.3",
+                        "@radix-ui/react-checkbox": "^1.1.4",
+                        "@radix-ui/react-collapsible": "^1.1.3",
+                        "@radix-ui/react-context-menu": "^2.2.6",
+                        "@radix-ui/react-dialog": "^1.1.6",
+                        "@radix-ui/react-dropdown-menu": "^2.1.6",
+                        "@radix-ui/react-hover-card": "^1.1.6",
+                        "@radix-ui/react-label": "^2.1.2",
+                        "@radix-ui/react-menubar": "^1.1.6",
+                        "@radix-ui/react-navigation-menu": "^1.2.5",
+                        "@radix-ui/react-popover": "^1.1.6",
+                        "@radix-ui/react-progress": "^1.1.2",
+                        "@radix-ui/react-radio-group": "^1.2.3",
+                        "@radix-ui/react-scroll-area": "^1.2.3",
+                        "@radix-ui/react-select": "^2.1.6",
+                        "@radix-ui/react-separator": "^1.1.2",
+                        "@radix-ui/react-slider": "^1.2.3",
+                        "@radix-ui/react-slot": "^1.1.2",
+                        "@radix-ui/react-switch": "^1.1.3",
+                        "@radix-ui/react-tabs": "^1.1.3",
+                        "@radix-ui/react-toggle": "^1.1.2",
+                        "@radix-ui/react-toggle-group": "^1.1.2",
+                        "@radix-ui/react-tooltip": "^1.1.8",
+                        "class-variance-authority": "^0.7.1",
+                        "clsx": "^2.1.1",
+                        "cmdk": "^1.1.1",
+                        "embla-carousel-react": "^8.6.0",
+                        "input-otp": "^1.4.2",
+                        "lucide-react": "^0.487.0",
+                        "motion": "^12.23.12",
+                        "next-themes": "^0.4.6",
+                        "react": "^18.3.1",
+                        "react-day-picker": "^8.10.1",
+                        "react-dom": "^18.3.1",
+                        "react-hook-form": "^7.55.0",
+                        "react-resizable-panels": "^2.1.7",
+                        "recharts": "^2.15.2",
+                        "sonner": "^2.0.3",
+                        "tailwind-merge": "^3.3.1",
+                        "vaul": "^1.1.2"
+                  },
+                  "devDependencies": {
+                        "@types/node": "^20.10.0",
+                        "@types/react": "^18.3.12",
+                        "@types/react-dom": "^18.3.7",
+                        "@vitejs/plugin-react-swc": "^3.10.2",
+                        "autoprefixer": "^10.4.21",
+                        "postcss": "^8.5.6",
+                        "tailwindcss": "^3.4.15",
+                        "typescript": "^5.9.2",
+                        "vite": "6.3.5"
+                  }
+            },
+            "node_modules/@alloc/quick-lru": {
+                  "version": "5.2.0",
+                  "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+                  "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=10"
+                  },
+                  "funding": {
+                        "url": "https://github.com/sponsors/sindresorhus"
+                  }
+            },
+            "node_modules/@babel/runtime": {
+                  "version": "7.28.4",
+                  "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+                  "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=6.9.0"
+                  }
+            },
+            "node_modules/@esbuild/aix-ppc64": {
+                  "version": "0.25.9",
+                  "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz",
+                  "integrity": "sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==",
+                  "cpu": [
+                        "ppc64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "aix"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/android-arm": {
+                  "version": "0.25.9",
+                  "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz",
+                  "integrity": "sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==",
+                  "cpu": [
+                        "arm"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "android"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/android-arm64": {
+                  "version": "0.25.9",
+                  "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz",
+                  "integrity": "sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "android"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/android-x64": {
+                  "version": "0.25.9",
+                  "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz",
+                  "integrity": "sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "android"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/darwin-arm64": {
+                  "version": "0.25.9",
+                  "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz",
+                  "integrity": "sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "darwin"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/darwin-x64": {
+                  "version": "0.25.9",
+                  "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz",
+                  "integrity": "sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "darwin"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/freebsd-arm64": {
+                  "version": "0.25.9",
+                  "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz",
+                  "integrity": "sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "freebsd"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/freebsd-x64": {
+                  "version": "0.25.9",
+                  "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz",
+                  "integrity": "sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "freebsd"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/linux-arm": {
+                  "version": "0.25.9",
+                  "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz",
+                  "integrity": "sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==",
+                  "cpu": [
+                        "arm"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/linux-arm64": {
+                  "version": "0.25.9",
+                  "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz",
+                  "integrity": "sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/linux-ia32": {
+                  "version": "0.25.9",
+                  "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz",
+                  "integrity": "sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==",
+                  "cpu": [
+                        "ia32"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/linux-loong64": {
+                  "version": "0.25.9",
+                  "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz",
+                  "integrity": "sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==",
+                  "cpu": [
+                        "loong64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/linux-mips64el": {
+                  "version": "0.25.9",
+                  "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz",
+                  "integrity": "sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==",
+                  "cpu": [
+                        "mips64el"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/linux-ppc64": {
+                  "version": "0.25.9",
+                  "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz",
+                  "integrity": "sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==",
+                  "cpu": [
+                        "ppc64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/linux-riscv64": {
+                  "version": "0.25.9",
+                  "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz",
+                  "integrity": "sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==",
+                  "cpu": [
+                        "riscv64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/linux-s390x": {
+                  "version": "0.25.9",
+                  "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz",
+                  "integrity": "sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==",
+                  "cpu": [
+                        "s390x"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/linux-x64": {
+                  "version": "0.25.9",
+                  "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz",
+                  "integrity": "sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/netbsd-arm64": {
+                  "version": "0.25.9",
+                  "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz",
+                  "integrity": "sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "netbsd"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/netbsd-x64": {
+                  "version": "0.25.9",
+                  "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz",
+                  "integrity": "sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "netbsd"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/openbsd-arm64": {
+                  "version": "0.25.9",
+                  "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz",
+                  "integrity": "sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "openbsd"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/openbsd-x64": {
+                  "version": "0.25.9",
+                  "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz",
+                  "integrity": "sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "openbsd"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/openharmony-arm64": {
+                  "version": "0.25.9",
+                  "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz",
+                  "integrity": "sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "openharmony"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/sunos-x64": {
+                  "version": "0.25.9",
+                  "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz",
+                  "integrity": "sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "sunos"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/win32-arm64": {
+                  "version": "0.25.9",
+                  "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz",
+                  "integrity": "sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "win32"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/win32-ia32": {
+                  "version": "0.25.9",
+                  "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz",
+                  "integrity": "sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==",
+                  "cpu": [
+                        "ia32"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "win32"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@esbuild/win32-x64": {
+                  "version": "0.25.9",
+                  "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz",
+                  "integrity": "sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "win32"
+                  ],
+                  "engines": {
+                        "node": ">=18"
+                  }
+            },
+            "node_modules/@floating-ui/core": {
+                  "version": "1.7.3",
+                  "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+                  "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@floating-ui/utils": "^0.2.10"
+                  }
+            },
+            "node_modules/@floating-ui/dom": {
+                  "version": "1.7.4",
+                  "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+                  "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@floating-ui/core": "^1.7.3",
+                        "@floating-ui/utils": "^0.2.10"
+                  }
+            },
+            "node_modules/@floating-ui/react-dom": {
+                  "version": "2.1.6",
+                  "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
+                  "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@floating-ui/dom": "^1.7.4"
+                  },
+                  "peerDependencies": {
+                        "react": ">=16.8.0",
+                        "react-dom": ">=16.8.0"
+                  }
+            },
+            "node_modules/@floating-ui/utils": {
+                  "version": "0.2.10",
+                  "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+                  "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+                  "license": "MIT"
+            },
+            "node_modules/@isaacs/cliui": {
+                  "version": "8.0.2",
+                  "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+                  "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+                  "dev": true,
+                  "license": "ISC",
+                  "dependencies": {
+                        "string-width": "^5.1.2",
+                        "string-width-cjs": "npm:string-width@^4.2.0",
+                        "strip-ansi": "^7.0.1",
+                        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                        "wrap-ansi": "^8.1.0",
+                        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+                  },
+                  "engines": {
+                        "node": ">=12"
+                  }
+            },
+            "node_modules/@jridgewell/gen-mapping": {
+                  "version": "0.3.13",
+                  "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+                  "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "@jridgewell/sourcemap-codec": "^1.5.0",
+                        "@jridgewell/trace-mapping": "^0.3.24"
+                  }
+            },
+            "node_modules/@jridgewell/resolve-uri": {
+                  "version": "3.1.2",
+                  "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+                  "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=6.0.0"
+                  }
+            },
+            "node_modules/@jridgewell/sourcemap-codec": {
+                  "version": "1.5.5",
+                  "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+                  "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+                  "dev": true,
+                  "license": "MIT"
+            },
+            "node_modules/@jridgewell/trace-mapping": {
+                  "version": "0.3.31",
+                  "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+                  "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "@jridgewell/resolve-uri": "^3.1.0",
+                        "@jridgewell/sourcemap-codec": "^1.4.14"
+                  }
+            },
+            "node_modules/@nodelib/fs.scandir": {
+                  "version": "2.1.5",
+                  "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+                  "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "@nodelib/fs.stat": "2.0.5",
+                        "run-parallel": "^1.1.9"
+                  },
+                  "engines": {
+                        "node": ">= 8"
+                  }
+            },
+            "node_modules/@nodelib/fs.stat": {
+                  "version": "2.0.5",
+                  "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+                  "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">= 8"
+                  }
+            },
+            "node_modules/@nodelib/fs.walk": {
+                  "version": "1.2.8",
+                  "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+                  "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "@nodelib/fs.scandir": "2.1.5",
+                        "fastq": "^1.6.0"
+                  },
+                  "engines": {
+                        "node": ">= 8"
+                  }
+            },
+            "node_modules/@pkgjs/parseargs": {
+                  "version": "0.11.0",
+                  "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+                  "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "engines": {
+                        "node": ">=14"
+                  }
+            },
+            "node_modules/@radix-ui/number": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+                  "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+                  "license": "MIT"
+            },
+            "node_modules/@radix-ui/primitive": {
+                  "version": "1.1.3",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+                  "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+                  "license": "MIT"
+            },
+            "node_modules/@radix-ui/react-accordion": {
+                  "version": "1.2.12",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.12.tgz",
+                  "integrity": "sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-collapsible": "1.1.12",
+                        "@radix-ui/react-collection": "1.1.7",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-direction": "1.1.1",
+                        "@radix-ui/react-id": "1.1.1",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-controllable-state": "1.2.2"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-alert-dialog": {
+                  "version": "1.1.15",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+                  "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-dialog": "1.1.15",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-slot": "1.2.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-arrow": {
+                  "version": "1.1.7",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+                  "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-primitive": "2.1.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-aspect-ratio": {
+                  "version": "1.1.7",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.7.tgz",
+                  "integrity": "sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-primitive": "2.1.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-avatar": {
+                  "version": "1.1.10",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.10.tgz",
+                  "integrity": "sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-callback-ref": "1.1.1",
+                        "@radix-ui/react-use-is-hydrated": "0.1.0",
+                        "@radix-ui/react-use-layout-effect": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-checkbox": {
+                  "version": "1.3.3",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+                  "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-presence": "1.1.5",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-controllable-state": "1.2.2",
+                        "@radix-ui/react-use-previous": "1.1.1",
+                        "@radix-ui/react-use-size": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-collapsible": {
+                  "version": "1.1.12",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
+                  "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-id": "1.1.1",
+                        "@radix-ui/react-presence": "1.1.5",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-controllable-state": "1.2.2",
+                        "@radix-ui/react-use-layout-effect": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-collection": {
+                  "version": "1.1.7",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+                  "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-slot": "1.2.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-compose-refs": {
+                  "version": "1.1.2",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+                  "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+                  "license": "MIT",
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-context": {
+                  "version": "1.1.2",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+                  "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+                  "license": "MIT",
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-context-menu": {
+                  "version": "2.2.16",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.2.16.tgz",
+                  "integrity": "sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-menu": "2.1.16",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-callback-ref": "1.1.1",
+                        "@radix-ui/react-use-controllable-state": "1.2.2"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-dialog": {
+                  "version": "1.1.15",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+                  "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-dismissable-layer": "1.1.11",
+                        "@radix-ui/react-focus-guards": "1.1.3",
+                        "@radix-ui/react-focus-scope": "1.1.7",
+                        "@radix-ui/react-id": "1.1.1",
+                        "@radix-ui/react-portal": "1.1.9",
+                        "@radix-ui/react-presence": "1.1.5",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-slot": "1.2.3",
+                        "@radix-ui/react-use-controllable-state": "1.2.2",
+                        "aria-hidden": "^1.2.4",
+                        "react-remove-scroll": "^2.6.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-direction": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+                  "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+                  "license": "MIT",
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-dismissable-layer": {
+                  "version": "1.1.11",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+                  "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-callback-ref": "1.1.1",
+                        "@radix-ui/react-use-escape-keydown": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-dropdown-menu": {
+                  "version": "2.1.16",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+                  "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-id": "1.1.1",
+                        "@radix-ui/react-menu": "2.1.16",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-controllable-state": "1.2.2"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-focus-guards": {
+                  "version": "1.1.3",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+                  "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+                  "license": "MIT",
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-focus-scope": {
+                  "version": "1.1.7",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+                  "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-callback-ref": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-hover-card": {
+                  "version": "1.1.15",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.15.tgz",
+                  "integrity": "sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-dismissable-layer": "1.1.11",
+                        "@radix-ui/react-popper": "1.2.8",
+                        "@radix-ui/react-portal": "1.1.9",
+                        "@radix-ui/react-presence": "1.1.5",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-controllable-state": "1.2.2"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-id": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+                  "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-use-layout-effect": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-label": {
+                  "version": "2.1.7",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+                  "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-primitive": "2.1.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-menu": {
+                  "version": "2.1.16",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+                  "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-collection": "1.1.7",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-direction": "1.1.1",
+                        "@radix-ui/react-dismissable-layer": "1.1.11",
+                        "@radix-ui/react-focus-guards": "1.1.3",
+                        "@radix-ui/react-focus-scope": "1.1.7",
+                        "@radix-ui/react-id": "1.1.1",
+                        "@radix-ui/react-popper": "1.2.8",
+                        "@radix-ui/react-portal": "1.1.9",
+                        "@radix-ui/react-presence": "1.1.5",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-roving-focus": "1.1.11",
+                        "@radix-ui/react-slot": "1.2.3",
+                        "@radix-ui/react-use-callback-ref": "1.1.1",
+                        "aria-hidden": "^1.2.4",
+                        "react-remove-scroll": "^2.6.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-menubar": {
+                  "version": "1.1.16",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.16.tgz",
+                  "integrity": "sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-collection": "1.1.7",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-direction": "1.1.1",
+                        "@radix-ui/react-id": "1.1.1",
+                        "@radix-ui/react-menu": "2.1.16",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-roving-focus": "1.1.11",
+                        "@radix-ui/react-use-controllable-state": "1.2.2"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-navigation-menu": {
+                  "version": "1.2.14",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.14.tgz",
+                  "integrity": "sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-collection": "1.1.7",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-direction": "1.1.1",
+                        "@radix-ui/react-dismissable-layer": "1.1.11",
+                        "@radix-ui/react-id": "1.1.1",
+                        "@radix-ui/react-presence": "1.1.5",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-callback-ref": "1.1.1",
+                        "@radix-ui/react-use-controllable-state": "1.2.2",
+                        "@radix-ui/react-use-layout-effect": "1.1.1",
+                        "@radix-ui/react-use-previous": "1.1.1",
+                        "@radix-ui/react-visually-hidden": "1.2.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-popover": {
+                  "version": "1.1.15",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+                  "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-dismissable-layer": "1.1.11",
+                        "@radix-ui/react-focus-guards": "1.1.3",
+                        "@radix-ui/react-focus-scope": "1.1.7",
+                        "@radix-ui/react-id": "1.1.1",
+                        "@radix-ui/react-popper": "1.2.8",
+                        "@radix-ui/react-portal": "1.1.9",
+                        "@radix-ui/react-presence": "1.1.5",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-slot": "1.2.3",
+                        "@radix-ui/react-use-controllable-state": "1.2.2",
+                        "aria-hidden": "^1.2.4",
+                        "react-remove-scroll": "^2.6.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-popper": {
+                  "version": "1.2.8",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+                  "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@floating-ui/react-dom": "^2.0.0",
+                        "@radix-ui/react-arrow": "1.1.7",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-callback-ref": "1.1.1",
+                        "@radix-ui/react-use-layout-effect": "1.1.1",
+                        "@radix-ui/react-use-rect": "1.1.1",
+                        "@radix-ui/react-use-size": "1.1.1",
+                        "@radix-ui/rect": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-portal": {
+                  "version": "1.1.9",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+                  "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-layout-effect": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-presence": {
+                  "version": "1.1.5",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+                  "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-use-layout-effect": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-primitive": {
+                  "version": "2.1.3",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+                  "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-slot": "1.2.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-progress": {
+                  "version": "1.1.7",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.7.tgz",
+                  "integrity": "sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-primitive": "2.1.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-radio-group": {
+                  "version": "1.3.8",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
+                  "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-direction": "1.1.1",
+                        "@radix-ui/react-presence": "1.1.5",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-roving-focus": "1.1.11",
+                        "@radix-ui/react-use-controllable-state": "1.2.2",
+                        "@radix-ui/react-use-previous": "1.1.1",
+                        "@radix-ui/react-use-size": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-roving-focus": {
+                  "version": "1.1.11",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+                  "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-collection": "1.1.7",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-direction": "1.1.1",
+                        "@radix-ui/react-id": "1.1.1",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-callback-ref": "1.1.1",
+                        "@radix-ui/react-use-controllable-state": "1.2.2"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-scroll-area": {
+                  "version": "1.2.10",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz",
+                  "integrity": "sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/number": "1.1.1",
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-direction": "1.1.1",
+                        "@radix-ui/react-presence": "1.1.5",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-callback-ref": "1.1.1",
+                        "@radix-ui/react-use-layout-effect": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-select": {
+                  "version": "2.2.6",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+                  "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/number": "1.1.1",
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-collection": "1.1.7",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-direction": "1.1.1",
+                        "@radix-ui/react-dismissable-layer": "1.1.11",
+                        "@radix-ui/react-focus-guards": "1.1.3",
+                        "@radix-ui/react-focus-scope": "1.1.7",
+                        "@radix-ui/react-id": "1.1.1",
+                        "@radix-ui/react-popper": "1.2.8",
+                        "@radix-ui/react-portal": "1.1.9",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-slot": "1.2.3",
+                        "@radix-ui/react-use-callback-ref": "1.1.1",
+                        "@radix-ui/react-use-controllable-state": "1.2.2",
+                        "@radix-ui/react-use-layout-effect": "1.1.1",
+                        "@radix-ui/react-use-previous": "1.1.1",
+                        "@radix-ui/react-visually-hidden": "1.2.3",
+                        "aria-hidden": "^1.2.4",
+                        "react-remove-scroll": "^2.6.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-separator": {
+                  "version": "1.1.7",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
+                  "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-primitive": "2.1.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-slider": {
+                  "version": "1.3.6",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
+                  "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/number": "1.1.1",
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-collection": "1.1.7",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-direction": "1.1.1",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-controllable-state": "1.2.2",
+                        "@radix-ui/react-use-layout-effect": "1.1.1",
+                        "@radix-ui/react-use-previous": "1.1.1",
+                        "@radix-ui/react-use-size": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-slot": {
+                  "version": "1.2.3",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+                  "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-compose-refs": "1.1.2"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-switch": {
+                  "version": "1.2.6",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+                  "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-controllable-state": "1.2.2",
+                        "@radix-ui/react-use-previous": "1.1.1",
+                        "@radix-ui/react-use-size": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-tabs": {
+                  "version": "1.1.13",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+                  "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-direction": "1.1.1",
+                        "@radix-ui/react-id": "1.1.1",
+                        "@radix-ui/react-presence": "1.1.5",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-roving-focus": "1.1.11",
+                        "@radix-ui/react-use-controllable-state": "1.2.2"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-toggle": {
+                  "version": "1.1.10",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
+                  "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-use-controllable-state": "1.2.2"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-toggle-group": {
+                  "version": "1.1.11",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.11.tgz",
+                  "integrity": "sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-direction": "1.1.1",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-roving-focus": "1.1.11",
+                        "@radix-ui/react-toggle": "1.1.10",
+                        "@radix-ui/react-use-controllable-state": "1.2.2"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-tooltip": {
+                  "version": "1.2.8",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+                  "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/primitive": "1.1.3",
+                        "@radix-ui/react-compose-refs": "1.1.2",
+                        "@radix-ui/react-context": "1.1.2",
+                        "@radix-ui/react-dismissable-layer": "1.1.11",
+                        "@radix-ui/react-id": "1.1.1",
+                        "@radix-ui/react-popper": "1.2.8",
+                        "@radix-ui/react-portal": "1.1.9",
+                        "@radix-ui/react-presence": "1.1.5",
+                        "@radix-ui/react-primitive": "2.1.3",
+                        "@radix-ui/react-slot": "1.2.3",
+                        "@radix-ui/react-use-controllable-state": "1.2.2",
+                        "@radix-ui/react-visually-hidden": "1.2.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-use-callback-ref": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+                  "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+                  "license": "MIT",
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-use-controllable-state": {
+                  "version": "1.2.2",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+                  "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-use-effect-event": "0.0.2",
+                        "@radix-ui/react-use-layout-effect": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-use-effect-event": {
+                  "version": "0.0.2",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+                  "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-use-layout-effect": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-use-escape-keydown": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+                  "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-use-callback-ref": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-use-is-hydrated": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.0.tgz",
+                  "integrity": "sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "use-sync-external-store": "^1.5.0"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-use-layout-effect": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+                  "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+                  "license": "MIT",
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-use-previous": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+                  "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+                  "license": "MIT",
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-use-rect": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+                  "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/rect": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-use-size": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+                  "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-use-layout-effect": "1.1.1"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/react-visually-hidden": {
+                  "version": "1.2.3",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+                  "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-primitive": "2.1.3"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "@types/react-dom": "*",
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        },
+                        "@types/react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@radix-ui/rect": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+                  "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+                  "license": "MIT"
+            },
+            "node_modules/@rolldown/pluginutils": {
+                  "version": "1.0.0-beta.27",
+                  "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+                  "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+                  "dev": true,
+                  "license": "MIT"
+            },
+            "node_modules/@rollup/rollup-android-arm-eabi": {
+                  "version": "4.50.2",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.50.2.tgz",
+                  "integrity": "sha512-uLN8NAiFVIRKX9ZQha8wy6UUs06UNSZ32xj6giK/rmMXAgKahwExvK6SsmgU5/brh4w/nSgj8e0k3c1HBQpa0A==",
+                  "cpu": [
+                        "arm"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "android"
+                  ]
+            },
+            "node_modules/@rollup/rollup-android-arm64": {
+                  "version": "4.50.2",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.50.2.tgz",
+                  "integrity": "sha512-oEouqQk2/zxxj22PNcGSskya+3kV0ZKH+nQxuCCOGJ4oTXBdNTbv+f/E3c74cNLeMO1S5wVWacSws10TTSB77g==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "android"
+                  ]
+            },
+            "node_modules/@rollup/rollup-darwin-arm64": {
+                  "version": "4.50.2",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.50.2.tgz",
+                  "integrity": "sha512-OZuTVTpj3CDSIxmPgGH8en/XtirV5nfljHZ3wrNwvgkT5DQLhIKAeuFSiwtbMto6oVexV0k1F1zqURPKf5rI1Q==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "darwin"
+                  ]
+            },
+            "node_modules/@rollup/rollup-darwin-x64": {
+                  "version": "4.50.2",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.50.2.tgz",
+                  "integrity": "sha512-Wa/Wn8RFkIkr1vy1k1PB//VYhLnlnn5eaJkfTQKivirOvzu5uVd2It01ukeQstMursuz7S1bU+8WW+1UPXpa8A==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "darwin"
+                  ]
+            },
+            "node_modules/@rollup/rollup-freebsd-arm64": {
+                  "version": "4.50.2",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.50.2.tgz",
+                  "integrity": "sha512-QkzxvH3kYN9J1w7D1A+yIMdI1pPekD+pWx7G5rXgnIlQ1TVYVC6hLl7SOV9pi5q9uIDF9AuIGkuzcbF7+fAhow==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "freebsd"
+                  ]
+            },
+            "node_modules/@rollup/rollup-freebsd-x64": {
+                  "version": "4.50.2",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.50.2.tgz",
+                  "integrity": "sha512-dkYXB0c2XAS3a3jmyDkX4Jk0m7gWLFzq1C3qUnJJ38AyxIF5G/dyS4N9B30nvFseCfgtCEdbYFhk0ChoCGxPog==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "freebsd"
+                  ]
+            },
+            "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+                  "version": "4.50.2",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.50.2.tgz",
+                  "integrity": "sha512-9VlPY/BN3AgbukfVHAB8zNFWB/lKEuvzRo1NKev0Po8sYFKx0i+AQlCYftgEjcL43F2h9Ui1ZSdVBc4En/sP2w==",
+                  "cpu": [
+                        "arm"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ]
+            },
+            "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+                  "version": "4.50.2",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.50.2.tgz",
+                  "integrity": "sha512-+GdKWOvsifaYNlIVf07QYan1J5F141+vGm5/Y8b9uCZnG/nxoGqgCmR24mv0koIWWuqvFYnbURRqw1lv7IBINw==",
+                  "cpu": [
+                        "arm"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ]
+            },
+            "node_modules/@rollup/rollup-linux-arm64-gnu": {
+                  "version": "4.50.2",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.50.2.tgz",
+                  "integrity": "sha512-df0Eou14ojtUdLQdPFnymEQteENwSJAdLf5KCDrmZNsy1c3YaCNaJvYsEUHnrg+/DLBH612/R0xd3dD03uz2dg==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ]
+            },
+            "node_modules/@rollup/rollup-linux-arm64-musl": {
+                  "version": "4.50.2",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.50.2.tgz",
+                  "integrity": "sha512-iPeouV0UIDtz8j1YFR4OJ/zf7evjauqv7jQ/EFs0ClIyL+by++hiaDAfFipjOgyz6y6xbDvJuiU4HwpVMpRFDQ==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ]
+            },
+            "node_modules/@rollup/rollup-linux-loong64-gnu": {
+                  "version": "4.50.2",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.50.2.tgz",
+                  "integrity": "sha512-OL6KaNvBopLlj5fTa5D5bau4W82f+1TyTZRr2BdnfsrnQnmdxh4okMxR2DcDkJuh4KeoQZVuvHvzuD/lyLn2Kw==",
+                  "cpu": [
+                        "loong64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ]
+            },
+            "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+                  "version": "4.50.2",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.50.2.tgz",
+                  "integrity": "sha512-I21VJl1w6z/K5OTRl6aS9DDsqezEZ/yKpbqlvfHbW0CEF5IL8ATBMuUx6/mp683rKTK8thjs/0BaNrZLXetLag==",
+                  "cpu": [
+                        "ppc64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ]
+            },
+            "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+                  "version": "4.50.2",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.50.2.tgz",
+                  "integrity": "sha512-Hq6aQJT/qFFHrYMjS20nV+9SKrXL2lvFBENZoKfoTH2kKDOJqff5OSJr4x72ZaG/uUn+XmBnGhfr4lwMRrmqCQ==",
+                  "cpu": [
+                        "riscv64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ]
+            },
+            "node_modules/@rollup/rollup-linux-riscv64-musl": {
+                  "version": "4.50.2",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.50.2.tgz",
+                  "integrity": "sha512-82rBSEXRv5qtKyr0xZ/YMF531oj2AIpLZkeNYxmKNN6I2sVE9PGegN99tYDLK2fYHJITL1P2Lgb4ZXnv0PjQvw==",
+                  "cpu": [
+                        "riscv64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ]
+            },
+            "node_modules/@rollup/rollup-linux-s390x-gnu": {
+                  "version": "4.50.2",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.50.2.tgz",
+                  "integrity": "sha512-4Q3S3Hy7pC6uaRo9gtXUTJ+EKo9AKs3BXKc2jYypEcMQ49gDPFU2P1ariX9SEtBzE5egIX6fSUmbmGazwBVF9w==",
+                  "cpu": [
+                        "s390x"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ]
+            },
+            "node_modules/@rollup/rollup-linux-x64-gnu": {
+                  "version": "4.50.2",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.50.2.tgz",
+                  "integrity": "sha512-9Jie/At6qk70dNIcopcL4p+1UirusEtznpNtcq/u/C5cC4HBX7qSGsYIcG6bdxj15EYWhHiu02YvmdPzylIZlA==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ]
+            },
+            "node_modules/@rollup/rollup-linux-x64-musl": {
+                  "version": "4.50.2",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.50.2.tgz",
+                  "integrity": "sha512-HPNJwxPL3EmhzeAnsWQCM3DcoqOz3/IC6de9rWfGR8ZCuEHETi9km66bH/wG3YH0V3nyzyFEGUZeL5PKyy4xvw==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ]
+            },
+            "node_modules/@rollup/rollup-openharmony-arm64": {
+                  "version": "4.50.2",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.50.2.tgz",
+                  "integrity": "sha512-nMKvq6FRHSzYfKLHZ+cChowlEkR2lj/V0jYj9JnGUVPL2/mIeFGmVM2mLaFeNa5Jev7W7TovXqXIG2d39y1KYA==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "openharmony"
+                  ]
+            },
+            "node_modules/@rollup/rollup-win32-arm64-msvc": {
+                  "version": "4.50.2",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.50.2.tgz",
+                  "integrity": "sha512-eFUvvnTYEKeTyHEijQKz81bLrUQOXKZqECeiWH6tb8eXXbZk+CXSG2aFrig2BQ/pjiVRj36zysjgILkqarS2YA==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "win32"
+                  ]
+            },
+            "node_modules/@rollup/rollup-win32-ia32-msvc": {
+                  "version": "4.50.2",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.50.2.tgz",
+                  "integrity": "sha512-cBaWmXqyfRhH8zmUxK3d3sAhEWLrtMjWBRwdMMHJIXSjvjLKvv49adxiEz+FJ8AP90apSDDBx2Tyd/WylV6ikA==",
+                  "cpu": [
+                        "ia32"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "win32"
+                  ]
+            },
+            "node_modules/@rollup/rollup-win32-x64-msvc": {
+                  "version": "4.50.2",
+                  "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.50.2.tgz",
+                  "integrity": "sha512-APwKy6YUhvZaEoHyM+9xqmTpviEI+9eL7LoCH+aLcvWYHJ663qG5zx7WzWZY+a9qkg5JtzcMyJ9z0WtQBMDmgA==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "win32"
+                  ]
+            },
+            "node_modules/@swc/core": {
+                  "version": "1.13.5",
+                  "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.13.5.tgz",
+                  "integrity": "sha512-WezcBo8a0Dg2rnR82zhwoR6aRNxeTGfK5QCD6TQ+kg3xx/zNT02s/0o+81h/3zhvFSB24NtqEr8FTw88O5W/JQ==",
+                  "dev": true,
+                  "hasInstallScript": true,
+                  "license": "Apache-2.0",
+                  "dependencies": {
+                        "@swc/counter": "^0.1.3",
+                        "@swc/types": "^0.1.24"
+                  },
+                  "engines": {
+                        "node": ">=10"
+                  },
+                  "funding": {
+                        "type": "opencollective",
+                        "url": "https://opencollective.com/swc"
+                  },
+                  "optionalDependencies": {
+                        "@swc/core-darwin-arm64": "1.13.5",
+                        "@swc/core-darwin-x64": "1.13.5",
+                        "@swc/core-linux-arm-gnueabihf": "1.13.5",
+                        "@swc/core-linux-arm64-gnu": "1.13.5",
+                        "@swc/core-linux-arm64-musl": "1.13.5",
+                        "@swc/core-linux-x64-gnu": "1.13.5",
+                        "@swc/core-linux-x64-musl": "1.13.5",
+                        "@swc/core-win32-arm64-msvc": "1.13.5",
+                        "@swc/core-win32-ia32-msvc": "1.13.5",
+                        "@swc/core-win32-x64-msvc": "1.13.5"
+                  },
+                  "peerDependencies": {
+                        "@swc/helpers": ">=0.5.17"
+                  },
+                  "peerDependenciesMeta": {
+                        "@swc/helpers": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/@swc/core-darwin-arm64": {
+                  "version": "1.13.5",
+                  "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.13.5.tgz",
+                  "integrity": "sha512-lKNv7SujeXvKn16gvQqUQI5DdyY8v7xcoO3k06/FJbHJS90zEwZdQiMNRiqpYw/orU543tPaWgz7cIYWhbopiQ==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "Apache-2.0 AND MIT",
+                  "optional": true,
+                  "os": [
+                        "darwin"
+                  ],
+                  "engines": {
+                        "node": ">=10"
+                  }
+            },
+            "node_modules/@swc/core-darwin-x64": {
+                  "version": "1.13.5",
+                  "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.13.5.tgz",
+                  "integrity": "sha512-ILd38Fg/w23vHb0yVjlWvQBoE37ZJTdlLHa8LRCFDdX4WKfnVBiblsCU9ar4QTMNdeTBEX9iUF4IrbNWhaF1Ng==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "Apache-2.0 AND MIT",
+                  "optional": true,
+                  "os": [
+                        "darwin"
+                  ],
+                  "engines": {
+                        "node": ">=10"
+                  }
+            },
+            "node_modules/@swc/core-linux-arm-gnueabihf": {
+                  "version": "1.13.5",
+                  "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.13.5.tgz",
+                  "integrity": "sha512-Q6eS3Pt8GLkXxqz9TAw+AUk9HpVJt8Uzm54MvPsqp2yuGmY0/sNaPPNVqctCX9fu/Nu8eaWUen0si6iEiCsazQ==",
+                  "cpu": [
+                        "arm"
+                  ],
+                  "dev": true,
+                  "license": "Apache-2.0",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=10"
+                  }
+            },
+            "node_modules/@swc/core-linux-arm64-gnu": {
+                  "version": "1.13.5",
+                  "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.13.5.tgz",
+                  "integrity": "sha512-aNDfeN+9af+y+M2MYfxCzCy/VDq7Z5YIbMqRI739o8Ganz6ST+27kjQFd8Y/57JN/hcnUEa9xqdS3XY7WaVtSw==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "Apache-2.0 AND MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=10"
+                  }
+            },
+            "node_modules/@swc/core-linux-arm64-musl": {
+                  "version": "1.13.5",
+                  "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.13.5.tgz",
+                  "integrity": "sha512-9+ZxFN5GJag4CnYnq6apKTnnezpfJhCumyz0504/JbHLo+Ue+ZtJnf3RhyA9W9TINtLE0bC4hKpWi8ZKoETyOQ==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "Apache-2.0 AND MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=10"
+                  }
+            },
+            "node_modules/@swc/core-linux-x64-gnu": {
+                  "version": "1.13.5",
+                  "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.13.5.tgz",
+                  "integrity": "sha512-WD530qvHrki8Ywt/PloKUjaRKgstQqNGvmZl54g06kA+hqtSE2FTG9gngXr3UJxYu/cNAjJYiBifm7+w4nbHbA==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "Apache-2.0 AND MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=10"
+                  }
+            },
+            "node_modules/@swc/core-linux-x64-musl": {
+                  "version": "1.13.5",
+                  "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.13.5.tgz",
+                  "integrity": "sha512-Luj8y4OFYx4DHNQTWjdIuKTq2f5k6uSXICqx+FSabnXptaOBAbJHNbHT/06JZh6NRUouaf0mYXN0mcsqvkhd7Q==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "Apache-2.0 AND MIT",
+                  "optional": true,
+                  "os": [
+                        "linux"
+                  ],
+                  "engines": {
+                        "node": ">=10"
+                  }
+            },
+            "node_modules/@swc/core-win32-arm64-msvc": {
+                  "version": "1.13.5",
+                  "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.13.5.tgz",
+                  "integrity": "sha512-cZ6UpumhF9SDJvv4DA2fo9WIzlNFuKSkZpZmPG1c+4PFSEMy5DFOjBSllCvnqihCabzXzpn6ykCwBmHpy31vQw==",
+                  "cpu": [
+                        "arm64"
+                  ],
+                  "dev": true,
+                  "license": "Apache-2.0 AND MIT",
+                  "optional": true,
+                  "os": [
+                        "win32"
+                  ],
+                  "engines": {
+                        "node": ">=10"
+                  }
+            },
+            "node_modules/@swc/core-win32-ia32-msvc": {
+                  "version": "1.13.5",
+                  "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.13.5.tgz",
+                  "integrity": "sha512-C5Yi/xIikrFUzZcyGj9L3RpKljFvKiDMtyDzPKzlsDrKIw2EYY+bF88gB6oGY5RGmv4DAX8dbnpRAqgFD0FMEw==",
+                  "cpu": [
+                        "ia32"
+                  ],
+                  "dev": true,
+                  "license": "Apache-2.0 AND MIT",
+                  "optional": true,
+                  "os": [
+                        "win32"
+                  ],
+                  "engines": {
+                        "node": ">=10"
+                  }
+            },
+            "node_modules/@swc/core-win32-x64-msvc": {
+                  "version": "1.13.5",
+                  "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.13.5.tgz",
+                  "integrity": "sha512-YrKdMVxbYmlfybCSbRtrilc6UA8GF5aPmGKBdPvjrarvsmf4i7ZHGCEnLtfOMd3Lwbs2WUZq3WdMbozYeLU93Q==",
+                  "cpu": [
+                        "x64"
+                  ],
+                  "dev": true,
+                  "license": "Apache-2.0 AND MIT",
+                  "optional": true,
+                  "os": [
+                        "win32"
+                  ],
+                  "engines": {
+                        "node": ">=10"
+                  }
+            },
+            "node_modules/@swc/counter": {
+                  "version": "0.1.3",
+                  "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+                  "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+                  "dev": true,
+                  "license": "Apache-2.0"
+            },
+            "node_modules/@swc/types": {
+                  "version": "0.1.25",
+                  "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
+                  "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
+                  "dev": true,
+                  "license": "Apache-2.0",
+                  "dependencies": {
+                        "@swc/counter": "^0.1.3"
+                  }
+            },
+            "node_modules/@types/d3-array": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+                  "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+                  "license": "MIT"
+            },
+            "node_modules/@types/d3-color": {
+                  "version": "3.1.3",
+                  "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+                  "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+                  "license": "MIT"
+            },
+            "node_modules/@types/d3-ease": {
+                  "version": "3.0.2",
+                  "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+                  "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+                  "license": "MIT"
+            },
+            "node_modules/@types/d3-interpolate": {
+                  "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+                  "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@types/d3-color": "*"
+                  }
+            },
+            "node_modules/@types/d3-path": {
+                  "version": "3.1.1",
+                  "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+                  "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+                  "license": "MIT"
+            },
+            "node_modules/@types/d3-scale": {
+                  "version": "4.0.9",
+                  "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+                  "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@types/d3-time": "*"
+                  }
+            },
+            "node_modules/@types/d3-shape": {
+                  "version": "3.1.7",
+                  "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+                  "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@types/d3-path": "*"
+                  }
+            },
+            "node_modules/@types/d3-time": {
+                  "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+                  "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+                  "license": "MIT"
+            },
+            "node_modules/@types/d3-timer": {
+                  "version": "3.0.2",
+                  "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+                  "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+                  "license": "MIT"
+            },
+            "node_modules/@types/estree": {
+                  "version": "1.0.8",
+                  "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+                  "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+                  "dev": true,
+                  "license": "MIT"
+            },
+            "node_modules/@types/node": {
+                  "version": "20.19.15",
+                  "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.15.tgz",
+                  "integrity": "sha512-W3bqcbLsRdFDVcmAM5l6oLlcl67vjevn8j1FPZ4nx+K5jNoWCh+FC/btxFoBPnvQlrHHDwfjp1kjIEDfwJ0Mog==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "undici-types": "~6.21.0"
+                  }
+            },
+            "node_modules/@types/prop-types": {
+                  "version": "15.7.15",
+                  "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+                  "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+                  "devOptional": true,
+                  "license": "MIT"
+            },
+            "node_modules/@types/react": {
+                  "version": "18.3.24",
+                  "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
+                  "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
+                  "devOptional": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "@types/prop-types": "*",
+                        "csstype": "^3.0.2"
+                  }
+            },
+            "node_modules/@types/react-dom": {
+                  "version": "18.3.7",
+                  "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+                  "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+                  "devOptional": true,
+                  "license": "MIT",
+                  "peerDependencies": {
+                        "@types/react": "^18.0.0"
+                  }
+            },
+            "node_modules/@vitejs/plugin-react-swc": {
+                  "version": "3.11.0",
+                  "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.11.0.tgz",
+                  "integrity": "sha512-YTJCGFdNMHCMfjODYtxRNVAYmTWQ1Lb8PulP/2/f/oEEtglw8oKxKIZmmRkyXrVrHfsKOaVkAc3NT9/dMutO5w==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "@rolldown/pluginutils": "1.0.0-beta.27",
+                        "@swc/core": "^1.12.11"
+                  },
+                  "peerDependencies": {
+                        "vite": "^4 || ^5 || ^6 || ^7"
+                  }
+            },
+            "node_modules/ansi-regex": {
+                  "version": "6.2.2",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+                  "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=12"
+                  },
+                  "funding": {
+                        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+                  }
+            },
+            "node_modules/ansi-styles": {
+                  "version": "6.2.3",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+                  "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=12"
+                  },
+                  "funding": {
+                        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+                  }
+            },
+            "node_modules/any-promise": {
+                  "version": "1.3.0",
+                  "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+                  "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+                  "dev": true,
+                  "license": "MIT"
+            },
+            "node_modules/anymatch": {
+                  "version": "3.1.3",
+                  "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+                  "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+                  "dev": true,
+                  "license": "ISC",
+                  "dependencies": {
+                        "normalize-path": "^3.0.0",
+                        "picomatch": "^2.0.4"
+                  },
+                  "engines": {
+                        "node": ">= 8"
+                  }
+            },
+            "node_modules/arg": {
+                  "version": "5.0.2",
+                  "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+                  "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+                  "dev": true,
+                  "license": "MIT"
+            },
+            "node_modules/aria-hidden": {
+                  "version": "1.2.6",
+                  "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+                  "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "tslib": "^2.0.0"
+                  },
+                  "engines": {
+                        "node": ">=10"
+                  }
+            },
+            "node_modules/autoprefixer": {
+                  "version": "10.4.21",
+                  "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
+                  "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
+                  "dev": true,
+                  "funding": [
+                        {
+                              "type": "opencollective",
+                              "url": "https://opencollective.com/postcss/"
+                        },
+                        {
+                              "type": "tidelift",
+                              "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+                        },
+                        {
+                              "type": "github",
+                              "url": "https://github.com/sponsors/ai"
+                        }
+                  ],
+                  "license": "MIT",
+                  "dependencies": {
+                        "browserslist": "^4.24.4",
+                        "caniuse-lite": "^1.0.30001702",
+                        "fraction.js": "^4.3.7",
+                        "normalize-range": "^0.1.2",
+                        "picocolors": "^1.1.1",
+                        "postcss-value-parser": "^4.2.0"
+                  },
+                  "bin": {
+                        "autoprefixer": "bin/autoprefixer"
+                  },
+                  "engines": {
+                        "node": "^10 || ^12 || >=14"
+                  },
+                  "peerDependencies": {
+                        "postcss": "^8.1.0"
+                  }
+            },
+            "node_modules/balanced-match": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+                  "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+                  "dev": true,
+                  "license": "MIT"
+            },
+            "node_modules/baseline-browser-mapping": {
+                  "version": "2.8.4",
+                  "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.4.tgz",
+                  "integrity": "sha512-L+YvJwGAgwJBV1p6ffpSTa2KRc69EeeYGYjRVWKs0GKrK+LON0GC0gV+rKSNtALEDvMDqkvCFq9r1r94/Gjwxw==",
+                  "dev": true,
+                  "license": "Apache-2.0",
+                  "bin": {
+                        "baseline-browser-mapping": "dist/cli.js"
+                  }
+            },
+            "node_modules/binary-extensions": {
+                  "version": "2.3.0",
+                  "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+                  "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=8"
+                  },
+                  "funding": {
+                        "url": "https://github.com/sponsors/sindresorhus"
+                  }
+            },
+            "node_modules/brace-expansion": {
+                  "version": "2.0.2",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+                  "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "balanced-match": "^1.0.0"
+                  }
+            },
+            "node_modules/braces": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+                  "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "fill-range": "^7.1.1"
+                  },
+                  "engines": {
+                        "node": ">=8"
+                  }
+            },
+            "node_modules/browserslist": {
+                  "version": "4.26.0",
+                  "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.0.tgz",
+                  "integrity": "sha512-P9go2WrP9FiPwLv3zqRD/Uoxo0RSHjzFCiQz7d4vbmwNqQFo9T9WCeP/Qn5EbcKQY6DBbkxEXNcpJOmncNrb7A==",
+                  "dev": true,
+                  "funding": [
+                        {
+                              "type": "opencollective",
+                              "url": "https://opencollective.com/browserslist"
+                        },
+                        {
+                              "type": "tidelift",
+                              "url": "https://tidelift.com/funding/github/npm/browserslist"
+                        },
+                        {
+                              "type": "github",
+                              "url": "https://github.com/sponsors/ai"
+                        }
+                  ],
+                  "license": "MIT",
+                  "dependencies": {
+                        "baseline-browser-mapping": "^2.8.2",
+                        "caniuse-lite": "^1.0.30001741",
+                        "electron-to-chromium": "^1.5.218",
+                        "node-releases": "^2.0.21",
+                        "update-browserslist-db": "^1.1.3"
+                  },
+                  "bin": {
+                        "browserslist": "cli.js"
+                  },
+                  "engines": {
+                        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+                  }
+            },
+            "node_modules/camelcase-css": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+                  "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">= 6"
+                  }
+            },
+            "node_modules/caniuse-lite": {
+                  "version": "1.0.30001741",
+                  "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001741.tgz",
+                  "integrity": "sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==",
+                  "dev": true,
+                  "funding": [
+                        {
+                              "type": "opencollective",
+                              "url": "https://opencollective.com/browserslist"
+                        },
+                        {
+                              "type": "tidelift",
+                              "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                        },
+                        {
+                              "type": "github",
+                              "url": "https://github.com/sponsors/ai"
+                        }
+                  ],
+                  "license": "CC-BY-4.0"
+            },
+            "node_modules/chokidar": {
+                  "version": "3.6.0",
+                  "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+                  "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "anymatch": "~3.1.2",
+                        "braces": "~3.0.2",
+                        "glob-parent": "~5.1.2",
+                        "is-binary-path": "~2.1.0",
+                        "is-glob": "~4.0.1",
+                        "normalize-path": "~3.0.0",
+                        "readdirp": "~3.6.0"
+                  },
+                  "engines": {
+                        "node": ">= 8.10.0"
+                  },
+                  "funding": {
+                        "url": "https://paulmillr.com/funding/"
+                  },
+                  "optionalDependencies": {
+                        "fsevents": "~2.3.2"
+                  }
+            },
+            "node_modules/chokidar/node_modules/glob-parent": {
+                  "version": "5.1.2",
+                  "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+                  "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+                  "dev": true,
+                  "license": "ISC",
+                  "dependencies": {
+                        "is-glob": "^4.0.1"
+                  },
+                  "engines": {
+                        "node": ">= 6"
+                  }
+            },
+            "node_modules/class-variance-authority": {
+                  "version": "0.7.1",
+                  "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+                  "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+                  "license": "Apache-2.0",
+                  "dependencies": {
+                        "clsx": "^2.1.1"
+                  },
+                  "funding": {
+                        "url": "https://polar.sh/cva"
+                  }
+            },
+            "node_modules/clsx": {
+                  "version": "2.1.1",
+                  "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+                  "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=6"
+                  }
+            },
+            "node_modules/cmdk": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+                  "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-compose-refs": "^1.1.1",
+                        "@radix-ui/react-dialog": "^1.1.6",
+                        "@radix-ui/react-id": "^1.1.0",
+                        "@radix-ui/react-primitive": "^2.0.2"
+                  },
+                  "peerDependencies": {
+                        "react": "^18 || ^19 || ^19.0.0-rc",
+                        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+                  }
+            },
+            "node_modules/color-convert": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                  "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "color-name": "~1.1.4"
+                  },
+                  "engines": {
+                        "node": ">=7.0.0"
+                  }
+            },
+            "node_modules/color-name": {
+                  "version": "1.1.4",
+                  "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                  "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                  "dev": true,
+                  "license": "MIT"
+            },
+            "node_modules/commander": {
+                  "version": "4.1.1",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+                  "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">= 6"
+                  }
+            },
+            "node_modules/cross-spawn": {
+                  "version": "7.0.6",
+                  "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+                  "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "path-key": "^3.1.0",
+                        "shebang-command": "^2.0.0",
+                        "which": "^2.0.1"
+                  },
+                  "engines": {
+                        "node": ">= 8"
+                  }
+            },
+            "node_modules/cssesc": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+                  "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+                  "dev": true,
+                  "license": "MIT",
+                  "bin": {
+                        "cssesc": "bin/cssesc"
+                  },
+                  "engines": {
+                        "node": ">=4"
+                  }
+            },
+            "node_modules/csstype": {
+                  "version": "3.1.3",
+                  "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+                  "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+                  "license": "MIT"
+            },
+            "node_modules/d3-array": {
+                  "version": "3.2.4",
+                  "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+                  "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+                  "license": "ISC",
+                  "dependencies": {
+                        "internmap": "1 - 2"
+                  },
+                  "engines": {
+                        "node": ">=12"
+                  }
+            },
+            "node_modules/d3-color": {
+                  "version": "3.1.0",
+                  "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+                  "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+                  "license": "ISC",
+                  "engines": {
+                        "node": ">=12"
+                  }
+            },
+            "node_modules/d3-ease": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+                  "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+                  "license": "BSD-3-Clause",
+                  "engines": {
+                        "node": ">=12"
+                  }
+            },
+            "node_modules/d3-format": {
+                  "version": "3.1.0",
+                  "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+                  "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+                  "license": "ISC",
+                  "engines": {
+                        "node": ">=12"
+                  }
+            },
+            "node_modules/d3-interpolate": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+                  "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+                  "license": "ISC",
+                  "dependencies": {
+                        "d3-color": "1 - 3"
+                  },
+                  "engines": {
+                        "node": ">=12"
+                  }
+            },
+            "node_modules/d3-path": {
+                  "version": "3.1.0",
+                  "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+                  "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+                  "license": "ISC",
+                  "engines": {
+                        "node": ">=12"
+                  }
+            },
+            "node_modules/d3-scale": {
+                  "version": "4.0.2",
+                  "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+                  "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+                  "license": "ISC",
+                  "dependencies": {
+                        "d3-array": "2.10.0 - 3",
+                        "d3-format": "1 - 3",
+                        "d3-interpolate": "1.2.0 - 3",
+                        "d3-time": "2.1.1 - 3",
+                        "d3-time-format": "2 - 4"
+                  },
+                  "engines": {
+                        "node": ">=12"
+                  }
+            },
+            "node_modules/d3-shape": {
+                  "version": "3.2.0",
+                  "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+                  "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+                  "license": "ISC",
+                  "dependencies": {
+                        "d3-path": "^3.1.0"
+                  },
+                  "engines": {
+                        "node": ">=12"
+                  }
+            },
+            "node_modules/d3-time": {
+                  "version": "3.1.0",
+                  "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+                  "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+                  "license": "ISC",
+                  "dependencies": {
+                        "d3-array": "2 - 3"
+                  },
+                  "engines": {
+                        "node": ">=12"
+                  }
+            },
+            "node_modules/d3-time-format": {
+                  "version": "4.1.0",
+                  "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+                  "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+                  "license": "ISC",
+                  "dependencies": {
+                        "d3-time": "1 - 3"
+                  },
+                  "engines": {
+                        "node": ">=12"
+                  }
+            },
+            "node_modules/d3-timer": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+                  "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+                  "license": "ISC",
+                  "engines": {
+                        "node": ">=12"
+                  }
+            },
+            "node_modules/date-fns": {
+                  "version": "3.6.0",
+                  "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+                  "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+                  "license": "MIT",
+                  "peer": true,
+                  "funding": {
+                        "type": "github",
+                        "url": "https://github.com/sponsors/kossnocorp"
+                  }
+            },
+            "node_modules/decimal.js-light": {
+                  "version": "2.5.1",
+                  "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+                  "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+                  "license": "MIT"
+            },
+            "node_modules/detect-node-es": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+                  "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+                  "license": "MIT"
+            },
+            "node_modules/didyoumean": {
+                  "version": "1.2.2",
+                  "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+                  "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+                  "dev": true,
+                  "license": "Apache-2.0"
+            },
+            "node_modules/dlv": {
+                  "version": "1.1.3",
+                  "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+                  "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+                  "dev": true,
+                  "license": "MIT"
+            },
+            "node_modules/dom-helpers": {
+                  "version": "5.2.1",
+                  "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+                  "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@babel/runtime": "^7.8.7",
+                        "csstype": "^3.0.2"
+                  }
+            },
+            "node_modules/eastasianwidth": {
+                  "version": "0.2.0",
+                  "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+                  "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+                  "dev": true,
+                  "license": "MIT"
+            },
+            "node_modules/electron-to-chromium": {
+                  "version": "1.5.218",
+                  "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.218.tgz",
+                  "integrity": "sha512-uwwdN0TUHs8u6iRgN8vKeWZMRll4gBkz+QMqdS7DDe49uiK68/UX92lFb61oiFPrpYZNeZIqa4bA7O6Aiasnzg==",
+                  "dev": true,
+                  "license": "ISC"
+            },
+            "node_modules/embla-carousel": {
+                  "version": "8.6.0",
+                  "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+                  "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+                  "license": "MIT"
+            },
+            "node_modules/embla-carousel-react": {
+                  "version": "8.6.0",
+                  "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.6.0.tgz",
+                  "integrity": "sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "embla-carousel": "8.6.0",
+                        "embla-carousel-reactive-utils": "8.6.0"
+                  },
+                  "peerDependencies": {
+                        "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+                  }
+            },
+            "node_modules/embla-carousel-reactive-utils": {
+                  "version": "8.6.0",
+                  "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.6.0.tgz",
+                  "integrity": "sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==",
+                  "license": "MIT",
+                  "peerDependencies": {
+                        "embla-carousel": "8.6.0"
+                  }
+            },
+            "node_modules/emoji-regex": {
+                  "version": "9.2.2",
+                  "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+                  "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+                  "dev": true,
+                  "license": "MIT"
+            },
+            "node_modules/esbuild": {
+                  "version": "0.25.9",
+                  "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
+                  "integrity": "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==",
+                  "dev": true,
+                  "hasInstallScript": true,
+                  "license": "MIT",
+                  "bin": {
+                        "esbuild": "bin/esbuild"
+                  },
+                  "engines": {
+                        "node": ">=18"
+                  },
+                  "optionalDependencies": {
+                        "@esbuild/aix-ppc64": "0.25.9",
+                        "@esbuild/android-arm": "0.25.9",
+                        "@esbuild/android-arm64": "0.25.9",
+                        "@esbuild/android-x64": "0.25.9",
+                        "@esbuild/darwin-arm64": "0.25.9",
+                        "@esbuild/darwin-x64": "0.25.9",
+                        "@esbuild/freebsd-arm64": "0.25.9",
+                        "@esbuild/freebsd-x64": "0.25.9",
+                        "@esbuild/linux-arm": "0.25.9",
+                        "@esbuild/linux-arm64": "0.25.9",
+                        "@esbuild/linux-ia32": "0.25.9",
+                        "@esbuild/linux-loong64": "0.25.9",
+                        "@esbuild/linux-mips64el": "0.25.9",
+                        "@esbuild/linux-ppc64": "0.25.9",
+                        "@esbuild/linux-riscv64": "0.25.9",
+                        "@esbuild/linux-s390x": "0.25.9",
+                        "@esbuild/linux-x64": "0.25.9",
+                        "@esbuild/netbsd-arm64": "0.25.9",
+                        "@esbuild/netbsd-x64": "0.25.9",
+                        "@esbuild/openbsd-arm64": "0.25.9",
+                        "@esbuild/openbsd-x64": "0.25.9",
+                        "@esbuild/openharmony-arm64": "0.25.9",
+                        "@esbuild/sunos-x64": "0.25.9",
+                        "@esbuild/win32-arm64": "0.25.9",
+                        "@esbuild/win32-ia32": "0.25.9",
+                        "@esbuild/win32-x64": "0.25.9"
+                  }
+            },
+            "node_modules/escalade": {
+                  "version": "3.2.0",
+                  "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+                  "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=6"
+                  }
+            },
+            "node_modules/eventemitter3": {
+                  "version": "4.0.7",
+                  "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+                  "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+                  "license": "MIT"
+            },
+            "node_modules/fast-equals": {
+                  "version": "5.2.2",
+                  "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
+                  "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=6.0.0"
+                  }
+            },
+            "node_modules/fast-glob": {
+                  "version": "3.3.3",
+                  "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+                  "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "@nodelib/fs.stat": "^2.0.2",
+                        "@nodelib/fs.walk": "^1.2.3",
+                        "glob-parent": "^5.1.2",
+                        "merge2": "^1.3.0",
+                        "micromatch": "^4.0.8"
+                  },
+                  "engines": {
+                        "node": ">=8.6.0"
+                  }
+            },
+            "node_modules/fast-glob/node_modules/glob-parent": {
+                  "version": "5.1.2",
+                  "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+                  "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+                  "dev": true,
+                  "license": "ISC",
+                  "dependencies": {
+                        "is-glob": "^4.0.1"
+                  },
+                  "engines": {
+                        "node": ">= 6"
+                  }
+            },
+            "node_modules/fastq": {
+                  "version": "1.19.1",
+                  "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+                  "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+                  "dev": true,
+                  "license": "ISC",
+                  "dependencies": {
+                        "reusify": "^1.0.4"
+                  }
+            },
+            "node_modules/fill-range": {
+                  "version": "7.1.1",
+                  "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+                  "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "to-regex-range": "^5.0.1"
+                  },
+                  "engines": {
+                        "node": ">=8"
+                  }
+            },
+            "node_modules/foreground-child": {
+                  "version": "3.3.1",
+                  "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+                  "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+                  "dev": true,
+                  "license": "ISC",
+                  "dependencies": {
+                        "cross-spawn": "^7.0.6",
+                        "signal-exit": "^4.0.1"
+                  },
+                  "engines": {
+                        "node": ">=14"
+                  },
+                  "funding": {
+                        "url": "https://github.com/sponsors/isaacs"
+                  }
+            },
+            "node_modules/fraction.js": {
+                  "version": "4.3.7",
+                  "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+                  "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": "*"
+                  },
+                  "funding": {
+                        "type": "patreon",
+                        "url": "https://github.com/sponsors/rawify"
+                  }
+            },
+            "node_modules/framer-motion": {
+                  "version": "12.23.12",
+                  "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.12.tgz",
+                  "integrity": "sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "motion-dom": "^12.23.12",
+                        "motion-utils": "^12.23.6",
+                        "tslib": "^2.4.0"
+                  },
+                  "peerDependencies": {
+                        "@emotion/is-prop-valid": "*",
+                        "react": "^18.0.0 || ^19.0.0",
+                        "react-dom": "^18.0.0 || ^19.0.0"
+                  },
+                  "peerDependenciesMeta": {
+                        "@emotion/is-prop-valid": {
+                              "optional": true
+                        },
+                        "react": {
+                              "optional": true
+                        },
+                        "react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/fsevents": {
+                  "version": "2.3.3",
+                  "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+                  "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+                  "dev": true,
+                  "hasInstallScript": true,
+                  "license": "MIT",
+                  "optional": true,
+                  "os": [
+                        "darwin"
+                  ],
+                  "engines": {
+                        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+                  }
+            },
+            "node_modules/function-bind": {
+                  "version": "1.1.2",
+                  "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+                  "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+                  "dev": true,
+                  "license": "MIT",
+                  "funding": {
+                        "url": "https://github.com/sponsors/ljharb"
+                  }
+            },
+            "node_modules/get-nonce": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+                  "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=6"
+                  }
+            },
+            "node_modules/glob": {
+                  "version": "10.4.5",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+                  "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+                  "dev": true,
+                  "license": "ISC",
+                  "dependencies": {
+                        "foreground-child": "^3.1.0",
+                        "jackspeak": "^3.1.2",
+                        "minimatch": "^9.0.4",
+                        "minipass": "^7.1.2",
+                        "package-json-from-dist": "^1.0.0",
+                        "path-scurry": "^1.11.1"
+                  },
+                  "bin": {
+                        "glob": "dist/esm/bin.mjs"
+                  },
+                  "funding": {
+                        "url": "https://github.com/sponsors/isaacs"
+                  }
+            },
+            "node_modules/glob-parent": {
+                  "version": "6.0.2",
+                  "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+                  "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+                  "dev": true,
+                  "license": "ISC",
+                  "dependencies": {
+                        "is-glob": "^4.0.3"
+                  },
+                  "engines": {
+                        "node": ">=10.13.0"
+                  }
+            },
+            "node_modules/hasown": {
+                  "version": "2.0.2",
+                  "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+                  "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "function-bind": "^1.1.2"
+                  },
+                  "engines": {
+                        "node": ">= 0.4"
+                  }
+            },
+            "node_modules/input-otp": {
+                  "version": "1.4.2",
+                  "resolved": "https://registry.npmjs.org/input-otp/-/input-otp-1.4.2.tgz",
+                  "integrity": "sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==",
+                  "license": "MIT",
+                  "peerDependencies": {
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
+                  }
+            },
+            "node_modules/internmap": {
+                  "version": "2.0.3",
+                  "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+                  "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+                  "license": "ISC",
+                  "engines": {
+                        "node": ">=12"
+                  }
+            },
+            "node_modules/is-binary-path": {
+                  "version": "2.1.0",
+                  "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+                  "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "binary-extensions": "^2.0.0"
+                  },
+                  "engines": {
+                        "node": ">=8"
+                  }
+            },
+            "node_modules/is-core-module": {
+                  "version": "2.16.1",
+                  "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+                  "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "hasown": "^2.0.2"
+                  },
+                  "engines": {
+                        "node": ">= 0.4"
+                  },
+                  "funding": {
+                        "url": "https://github.com/sponsors/ljharb"
+                  }
+            },
+            "node_modules/is-extglob": {
+                  "version": "2.1.1",
+                  "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+                  "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=0.10.0"
+                  }
+            },
+            "node_modules/is-fullwidth-code-point": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                  "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=8"
+                  }
+            },
+            "node_modules/is-glob": {
+                  "version": "4.0.3",
+                  "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+                  "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "is-extglob": "^2.1.1"
+                  },
+                  "engines": {
+                        "node": ">=0.10.0"
+                  }
+            },
+            "node_modules/is-number": {
+                  "version": "7.0.0",
+                  "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                  "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=0.12.0"
+                  }
+            },
+            "node_modules/isexe": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+                  "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+                  "dev": true,
+                  "license": "ISC"
+            },
+            "node_modules/jackspeak": {
+                  "version": "3.4.3",
+                  "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+                  "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+                  "dev": true,
+                  "license": "BlueOak-1.0.0",
+                  "dependencies": {
+                        "@isaacs/cliui": "^8.0.2"
+                  },
+                  "funding": {
+                        "url": "https://github.com/sponsors/isaacs"
+                  },
+                  "optionalDependencies": {
+                        "@pkgjs/parseargs": "^0.11.0"
+                  }
+            },
+            "node_modules/jiti": {
+                  "version": "1.21.7",
+                  "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+                  "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+                  "dev": true,
+                  "license": "MIT",
+                  "bin": {
+                        "jiti": "bin/jiti.js"
+                  }
+            },
+            "node_modules/js-tokens": {
+                  "version": "4.0.0",
+                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+                  "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+                  "license": "MIT"
+            },
+            "node_modules/lilconfig": {
+                  "version": "3.1.3",
+                  "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+                  "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=14"
+                  },
+                  "funding": {
+                        "url": "https://github.com/sponsors/antonk52"
+                  }
+            },
+            "node_modules/lines-and-columns": {
+                  "version": "1.2.4",
+                  "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+                  "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+                  "dev": true,
+                  "license": "MIT"
+            },
+            "node_modules/lodash": {
+                  "version": "4.17.21",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+                  "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+                  "license": "MIT"
+            },
+            "node_modules/loose-envify": {
+                  "version": "1.4.0",
+                  "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+                  "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "js-tokens": "^3.0.0 || ^4.0.0"
+                  },
+                  "bin": {
+                        "loose-envify": "cli.js"
+                  }
+            },
+            "node_modules/lru-cache": {
+                  "version": "10.4.3",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+                  "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+                  "dev": true,
+                  "license": "ISC"
+            },
+            "node_modules/lucide-react": {
+                  "version": "0.487.0",
+                  "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.487.0.tgz",
+                  "integrity": "sha512-aKqhOQ+YmFnwq8dWgGjOuLc8V1R9/c/yOd+zDY4+ohsR2Jo05lSGc3WsstYPIzcTpeosN7LoCkLReUUITvaIvw==",
+                  "license": "ISC",
+                  "peerDependencies": {
+                        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+                  }
+            },
+            "node_modules/merge2": {
+                  "version": "1.4.1",
+                  "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+                  "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">= 8"
+                  }
+            },
+            "node_modules/micromatch": {
+                  "version": "4.0.8",
+                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+                  "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "braces": "^3.0.3",
+                        "picomatch": "^2.3.1"
+                  },
+                  "engines": {
+                        "node": ">=8.6"
+                  }
+            },
+            "node_modules/minimatch": {
+                  "version": "9.0.5",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+                  "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+                  "dev": true,
+                  "license": "ISC",
+                  "dependencies": {
+                        "brace-expansion": "^2.0.1"
+                  },
+                  "engines": {
+                        "node": ">=16 || 14 >=14.17"
+                  },
+                  "funding": {
+                        "url": "https://github.com/sponsors/isaacs"
+                  }
+            },
+            "node_modules/minipass": {
+                  "version": "7.1.2",
+                  "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+                  "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+                  "dev": true,
+                  "license": "ISC",
+                  "engines": {
+                        "node": ">=16 || 14 >=14.17"
+                  }
+            },
+            "node_modules/motion": {
+                  "version": "12.23.12",
+                  "resolved": "https://registry.npmjs.org/motion/-/motion-12.23.12.tgz",
+                  "integrity": "sha512-8jCD8uW5GD1csOoqh1WhH1A6j5APHVE15nuBkFeRiMzYBdRwyAHmSP/oXSuW0WJPZRXTFdBoG4hY9TFWNhhwng==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "framer-motion": "^12.23.12",
+                        "tslib": "^2.4.0"
+                  },
+                  "peerDependencies": {
+                        "@emotion/is-prop-valid": "*",
+                        "react": "^18.0.0 || ^19.0.0",
+                        "react-dom": "^18.0.0 || ^19.0.0"
+                  },
+                  "peerDependenciesMeta": {
+                        "@emotion/is-prop-valid": {
+                              "optional": true
+                        },
+                        "react": {
+                              "optional": true
+                        },
+                        "react-dom": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/motion-dom": {
+                  "version": "12.23.12",
+                  "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
+                  "integrity": "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "motion-utils": "^12.23.6"
+                  }
+            },
+            "node_modules/motion-utils": {
+                  "version": "12.23.6",
+                  "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+                  "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+                  "license": "MIT"
+            },
+            "node_modules/mz": {
+                  "version": "2.7.0",
+                  "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+                  "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "any-promise": "^1.0.0",
+                        "object-assign": "^4.0.1",
+                        "thenify-all": "^1.0.0"
+                  }
+            },
+            "node_modules/nanoid": {
+                  "version": "3.3.11",
+                  "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+                  "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+                  "dev": true,
+                  "funding": [
+                        {
+                              "type": "github",
+                              "url": "https://github.com/sponsors/ai"
+                        }
+                  ],
+                  "license": "MIT",
+                  "bin": {
+                        "nanoid": "bin/nanoid.cjs"
+                  },
+                  "engines": {
+                        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+                  }
+            },
+            "node_modules/next-themes": {
+                  "version": "0.4.6",
+                  "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+                  "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+                  "license": "MIT",
+                  "peerDependencies": {
+                        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+                  }
+            },
+            "node_modules/node-releases": {
+                  "version": "2.0.21",
+                  "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.21.tgz",
+                  "integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
+                  "dev": true,
+                  "license": "MIT"
+            },
+            "node_modules/normalize-path": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+                  "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=0.10.0"
+                  }
+            },
+            "node_modules/normalize-range": {
+                  "version": "0.1.2",
+                  "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+                  "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=0.10.0"
+                  }
+            },
+            "node_modules/object-assign": {
+                  "version": "4.1.1",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                  "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=0.10.0"
+                  }
+            },
+            "node_modules/object-hash": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+                  "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">= 6"
+                  }
+            },
+            "node_modules/package-json-from-dist": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+                  "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+                  "dev": true,
+                  "license": "BlueOak-1.0.0"
+            },
+            "node_modules/path-key": {
+                  "version": "3.1.1",
+                  "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+                  "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=8"
+                  }
+            },
+            "node_modules/path-parse": {
+                  "version": "1.0.7",
+                  "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+                  "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+                  "dev": true,
+                  "license": "MIT"
+            },
+            "node_modules/path-scurry": {
+                  "version": "1.11.1",
+                  "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+                  "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+                  "dev": true,
+                  "license": "BlueOak-1.0.0",
+                  "dependencies": {
+                        "lru-cache": "^10.2.0",
+                        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+                  },
+                  "engines": {
+                        "node": ">=16 || 14 >=14.18"
+                  },
+                  "funding": {
+                        "url": "https://github.com/sponsors/isaacs"
+                  }
+            },
+            "node_modules/picocolors": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+                  "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+                  "dev": true,
+                  "license": "ISC"
+            },
+            "node_modules/picomatch": {
+                  "version": "2.3.1",
+                  "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+                  "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=8.6"
+                  },
+                  "funding": {
+                        "url": "https://github.com/sponsors/jonschlinkert"
+                  }
+            },
+            "node_modules/pify": {
+                  "version": "2.3.0",
+                  "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                  "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=0.10.0"
+                  }
+            },
+            "node_modules/pirates": {
+                  "version": "4.0.7",
+                  "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+                  "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">= 6"
+                  }
+            },
+            "node_modules/postcss": {
+                  "version": "8.5.6",
+                  "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+                  "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+                  "dev": true,
+                  "funding": [
+                        {
+                              "type": "opencollective",
+                              "url": "https://opencollective.com/postcss/"
+                        },
+                        {
+                              "type": "tidelift",
+                              "url": "https://tidelift.com/funding/github/npm/postcss"
+                        },
+                        {
+                              "type": "github",
+                              "url": "https://github.com/sponsors/ai"
+                        }
+                  ],
+                  "license": "MIT",
+                  "dependencies": {
+                        "nanoid": "^3.3.11",
+                        "picocolors": "^1.1.1",
+                        "source-map-js": "^1.2.1"
+                  },
+                  "engines": {
+                        "node": "^10 || ^12 || >=14"
+                  }
+            },
+            "node_modules/postcss-import": {
+                  "version": "15.1.0",
+                  "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+                  "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "postcss-value-parser": "^4.0.0",
+                        "read-cache": "^1.0.0",
+                        "resolve": "^1.1.7"
+                  },
+                  "engines": {
+                        "node": ">=14.0.0"
+                  },
+                  "peerDependencies": {
+                        "postcss": "^8.0.0"
+                  }
+            },
+            "node_modules/postcss-js": {
+                  "version": "4.0.1",
+                  "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
+                  "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "camelcase-css": "^2.0.1"
+                  },
+                  "engines": {
+                        "node": "^12 || ^14 || >= 16"
+                  },
+                  "funding": {
+                        "type": "opencollective",
+                        "url": "https://opencollective.com/postcss/"
+                  },
+                  "peerDependencies": {
+                        "postcss": "^8.4.21"
+                  }
+            },
+            "node_modules/postcss-load-config": {
+                  "version": "4.0.2",
+                  "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
+                  "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
+                  "dev": true,
+                  "funding": [
+                        {
+                              "type": "opencollective",
+                              "url": "https://opencollective.com/postcss/"
+                        },
+                        {
+                              "type": "github",
+                              "url": "https://github.com/sponsors/ai"
+                        }
+                  ],
+                  "license": "MIT",
+                  "dependencies": {
+                        "lilconfig": "^3.0.0",
+                        "yaml": "^2.3.4"
+                  },
+                  "engines": {
+                        "node": ">= 14"
+                  },
+                  "peerDependencies": {
+                        "postcss": ">=8.0.9",
+                        "ts-node": ">=9.0.0"
+                  },
+                  "peerDependenciesMeta": {
+                        "postcss": {
+                              "optional": true
+                        },
+                        "ts-node": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/postcss-nested": {
+                  "version": "6.2.0",
+                  "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+                  "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+                  "dev": true,
+                  "funding": [
+                        {
+                              "type": "opencollective",
+                              "url": "https://opencollective.com/postcss/"
+                        },
+                        {
+                              "type": "github",
+                              "url": "https://github.com/sponsors/ai"
+                        }
+                  ],
+                  "license": "MIT",
+                  "dependencies": {
+                        "postcss-selector-parser": "^6.1.1"
+                  },
+                  "engines": {
+                        "node": ">=12.0"
+                  },
+                  "peerDependencies": {
+                        "postcss": "^8.2.14"
+                  }
+            },
+            "node_modules/postcss-selector-parser": {
+                  "version": "6.1.2",
+                  "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+                  "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "cssesc": "^3.0.0",
+                        "util-deprecate": "^1.0.2"
+                  },
+                  "engines": {
+                        "node": ">=4"
+                  }
+            },
+            "node_modules/postcss-value-parser": {
+                  "version": "4.2.0",
+                  "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+                  "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+                  "dev": true,
+                  "license": "MIT"
+            },
+            "node_modules/prop-types": {
+                  "version": "15.8.1",
+                  "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+                  "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "loose-envify": "^1.4.0",
+                        "object-assign": "^4.1.1",
+                        "react-is": "^16.13.1"
+                  }
+            },
+            "node_modules/prop-types/node_modules/react-is": {
+                  "version": "16.13.1",
+                  "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+                  "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+                  "license": "MIT"
+            },
+            "node_modules/queue-microtask": {
+                  "version": "1.2.3",
+                  "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+                  "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+                  "dev": true,
+                  "funding": [
+                        {
+                              "type": "github",
+                              "url": "https://github.com/sponsors/feross"
+                        },
+                        {
+                              "type": "patreon",
+                              "url": "https://www.patreon.com/feross"
+                        },
+                        {
+                              "type": "consulting",
+                              "url": "https://feross.org/support"
+                        }
+                  ],
+                  "license": "MIT"
+            },
+            "node_modules/react": {
+                  "version": "18.3.1",
+                  "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+                  "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "loose-envify": "^1.1.0"
+                  },
+                  "engines": {
+                        "node": ">=0.10.0"
+                  }
+            },
+            "node_modules/react-day-picker": {
+                  "version": "8.10.1",
+                  "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.10.1.tgz",
+                  "integrity": "sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA==",
+                  "license": "MIT",
+                  "funding": {
+                        "type": "individual",
+                        "url": "https://github.com/sponsors/gpbl"
+                  },
+                  "peerDependencies": {
+                        "date-fns": "^2.28.0 || ^3.0.0",
+                        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+                  }
+            },
+            "node_modules/react-dom": {
+                  "version": "18.3.1",
+                  "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+                  "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "loose-envify": "^1.1.0",
+                        "scheduler": "^0.23.2"
+                  },
+                  "peerDependencies": {
+                        "react": "^18.3.1"
+                  }
+            },
+            "node_modules/react-hook-form": {
+                  "version": "7.62.0",
+                  "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
+                  "integrity": "sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==",
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=18.0.0"
+                  },
+                  "funding": {
+                        "type": "opencollective",
+                        "url": "https://opencollective.com/react-hook-form"
+                  },
+                  "peerDependencies": {
+                        "react": "^16.8.0 || ^17 || ^18 || ^19"
+                  }
+            },
+            "node_modules/react-is": {
+                  "version": "18.3.1",
+                  "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+                  "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+                  "license": "MIT"
+            },
+            "node_modules/react-remove-scroll": {
+                  "version": "2.7.1",
+                  "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
+                  "integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "react-remove-scroll-bar": "^2.3.7",
+                        "react-style-singleton": "^2.2.3",
+                        "tslib": "^2.1.0",
+                        "use-callback-ref": "^1.3.3",
+                        "use-sidecar": "^1.1.3"
+                  },
+                  "engines": {
+                        "node": ">=10"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/react-remove-scroll-bar": {
+                  "version": "2.3.8",
+                  "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+                  "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "react-style-singleton": "^2.2.2",
+                        "tslib": "^2.0.0"
+                  },
+                  "engines": {
+                        "node": ">=10"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/react-resizable-panels": {
+                  "version": "2.1.9",
+                  "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-2.1.9.tgz",
+                  "integrity": "sha512-z77+X08YDIrgAes4jl8xhnUu1LNIRp4+E7cv4xHmLOxxUPO/ML7PSrE813b90vj7xvQ1lcf7g2uA9GeMZonjhQ==",
+                  "license": "MIT",
+                  "peerDependencies": {
+                        "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+                        "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+                  }
+            },
+            "node_modules/react-smooth": {
+                  "version": "4.0.4",
+                  "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+                  "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "fast-equals": "^5.0.1",
+                        "prop-types": "^15.8.1",
+                        "react-transition-group": "^4.4.5"
+                  },
+                  "peerDependencies": {
+                        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+                  }
+            },
+            "node_modules/react-style-singleton": {
+                  "version": "2.2.3",
+                  "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+                  "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "get-nonce": "^1.0.0",
+                        "tslib": "^2.0.0"
+                  },
+                  "engines": {
+                        "node": ">=10"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/react-transition-group": {
+                  "version": "4.4.5",
+                  "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+                  "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+                  "license": "BSD-3-Clause",
+                  "dependencies": {
+                        "@babel/runtime": "^7.5.5",
+                        "dom-helpers": "^5.0.1",
+                        "loose-envify": "^1.4.0",
+                        "prop-types": "^15.6.2"
+                  },
+                  "peerDependencies": {
+                        "react": ">=16.6.0",
+                        "react-dom": ">=16.6.0"
+                  }
+            },
+            "node_modules/read-cache": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+                  "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "pify": "^2.3.0"
+                  }
+            },
+            "node_modules/readdirp": {
+                  "version": "3.6.0",
+                  "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+                  "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "picomatch": "^2.2.1"
+                  },
+                  "engines": {
+                        "node": ">=8.10.0"
+                  }
+            },
+            "node_modules/recharts": {
+                  "version": "2.15.4",
+                  "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+                  "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "clsx": "^2.0.0",
+                        "eventemitter3": "^4.0.1",
+                        "lodash": "^4.17.21",
+                        "react-is": "^18.3.1",
+                        "react-smooth": "^4.0.4",
+                        "recharts-scale": "^0.4.4",
+                        "tiny-invariant": "^1.3.1",
+                        "victory-vendor": "^36.6.8"
+                  },
+                  "engines": {
+                        "node": ">=14"
+                  },
+                  "peerDependencies": {
+                        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+                  }
+            },
+            "node_modules/recharts-scale": {
+                  "version": "0.4.5",
+                  "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+                  "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "decimal.js-light": "^2.4.1"
+                  }
+            },
+            "node_modules/resolve": {
+                  "version": "1.22.10",
+                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+                  "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "is-core-module": "^2.16.0",
+                        "path-parse": "^1.0.7",
+                        "supports-preserve-symlinks-flag": "^1.0.0"
+                  },
+                  "bin": {
+                        "resolve": "bin/resolve"
+                  },
+                  "engines": {
+                        "node": ">= 0.4"
+                  },
+                  "funding": {
+                        "url": "https://github.com/sponsors/ljharb"
+                  }
+            },
+            "node_modules/reusify": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+                  "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "iojs": ">=1.0.0",
+                        "node": ">=0.10.0"
+                  }
+            },
+            "node_modules/rollup": {
+                  "version": "4.50.2",
+                  "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.2.tgz",
+                  "integrity": "sha512-BgLRGy7tNS9H66aIMASq1qSYbAAJV6Z6WR4QYTvj5FgF15rZ/ympT1uixHXwzbZUBDbkvqUI1KR0fH1FhMaQ9w==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "@types/estree": "1.0.8"
+                  },
+                  "bin": {
+                        "rollup": "dist/bin/rollup"
+                  },
+                  "engines": {
+                        "node": ">=18.0.0",
+                        "npm": ">=8.0.0"
+                  },
+                  "optionalDependencies": {
+                        "@rollup/rollup-android-arm-eabi": "4.50.2",
+                        "@rollup/rollup-android-arm64": "4.50.2",
+                        "@rollup/rollup-darwin-arm64": "4.50.2",
+                        "@rollup/rollup-darwin-x64": "4.50.2",
+                        "@rollup/rollup-freebsd-arm64": "4.50.2",
+                        "@rollup/rollup-freebsd-x64": "4.50.2",
+                        "@rollup/rollup-linux-arm-gnueabihf": "4.50.2",
+                        "@rollup/rollup-linux-arm-musleabihf": "4.50.2",
+                        "@rollup/rollup-linux-arm64-gnu": "4.50.2",
+                        "@rollup/rollup-linux-arm64-musl": "4.50.2",
+                        "@rollup/rollup-linux-loong64-gnu": "4.50.2",
+                        "@rollup/rollup-linux-ppc64-gnu": "4.50.2",
+                        "@rollup/rollup-linux-riscv64-gnu": "4.50.2",
+                        "@rollup/rollup-linux-riscv64-musl": "4.50.2",
+                        "@rollup/rollup-linux-s390x-gnu": "4.50.2",
+                        "@rollup/rollup-linux-x64-gnu": "4.50.2",
+                        "@rollup/rollup-linux-x64-musl": "4.50.2",
+                        "@rollup/rollup-openharmony-arm64": "4.50.2",
+                        "@rollup/rollup-win32-arm64-msvc": "4.50.2",
+                        "@rollup/rollup-win32-ia32-msvc": "4.50.2",
+                        "@rollup/rollup-win32-x64-msvc": "4.50.2",
+                        "fsevents": "~2.3.2"
+                  }
+            },
+            "node_modules/run-parallel": {
+                  "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+                  "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+                  "dev": true,
+                  "funding": [
+                        {
+                              "type": "github",
+                              "url": "https://github.com/sponsors/feross"
+                        },
+                        {
+                              "type": "patreon",
+                              "url": "https://www.patreon.com/feross"
+                        },
+                        {
+                              "type": "consulting",
+                              "url": "https://feross.org/support"
+                        }
+                  ],
+                  "license": "MIT",
+                  "dependencies": {
+                        "queue-microtask": "^1.2.2"
+                  }
+            },
+            "node_modules/scheduler": {
+                  "version": "0.23.2",
+                  "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+                  "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "loose-envify": "^1.1.0"
+                  }
+            },
+            "node_modules/shebang-command": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+                  "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "shebang-regex": "^3.0.0"
+                  },
+                  "engines": {
+                        "node": ">=8"
+                  }
+            },
+            "node_modules/shebang-regex": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+                  "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=8"
+                  }
+            },
+            "node_modules/signal-exit": {
+                  "version": "4.1.0",
+                  "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+                  "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+                  "dev": true,
+                  "license": "ISC",
+                  "engines": {
+                        "node": ">=14"
+                  },
+                  "funding": {
+                        "url": "https://github.com/sponsors/isaacs"
+                  }
+            },
+            "node_modules/sonner": {
+                  "version": "2.0.7",
+                  "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+                  "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+                  "license": "MIT",
+                  "peerDependencies": {
+                        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+                        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+                  }
+            },
+            "node_modules/source-map-js": {
+                  "version": "1.2.1",
+                  "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+                  "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+                  "dev": true,
+                  "license": "BSD-3-Clause",
+                  "engines": {
+                        "node": ">=0.10.0"
+                  }
+            },
+            "node_modules/string-width": {
+                  "version": "5.1.2",
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+                  "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "eastasianwidth": "^0.2.0",
+                        "emoji-regex": "^9.2.2",
+                        "strip-ansi": "^7.0.1"
+                  },
+                  "engines": {
+                        "node": ">=12"
+                  },
+                  "funding": {
+                        "url": "https://github.com/sponsors/sindresorhus"
+                  }
+            },
+            "node_modules/string-width-cjs": {
+                  "name": "string-width",
+                  "version": "4.2.3",
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+                  "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.1"
+                  },
+                  "engines": {
+                        "node": ">=8"
+                  }
+            },
+            "node_modules/string-width-cjs/node_modules/ansi-regex": {
+                  "version": "5.0.1",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+                  "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=8"
+                  }
+            },
+            "node_modules/string-width-cjs/node_modules/emoji-regex": {
+                  "version": "8.0.0",
+                  "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+                  "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+                  "dev": true,
+                  "license": "MIT"
+            },
+            "node_modules/string-width-cjs/node_modules/strip-ansi": {
+                  "version": "6.0.1",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+                  "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "ansi-regex": "^5.0.1"
+                  },
+                  "engines": {
+                        "node": ">=8"
+                  }
+            },
+            "node_modules/strip-ansi": {
+                  "version": "7.1.2",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+                  "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "ansi-regex": "^6.0.1"
+                  },
+                  "engines": {
+                        "node": ">=12"
+                  },
+                  "funding": {
+                        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+                  }
+            },
+            "node_modules/strip-ansi-cjs": {
+                  "name": "strip-ansi",
+                  "version": "6.0.1",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+                  "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "ansi-regex": "^5.0.1"
+                  },
+                  "engines": {
+                        "node": ">=8"
+                  }
+            },
+            "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+                  "version": "5.0.1",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+                  "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=8"
+                  }
+            },
+            "node_modules/sucrase": {
+                  "version": "3.35.0",
+                  "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
+                  "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "@jridgewell/gen-mapping": "^0.3.2",
+                        "commander": "^4.0.0",
+                        "glob": "^10.3.10",
+                        "lines-and-columns": "^1.1.6",
+                        "mz": "^2.7.0",
+                        "pirates": "^4.0.1",
+                        "ts-interface-checker": "^0.1.9"
+                  },
+                  "bin": {
+                        "sucrase": "bin/sucrase",
+                        "sucrase-node": "bin/sucrase-node"
+                  },
+                  "engines": {
+                        "node": ">=16 || 14 >=14.17"
+                  }
+            },
+            "node_modules/supports-preserve-symlinks-flag": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+                  "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">= 0.4"
+                  },
+                  "funding": {
+                        "url": "https://github.com/sponsors/ljharb"
+                  }
+            },
+            "node_modules/tailwind-merge": {
+                  "version": "3.3.1",
+                  "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
+                  "integrity": "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==",
+                  "license": "MIT",
+                  "funding": {
+                        "type": "github",
+                        "url": "https://github.com/sponsors/dcastil"
+                  }
+            },
+            "node_modules/tailwindcss": {
+                  "version": "3.4.17",
+                  "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
+                  "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "@alloc/quick-lru": "^5.2.0",
+                        "arg": "^5.0.2",
+                        "chokidar": "^3.6.0",
+                        "didyoumean": "^1.2.2",
+                        "dlv": "^1.1.3",
+                        "fast-glob": "^3.3.2",
+                        "glob-parent": "^6.0.2",
+                        "is-glob": "^4.0.3",
+                        "jiti": "^1.21.6",
+                        "lilconfig": "^3.1.3",
+                        "micromatch": "^4.0.8",
+                        "normalize-path": "^3.0.0",
+                        "object-hash": "^3.0.0",
+                        "picocolors": "^1.1.1",
+                        "postcss": "^8.4.47",
+                        "postcss-import": "^15.1.0",
+                        "postcss-js": "^4.0.1",
+                        "postcss-load-config": "^4.0.2",
+                        "postcss-nested": "^6.2.0",
+                        "postcss-selector-parser": "^6.1.2",
+                        "resolve": "^1.22.8",
+                        "sucrase": "^3.35.0"
+                  },
+                  "bin": {
+                        "tailwind": "lib/cli.js",
+                        "tailwindcss": "lib/cli.js"
+                  },
+                  "engines": {
+                        "node": ">=14.0.0"
+                  }
+            },
+            "node_modules/thenify": {
+                  "version": "3.3.1",
+                  "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+                  "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "any-promise": "^1.0.0"
+                  }
+            },
+            "node_modules/thenify-all": {
+                  "version": "1.6.0",
+                  "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+                  "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "thenify": ">= 3.1.0 < 4"
+                  },
+                  "engines": {
+                        "node": ">=0.8"
+                  }
+            },
+            "node_modules/tiny-invariant": {
+                  "version": "1.3.3",
+                  "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+                  "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+                  "license": "MIT"
+            },
+            "node_modules/tinyglobby": {
+                  "version": "0.2.15",
+                  "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+                  "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "fdir": "^6.5.0",
+                        "picomatch": "^4.0.3"
+                  },
+                  "engines": {
+                        "node": ">=12.0.0"
+                  },
+                  "funding": {
+                        "url": "https://github.com/sponsors/SuperchupuDev"
+                  }
+            },
+            "node_modules/tinyglobby/node_modules/fdir": {
+                  "version": "6.5.0",
+                  "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+                  "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=12.0.0"
+                  },
+                  "peerDependencies": {
+                        "picomatch": "^3 || ^4"
+                  },
+                  "peerDependenciesMeta": {
+                        "picomatch": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/tinyglobby/node_modules/picomatch": {
+                  "version": "4.0.3",
+                  "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+                  "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=12"
+                  },
+                  "funding": {
+                        "url": "https://github.com/sponsors/jonschlinkert"
+                  }
+            },
+            "node_modules/to-regex-range": {
+                  "version": "5.0.1",
+                  "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                  "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "is-number": "^7.0.0"
+                  },
+                  "engines": {
+                        "node": ">=8.0"
+                  }
+            },
+            "node_modules/ts-interface-checker": {
+                  "version": "0.1.13",
+                  "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+                  "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+                  "dev": true,
+                  "license": "Apache-2.0"
+            },
+            "node_modules/tslib": {
+                  "version": "2.8.1",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+                  "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+                  "license": "0BSD"
+            },
+            "node_modules/typescript": {
+                  "version": "5.9.2",
+                  "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+                  "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+                  "dev": true,
+                  "license": "Apache-2.0",
+                  "bin": {
+                        "tsc": "bin/tsc",
+                        "tsserver": "bin/tsserver"
+                  },
+                  "engines": {
+                        "node": ">=14.17"
+                  }
+            },
+            "node_modules/undici-types": {
+                  "version": "6.21.0",
+                  "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+                  "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+                  "dev": true,
+                  "license": "MIT"
+            },
+            "node_modules/update-browserslist-db": {
+                  "version": "1.1.3",
+                  "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+                  "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+                  "dev": true,
+                  "funding": [
+                        {
+                              "type": "opencollective",
+                              "url": "https://opencollective.com/browserslist"
+                        },
+                        {
+                              "type": "tidelift",
+                              "url": "https://tidelift.com/funding/github/npm/browserslist"
+                        },
+                        {
+                              "type": "github",
+                              "url": "https://github.com/sponsors/ai"
+                        }
+                  ],
+                  "license": "MIT",
+                  "dependencies": {
+                        "escalade": "^3.2.0",
+                        "picocolors": "^1.1.1"
+                  },
+                  "bin": {
+                        "update-browserslist-db": "cli.js"
+                  },
+                  "peerDependencies": {
+                        "browserslist": ">= 4.21.0"
+                  }
+            },
+            "node_modules/use-callback-ref": {
+                  "version": "1.3.3",
+                  "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+                  "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "tslib": "^2.0.0"
+                  },
+                  "engines": {
+                        "node": ">=10"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/use-sidecar": {
+                  "version": "1.1.3",
+                  "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+                  "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "detect-node-es": "^1.1.0",
+                        "tslib": "^2.0.0"
+                  },
+                  "engines": {
+                        "node": ">=10"
+                  },
+                  "peerDependencies": {
+                        "@types/react": "*",
+                        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/react": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/use-sync-external-store": {
+                  "version": "1.5.0",
+                  "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+                  "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+                  "license": "MIT",
+                  "peerDependencies": {
+                        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+                  }
+            },
+            "node_modules/util-deprecate": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+                  "dev": true,
+                  "license": "MIT"
+            },
+            "node_modules/vaul": {
+                  "version": "1.1.2",
+                  "resolved": "https://registry.npmjs.org/vaul/-/vaul-1.1.2.tgz",
+                  "integrity": "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@radix-ui/react-dialog": "^1.1.1"
+                  },
+                  "peerDependencies": {
+                        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+                        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
+                  }
+            },
+            "node_modules/victory-vendor": {
+                  "version": "36.9.2",
+                  "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+                  "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+                  "license": "MIT AND ISC",
+                  "dependencies": {
+                        "@types/d3-array": "^3.0.3",
+                        "@types/d3-ease": "^3.0.0",
+                        "@types/d3-interpolate": "^3.0.1",
+                        "@types/d3-scale": "^4.0.2",
+                        "@types/d3-shape": "^3.1.0",
+                        "@types/d3-time": "^3.0.0",
+                        "@types/d3-timer": "^3.0.0",
+                        "d3-array": "^3.1.6",
+                        "d3-ease": "^3.0.1",
+                        "d3-interpolate": "^3.0.1",
+                        "d3-scale": "^4.0.2",
+                        "d3-shape": "^3.1.0",
+                        "d3-time": "^3.0.0",
+                        "d3-timer": "^3.0.1"
+                  }
+            },
+            "node_modules/vite": {
+                  "version": "6.3.5",
+                  "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
+                  "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "esbuild": "^0.25.0",
+                        "fdir": "^6.4.4",
+                        "picomatch": "^4.0.2",
+                        "postcss": "^8.5.3",
+                        "rollup": "^4.34.9",
+                        "tinyglobby": "^0.2.13"
+                  },
+                  "bin": {
+                        "vite": "bin/vite.js"
+                  },
+                  "engines": {
+                        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+                  },
+                  "funding": {
+                        "url": "https://github.com/vitejs/vite?sponsor=1"
+                  },
+                  "optionalDependencies": {
+                        "fsevents": "~2.3.3"
+                  },
+                  "peerDependencies": {
+                        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+                        "jiti": ">=1.21.0",
+                        "less": "*",
+                        "lightningcss": "^1.21.0",
+                        "sass": "*",
+                        "sass-embedded": "*",
+                        "stylus": "*",
+                        "sugarss": "*",
+                        "terser": "^5.16.0",
+                        "tsx": "^4.8.1",
+                        "yaml": "^2.4.2"
+                  },
+                  "peerDependenciesMeta": {
+                        "@types/node": {
+                              "optional": true
+                        },
+                        "jiti": {
+                              "optional": true
+                        },
+                        "less": {
+                              "optional": true
+                        },
+                        "lightningcss": {
+                              "optional": true
+                        },
+                        "sass": {
+                              "optional": true
+                        },
+                        "sass-embedded": {
+                              "optional": true
+                        },
+                        "stylus": {
+                              "optional": true
+                        },
+                        "sugarss": {
+                              "optional": true
+                        },
+                        "terser": {
+                              "optional": true
+                        },
+                        "tsx": {
+                              "optional": true
+                        },
+                        "yaml": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/vite/node_modules/fdir": {
+                  "version": "6.5.0",
+                  "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+                  "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=12.0.0"
+                  },
+                  "peerDependencies": {
+                        "picomatch": "^3 || ^4"
+                  },
+                  "peerDependenciesMeta": {
+                        "picomatch": {
+                              "optional": true
+                        }
+                  }
+            },
+            "node_modules/vite/node_modules/picomatch": {
+                  "version": "4.0.3",
+                  "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+                  "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=12"
+                  },
+                  "funding": {
+                        "url": "https://github.com/sponsors/jonschlinkert"
+                  }
+            },
+            "node_modules/which": {
+                  "version": "2.0.2",
+                  "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                  "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                  "dev": true,
+                  "license": "ISC",
+                  "dependencies": {
+                        "isexe": "^2.0.0"
+                  },
+                  "bin": {
+                        "node-which": "bin/node-which"
+                  },
+                  "engines": {
+                        "node": ">= 8"
+                  }
+            },
+            "node_modules/wrap-ansi": {
+                  "version": "8.1.0",
+                  "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+                  "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "ansi-styles": "^6.1.0",
+                        "string-width": "^5.0.1",
+                        "strip-ansi": "^7.0.1"
+                  },
+                  "engines": {
+                        "node": ">=12"
+                  },
+                  "funding": {
+                        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+                  }
+            },
+            "node_modules/wrap-ansi-cjs": {
+                  "name": "wrap-ansi",
+                  "version": "7.0.0",
+                  "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+                  "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "ansi-styles": "^4.0.0",
+                        "string-width": "^4.1.0",
+                        "strip-ansi": "^6.0.0"
+                  },
+                  "engines": {
+                        "node": ">=10"
+                  },
+                  "funding": {
+                        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+                  }
+            },
+            "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+                  "version": "5.0.1",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+                  "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+                  "dev": true,
+                  "license": "MIT",
+                  "engines": {
+                        "node": ">=8"
+                  }
+            },
+            "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+                  "version": "4.3.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                  "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "color-convert": "^2.0.1"
+                  },
+                  "engines": {
+                        "node": ">=8"
+                  },
+                  "funding": {
+                        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+                  }
+            },
+            "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+                  "version": "8.0.0",
+                  "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+                  "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+                  "dev": true,
+                  "license": "MIT"
+            },
+            "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+                  "version": "4.2.3",
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+                  "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.1"
+                  },
+                  "engines": {
+                        "node": ">=8"
+                  }
+            },
+            "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+                  "version": "6.0.1",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+                  "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "ansi-regex": "^5.0.1"
+                  },
+                  "engines": {
+                        "node": ">=8"
+                  }
+            },
+            "node_modules/yaml": {
+                  "version": "2.8.1",
+                  "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+                  "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+                  "dev": true,
+                  "license": "ISC",
+                  "bin": {
+                        "yaml": "bin.mjs"
+                  },
+                  "engines": {
+                        "node": ">= 14.6"
+                  }
+            }
+      }
+}

--- a/revenuepilot-frontend/package.json
+++ b/revenuepilot-frontend/package.json
@@ -53,12 +53,11 @@
           "@types/react": "^18.3.12",
           "@types/react-dom": "^18.3.7",
           "@vitejs/plugin-react-swc": "^3.10.2",
-          "vite": "6.3.5"
+          "vite": "6.3.5",
           "autoprefixer": "^10.4.21",
           "postcss": "^8.5.6",
           "tailwindcss": "^3.4.15",
-          "typescript": "^5.9.2",
-          "vite": "^5.4.10"
+          "typescript": "^5.9.2"
       },
       "scripts": {
           "dev": "vite",


### PR DESCRIPTION
## Summary
- remove the duplicate Vite entry in the frontend devDependencies and ensure the version is declared once with the proper comma
- regenerate the frontend package-lock.json after reinstalling dependencies

## Testing
- npm install

------
https://chatgpt.com/codex/tasks/task_e_68c8d08e9db88324b9875688f95458f9