### PR TITLE
Integrate finalization wizard into note editor

### DIFF
--- a/revenuepilot-frontend/src/components/NoteEditor.tsx
+++ b/revenuepilot-frontend/src/components/NoteEditor.tsx
@@ -21,6 +21,7 @@ import {
 } from "lucide-react"
 import { RichTextEditor } from "./RichTextEditor"
 import { BeautifiedView } from "./BeautifiedView"
+import { FinalizationWizard } from "./FinalizationWizard"
 
 interface ComplianceIssue {
   id: string
@@ -64,6 +65,7 @@ export function NoteEditor({
   const [pausedTime, setPausedTime] = useState(0)
   const [transcriptionIndex, setTranscriptionIndex] = useState(0)
   const [showFullTranscript, setShowFullTranscript] = useState(false)
+  const [showFinalizationWizard, setShowFinalizationWizard] = useState(false)
 
   // Mock compliance issues data
   const [complianceIssues, setComplianceIssues] = useState<ComplianceIssue[]>([
@@ -177,8 +179,7 @@ export function NoteEditor({
   }
 
   const handleFinalize = () => {
-    console.log("Finalize action - Finalization wizard will be available separately")
-    // TODO: Connect to separate finalization component when needed
+    setShowFinalizationWizard(true)
   }
 
   const handleSaveDraft = () => {
@@ -507,6 +508,21 @@ export function NoteEditor({
         </DialogContent>
       </Dialog>
 
+
+      {showFinalizationWizard && (
+        <FinalizationWizard
+          isOpen={showFinalizationWizard}
+          onClose={() => setShowFinalizationWizard(false)}
+          selectedCodes={selectedCodes}
+          selectedCodesList={selectedCodesList}
+          complianceIssues={complianceIssues}
+          noteContent={noteContent}
+          patientInfo={{
+            patientId,
+            encounterId
+          }}
+        />
+      )}
 
     </div>
   )


### PR DESCRIPTION
## Summary
- import the FinalizationWizard into the note editor and add state to control its visibility
- open the wizard when the finalize action is triggered and supply the current note, code selections, and compliance data
- render the wizard from the editor and close it again when the dialog is dismissed

## Testing
- `npm run lint` *(fails: pre-existing no-undef errors in src/components/SuggestionPanel.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d08cbb3c83249370945629efe9c5