### PR TITLE
Connect suggestion panel to AI APIs

### DIFF
--- a/revenuepilot-frontend/src/App.tsx
+++ b/revenuepilot-frontend/src/App.tsx
@@ -203,6 +203,7 @@ export default function App() {
       confidence: 85
     }
   ])
+  const [noteContent, setNoteContent] = useState("")
 
   const handleAddCode = (code: any) => {
     // Add to the addedCodes array for filtering suggestions
@@ -860,10 +861,11 @@ export default function App() {
             <ResizablePanelGroup direction="horizontal" className="flex-1">
               <ResizablePanel defaultSize={70} minSize={50}>
                 <div className="flex flex-col h-full">
-                  <NoteEditor 
+                  <NoteEditor
                     prePopulatedPatient={prePopulatedPatient}
                     selectedCodes={selectedCodes}
                     selectedCodesList={selectedCodesList}
+                    onNoteContentChange={setNoteContent}
                   />
                   <SelectedCodesBar 
                     selectedCodes={selectedCodes}
@@ -879,12 +881,14 @@ export default function App() {
                 <>
                   <ResizableHandle />
                   <ResizablePanel defaultSize={30} minSize={25} maxSize={40}>
-                    <SuggestionPanel 
-                      onClose={() => setIsSuggestionPanelOpen(false)} 
+                    <SuggestionPanel
+                      onClose={() => setIsSuggestionPanelOpen(false)}
                       selectedCodes={selectedCodes}
                       onUpdateCodes={setSelectedCodes}
                       onAddCode={handleAddCode}
                       addedCodes={addedCodes}
+                      noteContent={noteContent}
+                      selectedCodesList={selectedCodesList}
                     />
                   </ResizablePanel>
                 </>

--- a/revenuepilot-frontend/src/components/NoteEditor.tsx
+++ b/revenuepilot-frontend/src/components/NoteEditor.tsx
@@ -47,12 +47,14 @@ interface NoteEditorProps {
     differentials: number
   }
   selectedCodesList?: any[]
+  onNoteContentChange?: (content: string) => void
 }
 
-export function NoteEditor({ 
+export function NoteEditor({
   prePopulatedPatient,
   selectedCodes = { codes: 0, prevention: 0, diagnoses: 0, differentials: 0 },
-  selectedCodesList = []
+  selectedCodesList = [],
+  onNoteContentChange
 }: NoteEditorProps) {
   const [patientId, setPatientId] = useState(prePopulatedPatient?.patientId || "")
   const [encounterId, setEncounterId] = useState(prePopulatedPatient?.encounterId || "")
@@ -388,12 +390,17 @@ export function NoteEditor({
       
       {/* Rich Text Editor */}
       <div className="flex-1">
-        <RichTextEditor 
+        <RichTextEditor
           disabled={isEditorDisabled}
           complianceIssues={complianceIssues}
           onDismissIssue={handleDismissIssue}
           onRestoreIssue={handleRestoreIssue}
-          onContentChange={setNoteContent}
+          onContentChange={(content) => {
+            setNoteContent(content)
+            if (onNoteContentChange) {
+              onNoteContentChange(content)
+            }
+          }}
         />
       </div>
 


### PR DESCRIPTION
## Summary
- replace static suggestion data with API-driven requests for codes, compliance, differentials, and prevention content
- surface confidence scores, rationales, and error/loading states while letting cards react to note content updates
- lift note content state to App and pass it to the suggestion panel via NoteEditor so fetches re-run as documentation changes

## Testing
- `npm run test` *(fails: suite expects legacy static suggestion data)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d7b32db483248d54a8d8e4b73118