### PR TITLE
Update sonner import in NoteEditor

### DIFF
--- a/revenuepilot-frontend/src/components/NoteEditor.tsx
+++ b/revenuepilot-frontend/src/components/NoteEditor.tsx
@@ -17,7 +17,7 @@ import {
   AlertTriangle,
   Loader2
 } from "lucide-react"
-import { toast } from "sonner@2.0.3"
+import { toast } from "sonner"
 import { RichTextEditor } from "./RichTextEditor"
 import { BeautifiedView } from "./BeautifiedView"
 import {


### PR DESCRIPTION
## Summary
- update the NoteEditor component to import `toast` from the default `sonner` package instead of the version-suffixed alias

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb638e7dec8324b0b1e92fe0ba0337