### PR TITLE
Ensure finalization wizard assets build with main app

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "electron/main.js",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "npm --workspace finalization-wizard run build && vite build",
     "preview": "vite preview",
     "electron:dev": "npm run build && npm run backend:prebuild && electron electron/main.js",
     "electron:build": "npm run build && npm run fetch-icons && npm run backend:prebuild && node -r dotenv/config scripts/check-build-env.js && node -r dotenv/config ./node_modules/.bin/electron-builder -mwl",

--- a/revenuepilot-frontend/src/components/FinalizationWizardAdapter.tsx
+++ b/revenuepilot-frontend/src/components/FinalizationWizardAdapter.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useMemo } from "react"
 
+import "finalization-wizard/dist/style.css"
+
 import {
   FinalizationWizard,
   type FinalizeRequest,


### PR DESCRIPTION
## Summary
- update the root build script to compile the finalization wizard workspace before the main Vite build so the generated dist assets exist
- pull the wizard's compiled stylesheet into the adapter so the embedded UI keeps its Tailwind styling

## Testing
- pytest --override-ini="addopts=" tests/test_api_endpoints.py::test_pre_finalize_and_finalize --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68cc4df5ec488324aff40758816d3512