### PR TITLE
Integrate workflow-driven finalization wizard

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,23 +27,23 @@
     "mock": "node mock/server.js"
   },
   "dependencies": {
+    "body-parser": "^1.20.2",
     "chart.js": "^4.5.0",
+    "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "electron-updater": "^6.6.2",
+    "express": "^4.18.2",
     "html-to-rtf": "^2.1.0",
     "html2pdf.js": "^0.10.3",
     "i18next": "^25.3.2",
     "js-yaml": "^4.1.0",
+    "jsonwebtoken": "^9.0.0",
     "pdfkit": "^0.17.1",
     "react": "^18.3.1",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^18.3.1",
     "react-i18next": "^15.6.1",
-    "react-quill": "^2.0.0",
-    "express": "^4.18.2",
-    "cors": "^2.8.5",
-    "body-parser": "^1.20.2",
-    "jsonwebtoken": "^9.0.0"
+    "react-quill": "^2.0.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.54.2",
@@ -142,18 +142,6 @@
     "win": {
       "target": "nsis"
     },
-
-  "linux": {
-    "target": [
-      "AppImage",
-      "deb"
-    ],
-    "category": "Utility",
-
-    "cscLink": "${env.LINUX_CSC_LINK}",
-    "cscKeyPassword": "${env.LINUX_CSC_KEY_PASSWORD}"
-  },
-
     "linux": {
       "target": [
         "AppImage",
@@ -162,9 +150,7 @@
       "category": "Utility",
       "cscLink": "${env.LINUX_CSC_LINK}",
       "cscKeyPassword": "${env.LINUX_CSC_KEY_PASSWORD}"
-
     },
-
     "publish": [
       {
         "provider": "generic",

--- a/revenuepilot-frontend/src/components/NoteEditor.tsx
+++ b/revenuepilot-frontend/src/components/NoteEditor.tsx
@@ -1580,6 +1580,7 @@ export function NoteEditor({
             sex: patientSexValue ?? null,
             encounterDate: encounterDateValue ?? null
           }}
+          transcriptEntries={transcriptEntries}
           fetchWithAuth={fetchWithAuth}
           noteId={noteId}
           onPreFinalizeResult={handlePreFinalizeResult}


### PR DESCRIPTION
## Summary
- initialize and resume workflow sessions with full note, transcript, and code context, then update, attest, and dispatch final notes through the workflow API
- surface session-derived progress, reimbursement, transcript, and code data throughout the wizard steps and dual editor
- render applied codes and unused AI suggestions dynamically so the wizard reflects live selections and confidence-driven groupings

## Testing
- `npm test` *(fails: missing @testing-library/dom dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68cd8d3adc4083248f387edaaf8fa78f