### PR TITLE
Wire clinical note editor to backend services

### DIFF
--- a/revenuepilot-frontend/src/components/SuggestionPanel.tsx
+++ b/revenuepilot-frontend/src/components/SuggestionPanel.tsx
@@ -179,7 +179,7 @@ export function SuggestionPanel({ onClose, selectedCodes, onUpdateCodes, onAddCo
         const data =
           (await apiFetchJson<{ suggestions?: any[] }>("/api/ai/codes/suggest", {
             method: "POST",
-            jsonBody: { content: trimmed, useOfflineMode: true },
+            jsonBody: { content: trimmed },
             signal
           })) ?? {}
 
@@ -215,7 +215,7 @@ export function SuggestionPanel({ onClose, selectedCodes, onUpdateCodes, onAddCo
         const data =
           (await apiFetchJson<{ alerts?: any[] }>("/api/ai/compliance/check", {
             method: "POST",
-            jsonBody: { content: trimmed, codes: codesInUse, useOfflineMode: true },
+            jsonBody: { content: trimmed, codes: codesInUse },
             signal
           })) ?? {}
 
@@ -246,7 +246,7 @@ export function SuggestionPanel({ onClose, selectedCodes, onUpdateCodes, onAddCo
         const data =
           (await apiFetchJson<{ differentials?: any[] }>("/api/ai/differentials/generate", {
             method: "POST",
-            jsonBody: { content: trimmed, useOfflineMode: true },
+            jsonBody: { content: trimmed },
             signal
           })) ?? {}
 
@@ -310,7 +310,7 @@ export function SuggestionPanel({ onClose, selectedCodes, onUpdateCodes, onAddCo
         const data =
           (await apiFetchJson<{ recommendations?: any[] }>("/api/ai/prevention/suggest", {
             method: "POST",
-            jsonBody: { useOfflineMode: true },
+            jsonBody: {},
             signal
           })) ?? {}
 

--- a/revenuepilot-frontend/src/contexts/SessionContext.tsx
+++ b/revenuepilot-frontend/src/contexts/SessionContext.tsx
@@ -122,71 +122,10 @@ function countCodes(list: SessionCode[]): SelectedCodesCounts {
 }
 
 function createInitialSessionState(): SessionState {
-  const initialCodes: SessionCode[] = [
-    {
-      code: "99213",
-      type: "CPT",
-      category: "codes",
-      description: "Office visit, established patient",
-      rationale: "Moderate complexity medical decision making with established patient visit",
-      confidence: 87,
-      reimbursement: "$127.42",
-      rvu: "1.92"
-    },
-    {
-      code: "99214",
-      type: "CPT",
-      category: "codes",
-      description: "Office visit, established patient (moderate complexity)",
-      rationale: "High complexity decision making documented with comprehensive assessment",
-      confidence: 78,
-      reimbursement: "$184.93",
-      rvu: "2.80"
-    },
-    {
-      code: "J06.9",
-      type: "ICD-10",
-      category: "diagnoses",
-      description: "Acute upper respiratory infection, unspecified",
-      rationale: "Primary diagnosis based on presenting symptoms and clinical findings",
-      confidence: 92
-    },
-    {
-      code: "J02.9",
-      type: "ICD-10",
-      category: "diagnoses",
-      description: "Acute pharyngitis, unspecified",
-      rationale: "Secondary diagnosis from physical examination findings",
-      confidence: 84
-    },
-    {
-      code: "Z23",
-      type: "ICD-10",
-      category: "diagnoses",
-      description: "Encounter for immunization",
-      rationale: "Patient received influenza vaccination during visit",
-      confidence: 95
-    },
-    {
-      code: "M25.50",
-      type: "ICD-10",
-      category: "diagnoses",
-      description: "Pain in unspecified joint",
-      rationale: "Patient reports joint discomfort as secondary concern",
-      confidence: 78
-    },
-    {
-      code: "Viral URI vs Bacterial Sinusitis",
-      type: "DIFFERENTIAL",
-      category: "differentials",
-      description: "Primary differential diagnosis consideration",
-      rationale: "85% confidence viral, 35% bacterial based on symptom pattern",
-      confidence: 85
-    }
-  ]
+  const initialCodes: SessionCode[] = []
 
   return {
-    selectedCodes: countCodes(initialCodes),
+    selectedCodes: { ...EMPTY_COUNTS },
     selectedCodesList: initialCodes,
     addedCodes: [],
     isSuggestionPanelOpen: true,


### PR DESCRIPTION
## Summary
- add a reusable API base resolver and websocket helper so browser fetches target the FastAPI service
- connect note creation, autosave, visit session timing, and live transcription in the TypeScript editor to backend endpoints instead of mocks
- drive AI suggestions, code validation, and reimbursement details from the real API and drop placeholder session codes

## Testing
- yarn build *(fails: `finalization-wizard` package is missing `dist/style.css` during Vite build)*

------
https://chatgpt.com/codex/tasks/task_e_68cd8ef8c1b483249b768882b74b6230