### PR TITLE
Implement manual draft save flow with tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.54.2",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
     "@vitejs/plugin-react": "^5.0.0",
     "@vitest/coverage-v8": "^3.2.4",

--- a/revenuepilot-frontend/src/ProtectedApp.tsx
+++ b/revenuepilot-frontend/src/ProtectedApp.tsx
@@ -1116,6 +1116,7 @@ export function ProtectedApp() {
                     prePopulatedPatient={prePopulatedPatient}
                     selectedCodes={selectedCodes}
                     selectedCodesList={selectedCodesList}
+                    onNavigateToDrafts={() => handleNavigate('drafts')}
                   />
                   <SelectedCodesBar
                     selectedCodes={selectedCodes}

--- a/revenuepilot-frontend/src/components/NoteEditor.tsx
+++ b/revenuepilot-frontend/src/components/NoteEditor.tsx
@@ -128,13 +128,19 @@ interface NoteEditorProps {
   }
   selectedCodesList?: any[]
   onNoteContentChange?: (content: string) => void
+  onNavigateToDrafts?: () => void
+  testOverrides?: {
+    initialRecordedSeconds?: number
+  }
 }
 
 export function NoteEditor({
   prePopulatedPatient,
   selectedCodes = { codes: 0, prevention: 0, diagnoses: 0, differentials: 0 },
   selectedCodesList = [],
-  onNoteContentChange
+  onNoteContentChange,
+  onNavigateToDrafts,
+  testOverrides
 }: NoteEditorProps) {
   const auth = useAuth()
   const [patientInputValue, setPatientInputValue] = useState(prePopulatedPatient?.patientId || "")
@@ -200,13 +206,14 @@ export function NoteEditor({
   const [transcriptionIndex, setTranscriptionIndex] = useState(-1)
   const [showFullTranscript, setShowFullTranscript] = useState(false)
 
+  const initialRecordedSeconds = testOverrides?.initialRecordedSeconds ?? 0
   const [visitStarted, setVisitStarted] = useState(false)
   const [visitLoading, setVisitLoading] = useState(false)
   const [visitError, setVisitError] = useState<string | null>(null)
   const [visitSession, setVisitSession] = useState<{ sessionId?: number; status?: string; startTime?: string; endTime?: string }>({})
-  const [hasEverStarted, setHasEverStarted] = useState(false)
+  const [hasEverStarted, setHasEverStarted] = useState(initialRecordedSeconds > 0)
   const [currentSessionTime, setCurrentSessionTime] = useState(0)
-  const [pausedTime, setPausedTime] = useState(0)
+  const [pausedTime, setPausedTime] = useState(initialRecordedSeconds)
 
   const [showFinalizationWizard, setShowFinalizationWizard] = useState(false)
   const [isFinalized, setIsFinalized] = useState(false)
@@ -214,6 +221,8 @@ export function NoteEditor({
   const [noteId, setNoteId] = useState<string | null>(null)
   const [lastAutoSaveTime, setLastAutoSaveTime] = useState<string | null>(null)
   const [autoSaveError, setAutoSaveError] = useState<string | null>(null)
+  const [saveDraftLoading, setSaveDraftLoading] = useState(false)
+  const [saveDraftError, setSaveDraftError] = useState<string | null>(null)
 
   const patientSearchAbortRef = useRef<AbortController | null>(null)
   const patientSearchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -1264,6 +1273,10 @@ export function NoteEditor({
     return undefined
   }, [visitSession?.startTime])
 
+  const totalDisplayTime = visitStarted ? currentSessionTime : pausedTime
+  const isEditorDisabled = isFinalized || !visitStarted
+  const hasRecordedTime = totalDisplayTime > 0
+
   // Calculate active issues for button state
   const activeIssues = complianceIssues.filter(issue => !issue.dismissed)
   const criticalIssues = activeIssues.filter(issue => issue.severity === 'critical')
@@ -1325,10 +1338,152 @@ export function NoteEditor({
     }
   }, [ensureNoteCreated, isFinalized])
 
-  const handleSaveDraft = () => {
-    // TODO: Save draft and navigate to drafts page
-    console.log("Saving draft and exiting...")
-  }
+  const handleSaveDraft = useCallback(async () => {
+    if (saveDraftLoading) {
+      return
+    }
+
+    if (isFinalized) {
+      toast.info("Note already finalized", {
+        description: "Finalized notes cannot be saved as drafts."
+      })
+      return
+    }
+
+    const trimmedPatientId = patientId.trim()
+    if (!trimmedPatientId) {
+      const message = "Patient ID is required before saving a draft."
+      setSaveDraftError(message)
+      toast.error("Unable to save draft", { description: message })
+      return
+    }
+
+    const previousAutoSaveTime = lastAutoSaveTime
+    const optimisticTimestamp = new Date().toISOString()
+
+    setSaveDraftLoading(true)
+    setSaveDraftError(null)
+    setLastAutoSaveTime(optimisticTimestamp)
+
+    try {
+      const content = noteContentRef.current ?? ""
+      const ensuredId = await ensureNoteCreated(content)
+      if (!ensuredId) {
+        throw new Error("Unable to determine draft identifier")
+      }
+
+      const numericId = Number(ensuredId)
+      const payload: Record<string, unknown> = {
+        note_id: Number.isFinite(numericId) ? numericId : ensuredId,
+        content
+      }
+
+      const response = await fetchWithAuth("/api/notes/auto-save", {
+        method: "PUT",
+        jsonBody: payload
+      })
+
+      if (!response.ok) {
+        let message = `Failed to save draft (${response.status})`
+        try {
+          const errorBody = await response.json()
+          const detail =
+            typeof errorBody?.message === "string" && errorBody.message.trim().length > 0
+              ? errorBody.message
+              : typeof errorBody?.detail === "string" && errorBody.detail.trim().length > 0
+                ? errorBody.detail
+                : ""
+          if (detail) {
+            message = detail
+          }
+        } catch {
+          // Ignore parsing errors
+        }
+        throw new Error(message)
+      }
+
+      await response.json().catch(() => ({}))
+
+      autoSaveLastContentRef.current = content
+      setAutoSaveError(null)
+      if (!noteId) {
+        setNoteId(String(ensuredId))
+      }
+
+      if (visitSession.sessionId) {
+        try {
+          const sessionResponse = await fetchWithAuth("/api/visits/session", {
+            method: "PUT",
+            jsonBody: { session_id: visitSession.sessionId, action: "complete" }
+          })
+          if (sessionResponse.ok) {
+            const sessionData = await sessionResponse.json().catch(() => null)
+            if (sessionData) {
+              setVisitSession(prev => ({ ...prev, ...sessionData }))
+            }
+          }
+        } catch (error) {
+          console.error("Failed to update visit session after draft save", error)
+        }
+      }
+
+      stopAudioStream()
+      setVisitStarted(false)
+      setPausedTime(currentSessionTime)
+
+      try {
+        const encounterValue = encounterId.trim()
+        await fetchWithAuth("/api/activity/log", {
+          method: "POST",
+          jsonBody: {
+            eventType: "draft_saved",
+            details: {
+              manual: true,
+              patientId: trimmedPatientId,
+              encounterId: encounterValue || undefined,
+              noteId: ensuredId,
+              source: "note-editor"
+            }
+          }
+        })
+      } catch (error) {
+        console.error("Failed to log draft save activity", error)
+      }
+
+      toast.success("Draft saved", {
+        description: "Draft saved and available in drafts overview."
+      })
+      onNavigateToDrafts?.()
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unable to save draft"
+      setSaveDraftError(message)
+      setAutoSaveError(message)
+      setLastAutoSaveTime(previousAutoSaveTime ?? null)
+      toast.error("Unable to save draft", {
+        description: message
+      })
+    } finally {
+      setSaveDraftLoading(false)
+    }
+  }, [
+    saveDraftLoading,
+    isFinalized,
+    patientId,
+    lastAutoSaveTime,
+    noteContentRef,
+    ensureNoteCreated,
+    fetchWithAuth,
+    noteId,
+    visitSession.sessionId,
+    setVisitSession,
+    stopAudioStream,
+    setVisitStarted,
+    currentSessionTime,
+    setPausedTime,
+    encounterId,
+    onNavigateToDrafts,
+    setAutoSaveError
+  ])
 
   const canStartVisit = useMemo(() => {
     if (isFinalized) {
@@ -1446,10 +1601,6 @@ export function NoteEditor({
     currentSessionTime,
     isFinalized
   ])
-
-  const totalDisplayTime = visitStarted ? currentSessionTime : pausedTime
-  const isEditorDisabled = isFinalized || !visitStarted
-  const hasRecordedTime = totalDisplayTime > 0
 
   return (
     <div className="flex flex-col flex-1">
@@ -1604,13 +1755,24 @@ export function NoteEditor({
           
           <Button
             variant="outline"
-            onClick={handleSaveDraft}
-            disabled={!hasRecordedTime}
+            onClick={() => {
+              void handleSaveDraft()
+            }}
+            disabled={!hasRecordedTime || saveDraftLoading || isFinalized}
             className="border-border text-muted-foreground hover:bg-muted hover:text-foreground"
           >
-            <Save className="w-4 h-4 mr-2" />
-            Save Draft & Exit
+            {saveDraftLoading ? (
+              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+            ) : (
+              <Save className="w-4 h-4 mr-2" />
+            )}
+            {saveDraftLoading ? "Saving Draft…" : "Save Draft & Exit"}
           </Button>
+          {saveDraftError && (
+            <p className="text-xs text-destructive" role="alert">
+              {saveDraftError}
+            </p>
+          )}
           <div className="text-xs text-muted-foreground">
             {lastAutoSaveTime
               ? `Auto-saved ${new Date(lastAutoSaveTime).toLocaleTimeString()}`

--- a/revenuepilot-frontend/src/components/__tests__/NoteEditor.saveDraft.test.tsx
+++ b/revenuepilot-frontend/src/components/__tests__/NoteEditor.saveDraft.test.tsx
@@ -1,0 +1,297 @@
+import "../../test/setupDom"
+import "@testing-library/jest-dom/vitest"
+import { fireEvent, render, screen, waitFor, cleanup } from "@testing-library/react"
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest"
+
+const {
+  toastSuccess,
+  toastError,
+  toastInfo,
+  fetchMock,
+  fetchJsonMock
+} = vi.hoisted(() => {
+  return {
+    toastSuccess: vi.fn(),
+    toastError: vi.fn(),
+    toastInfo: vi.fn(),
+    fetchMock: vi.fn<
+      [RequestInfo | URL, Record<string, any> | undefined],
+      Promise<Response>
+    >(),
+    fetchJsonMock: vi.fn<
+      [RequestInfo | URL, Record<string, any> | undefined],
+      Promise<any>
+    >()
+  }
+})
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: toastSuccess,
+    error: toastError,
+    info: toastInfo
+  }
+}))
+
+vi.mock("../RichTextEditor", () => ({
+  RichTextEditor: () => <div data-testid="rich-text-editor" />
+}))
+
+vi.mock("../BeautifiedView", () => ({
+  BeautifiedView: () => <div data-testid="beautified-view" />
+}))
+
+vi.mock("../FinalizationWizardAdapter", () => ({
+  FinalizationWizardAdapter: () => null
+}))
+
+vi.mock("lucide-react", () => ({
+  CheckCircle: () => null,
+  Save: () => null,
+  Play: () => null,
+  Square: () => null,
+  Clock: () => null,
+  Mic: () => null,
+  MicOff: () => null,
+  AlertTriangle: () => null,
+  Loader2: () => null,
+  XIcon: () => null
+}))
+
+vi.mock("../../contexts/AuthContext", () => ({
+  useAuth: () => ({
+    user: { id: "user-1", specialty: "Cardiology" },
+    status: "authenticated",
+    checking: false,
+    hasPermission: () => true
+  })
+}))
+
+import { NoteEditor } from "../NoteEditor"
+
+vi.mock("../../lib/api", async () => {
+  const actual = await vi.importActual<typeof import("../../lib/api")>("../../lib/api")
+  return {
+    ...actual,
+    apiFetch: (input: RequestInfo | URL, init?: Record<string, any>) => fetchMock(input, init),
+    apiFetchJson: (input: RequestInfo | URL, init?: Record<string, any>) => fetchJsonMock(input, init),
+    resolveWebsocketUrl: () => "ws://localhost/api/transcribe/stream",
+    getStoredToken: () => "test-token"
+  }
+})
+
+class MockMediaRecorder {
+  public ondataavailable: ((event: any) => void) | null = null
+  public onstop: (() => void) | null = null
+  public state: "inactive" | "recording" = "inactive"
+  constructor(private readonly stream: any) {
+    this.stream = stream
+  }
+  start() {
+    this.state = "recording"
+  }
+  stop() {
+    this.state = "inactive"
+    this.onstop?.()
+  }
+}
+
+class MockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  static CLOSED = 3
+  readyState = MockWebSocket.OPEN
+  onopen: (() => void) | null = null
+  onclose: (() => void) | null = null
+  onerror: (() => void) | null = null
+  onmessage: ((event: any) => void) | null = null
+  constructor() {
+    setTimeout(() => {
+      this.onopen?.()
+    }, 0)
+  }
+  send() {}
+  close() {
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.()
+  }
+}
+
+const mediaDevices = {
+  getUserMedia: vi.fn(async () => ({
+    getTracks: () => []
+  }))
+}
+
+Object.defineProperty(globalThis.navigator, "mediaDevices", {
+  value: mediaDevices,
+  configurable: true
+})
+
+Object.defineProperty(globalThis, "MediaRecorder", {
+  value: MockMediaRecorder,
+  configurable: true
+})
+
+Object.defineProperty(globalThis, "WebSocket", {
+  value: MockWebSocket,
+  configurable: true
+})
+
+let autoSaveShouldFail = false
+
+const resolveUrl = (input: RequestInfo | URL): string => {
+  const raw = typeof input === "string" ? input : input instanceof URL ? input.toString() : (input as Request).url
+  if (!raw) return ""
+  return raw.replace(/^https?:\/\/[^/]+/i, "")
+}
+
+const defaultFetchImplementation = async (input: RequestInfo | URL, init: Record<string, any> = {}) => {
+  const url = resolveUrl(input)
+  const method = (init.method ?? "GET").toUpperCase()
+
+  if (url.startsWith("/api/patients/search")) {
+    return new Response(JSON.stringify({ patients: [], externalPatients: [] }), { status: 200 })
+  }
+
+  if (url.startsWith("/api/patients/")) {
+    return new Response(JSON.stringify({ demographics: {} }), { status: 200 })
+  }
+
+  if (url.startsWith("/api/encounters/validate/")) {
+    return new Response(
+      JSON.stringify({
+        valid: true,
+        encounter: {
+          encounterId: 1001,
+          patientId: "PT-1001",
+          patient: { patientId: "PT-1001" },
+          date: "2024-03-14",
+          type: "Consult",
+          provider: "Dr. Example"
+        }
+      }),
+      { status: 200 }
+    )
+  }
+
+  if (url === "/api/visits/session" && method === "POST") {
+    return new Response(
+      JSON.stringify({ sessionId: 42, status: "started", startTime: "2024-03-14T10:00:00Z" }),
+      { status: 200 }
+    )
+  }
+
+  if (url === "/api/visits/session" && method === "PUT") {
+    return new Response(
+      JSON.stringify({ sessionId: 42, status: init.jsonBody?.action ?? "complete", endTime: "2024-03-14T10:10:00Z" }),
+      { status: 200 }
+    )
+  }
+
+  if (url === "/api/notes/create") {
+    return new Response(JSON.stringify({ noteId: "note-123" }), { status: 200 })
+  }
+
+  if (url === "/api/notes/auto-save") {
+    if (autoSaveShouldFail) {
+      return new Response(JSON.stringify({ message: "Manual save failed" }), { status: 500 })
+    }
+    return new Response(JSON.stringify({ status: "saved", version: 2 }), { status: 200 })
+  }
+
+  if (url === "/api/activity/log" && method === "POST") {
+    return new Response(JSON.stringify({ status: "logged" }), { status: 200 })
+  }
+
+  return new Response(JSON.stringify({}), { status: 200 })
+}
+
+fetchMock.mockImplementation(defaultFetchImplementation)
+fetchJsonMock.mockImplementation(async (input: RequestInfo | URL, init?: Record<string, any>) => {
+  const response = await fetchMock(input, init)
+  const text = await response.text()
+  return text ? JSON.parse(text) : null
+})
+
+describe("NoteEditor manual draft save", () => {
+  beforeEach(() => {
+    autoSaveShouldFail = false
+    fetchMock.mockClear()
+    fetchMock.mockImplementation(defaultFetchImplementation)
+    fetchJsonMock.mockClear()
+    fetchJsonMock.mockImplementation(async (input: RequestInfo | URL, init?: Record<string, any>) => {
+      const response = await fetchMock(input, init)
+      const text = await response.text()
+      return text ? JSON.parse(text) : null
+    })
+    toastSuccess.mockReset()
+    toastError.mockReset()
+    toastInfo.mockReset()
+    mediaDevices.getUserMedia.mockClear()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  const renderComponent = (navigateSpy = vi.fn()) =>
+    render(
+      <NoteEditor
+        prePopulatedPatient={{ patientId: "PT-1001", encounterId: "1001" }}
+        selectedCodes={{ codes: 0, prevention: 0, diagnoses: 0, differentials: 0 }}
+        selectedCodesList={[]}
+        onNavigateToDrafts={navigateSpy}
+        testOverrides={{ initialRecordedSeconds: 120 }}
+      />
+    )
+
+  it("saves the draft, logs activity and navigates on success", async () => {
+    const onNavigate = vi.fn()
+    renderComponent(onNavigate)
+
+    const saveButton = await screen.findByRole("button", { name: /save draft/i })
+    expect(saveButton).toBeEnabled()
+
+    fireEvent.click(saveButton)
+
+    await waitFor(() => {
+      expect(saveButton).toBeDisabled()
+    })
+
+    await waitFor(() => {
+      expect(onNavigate).toHaveBeenCalledTimes(1)
+    })
+
+    const autoSaveCall = fetchMock.mock.calls.find(
+      ([input, init]) => resolveUrl(input).includes("/api/notes/auto-save") && (init?.method ?? "GET").toUpperCase() === "PUT"
+    )
+    expect(autoSaveCall?.[1]?.jsonBody).toMatchObject({ content: expect.any(String), note_id: expect.anything() })
+
+    const activityCall = fetchMock.mock.calls.find(
+      ([input, init]) => resolveUrl(input) === "/api/activity/log" && (init?.method ?? "GET").toUpperCase() === "POST"
+    )
+    expect(activityCall?.[1]?.jsonBody).toMatchObject({
+      eventType: "draft_saved",
+      details: expect.objectContaining({ manual: true, patientId: "PT-1001", source: "note-editor" })
+    })
+
+    expect(toastSuccess).toHaveBeenCalled()
+    expect(toastError).not.toHaveBeenCalled()
+  })
+
+  it("surfaces an error when the draft save fails", async () => {
+    autoSaveShouldFail = true
+    const onNavigate = vi.fn()
+    renderComponent(onNavigate)
+
+    const saveButton = await screen.findByRole("button", { name: /save draft/i })
+    fireEvent.click(saveButton)
+
+    const alert = await screen.findByRole("alert")
+    expect(alert).toHaveTextContent("Manual save failed")
+
+    expect(onNavigate).not.toHaveBeenCalled()
+    expect(toastError).toHaveBeenCalled()
+  })
+})

--- a/revenuepilot-frontend/src/test/setupDom.ts
+++ b/revenuepilot-frontend/src/test/setupDom.ts
@@ -1,0 +1,8 @@
+import { JSDOM } from "jsdom"
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>")
+;(globalThis as any).window = dom.window
+;(globalThis as any).document = dom.window.document
+;(globalThis as any).navigator = dom.window.navigator
+;(globalThis as any).HTMLElement = dom.window.HTMLElement
+;(globalThis as any).Event = dom.window.Event

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@adobe/css-tools@npm:^4.4.0":
+  version: 4.4.4
+  resolution: "@adobe/css-tools@npm:4.4.4"
+  checksum: 10c0/8f3e6cfaa5e6286e6f05de01d91d060425be2ebaef490881f5fe6da8bbdb336835c5d373ea337b0c3b0a1af4be048ba18780f0f6021d30809b4545922a7e13d9
+  languageName: node
+  linkType: hard
+
 "@alloc/quick-lru@npm:^5.2.0":
   version: 5.2.0
   resolution: "@alloc/quick-lru@npm:5.2.0"
@@ -42,7 +49,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.27.1":
+"@babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/code-frame@npm:7.27.1"
   dependencies:
@@ -2457,6 +2464,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/dom@npm:^10.4.1":
+  version: 10.4.1
+  resolution: "@testing-library/dom@npm:10.4.1"
+  dependencies:
+    "@babel/code-frame": "npm:^7.10.4"
+    "@babel/runtime": "npm:^7.12.5"
+    "@types/aria-query": "npm:^5.0.1"
+    aria-query: "npm:5.3.0"
+    dom-accessibility-api: "npm:^0.5.9"
+    lz-string: "npm:^1.5.0"
+    picocolors: "npm:1.1.1"
+    pretty-format: "npm:^27.0.2"
+  checksum: 10c0/19ce048012d395ad0468b0dbcc4d0911f6f9e39464d7a8464a587b29707eed5482000dad728f5acc4ed314d2f4d54f34982999a114d2404f36d048278db815b1
+  languageName: node
+  linkType: hard
+
+"@testing-library/jest-dom@npm:^6.8.0":
+  version: 6.8.0
+  resolution: "@testing-library/jest-dom@npm:6.8.0"
+  dependencies:
+    "@adobe/css-tools": "npm:^4.4.0"
+    aria-query: "npm:^5.0.0"
+    css.escape: "npm:^1.5.1"
+    dom-accessibility-api: "npm:^0.6.3"
+    picocolors: "npm:^1.1.1"
+    redent: "npm:^3.0.0"
+  checksum: 10c0/4c5b8b433e0339e0399b940ae901a99ae00f1d5ffb7cbb295460b2c44aaad0bc7befcca7b06ceed7aa68a524970077468046c9fe52836ee26f45b807c80a7ff1
+  languageName: node
+  linkType: hard
+
 "@testing-library/react@npm:^16.3.0":
   version: 16.3.0
   resolution: "@testing-library/react@npm:16.3.0"
@@ -2481,6 +2518,13 @@ __metadata:
   version: 2.0.0
   resolution: "@tootallnate/once@npm:2.0.0"
   checksum: 10c0/073bfa548026b1ebaf1659eb8961e526be22fa77139b10d60e712f46d2f0f05f4e6c8bec62a087d41088ee9e29faa7f54838568e475ab2f776171003c3920858
+  languageName: node
+  linkType: hard
+
+"@types/aria-query@npm:^5.0.1":
+  version: 5.0.4
+  resolution: "@types/aria-query@npm:5.0.4"
+  checksum: 10c0/dc667bc6a3acc7bba2bccf8c23d56cb1f2f4defaa704cfef595437107efaa972d3b3db9ec1d66bc2711bfc35086821edd32c302bffab36f2e79b97f312069f08
   languageName: node
   linkType: hard
 
@@ -3132,6 +3176,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-styles@npm:^5.0.0":
+  version: 5.2.0
+  resolution: "ansi-styles@npm:5.2.0"
+  checksum: 10c0/9c4ca80eb3c2fb7b33841c210d2f20807f40865d27008d7c3f707b7f95cab7d67462a565e2388ac3285b71cb3d9bb2173de8da37c57692a362885ec34d6e27df
+  languageName: node
+  linkType: hard
+
 "ansi-styles@npm:^6.1.0":
   version: 6.2.3
   resolution: "ansi-styles@npm:6.2.3"
@@ -3228,6 +3279,22 @@ __metadata:
   dependencies:
     tslib: "npm:^2.0.0"
   checksum: 10c0/7720cb539497a9f760f68f98a4b30f22c6767aa0e72fa7d58279f7c164e258fc38b2699828f8de881aab0fc8e9c56d1313a3f1a965046fc0381a554dbc72b54a
+  languageName: node
+  linkType: hard
+
+"aria-query@npm:5.3.0":
+  version: 5.3.0
+  resolution: "aria-query@npm:5.3.0"
+  dependencies:
+    dequal: "npm:^2.0.3"
+  checksum: 10c0/2bff0d4eba5852a9dd578ecf47eaef0e82cc52569b48469b0aac2db5145db0b17b7a58d9e01237706d1e14b7a1b0ac9b78e9c97027ad97679dd8f91b85da1469
+  languageName: node
+  linkType: hard
+
+"aria-query@npm:^5.0.0":
+  version: 5.3.2
+  resolution: "aria-query@npm:5.3.2"
+  checksum: 10c0/003c7e3e2cff5540bf7a7893775fc614de82b0c5dde8ae823d47b7a28a9d4da1f7ed85f340bdb93d5649caa927755f0e31ecc7ab63edfdfc00c8ef07e505e03e
   languageName: node
   linkType: hard
 
@@ -4301,6 +4368,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css.escape@npm:^1.5.1":
+  version: 1.5.1
+  resolution: "css.escape@npm:1.5.1"
+  checksum: 10c0/5e09035e5bf6c2c422b40c6df2eb1529657a17df37fda5d0433d722609527ab98090baf25b13970ca754079a0f3161dd3dfc0e743563ded8cfa0749d861c1525
+  languageName: node
+  linkType: hard
+
 "cssesc@npm:^3.0.0":
   version: 3.0.0
   resolution: "cssesc@npm:3.0.0"
@@ -4620,6 +4694,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dequal@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "dequal@npm:2.0.3"
+  checksum: 10c0/f98860cdf58b64991ae10205137c0e97d384c3a4edc7f807603887b7c4b850af1224a33d88012009f150861cbee4fa2d322c4cc04b9313bee312e47f6ecaa888
+  languageName: node
+  linkType: hard
+
 "destroy@npm:1.2.0":
   version: 1.2.0
   resolution: "destroy@npm:1.2.0"
@@ -4720,6 +4801,20 @@ __metadata:
   dependencies:
     esutils: "npm:^2.0.2"
   checksum: 10c0/b6416aaff1f380bf56c3b552f31fdf7a69b45689368deca72d28636f41c16bb28ec3ebc40ace97db4c1afc0ceeb8120e8492fe0046841c94c2933b2e30a7d5ac
+  languageName: node
+  linkType: hard
+
+"dom-accessibility-api@npm:^0.5.9":
+  version: 0.5.16
+  resolution: "dom-accessibility-api@npm:0.5.16"
+  checksum: 10c0/b2c2eda4fae568977cdac27a9f0c001edf4f95a6a6191dfa611e3721db2478d1badc01db5bb4fa8a848aeee13e442a6c2a4386d65ec65a1436f24715a2f8d053
+  languageName: node
+  linkType: hard
+
+"dom-accessibility-api@npm:^0.6.3":
+  version: 0.6.3
+  resolution: "dom-accessibility-api@npm:0.6.3"
+  checksum: 10c0/10bee5aa514b2a9a37c87cd81268db607a2e933a050074abc2f6fa3da9080ebed206a320cbc123567f2c3087d22292853bdfdceaffdd4334ffe2af9510b29360
   languageName: node
   linkType: hard
 
@@ -7815,6 +7910,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lz-string@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "lz-string@npm:1.5.0"
+  bin:
+    lz-string: bin/bin.js
+  checksum: 10c0/36128e4de34791838abe979b19927c26e67201ca5acf00880377af7d765b38d1c60847e01c5ec61b1a260c48029084ab3893a3925fd6e48a04011364b089991b
+  languageName: node
+  linkType: hard
+
 "magic-string@npm:^0.30.17":
   version: 0.30.19
   resolution: "magic-string@npm:0.30.19"
@@ -8009,6 +8113,13 @@ __metadata:
   version: 3.1.0
   resolution: "mimic-response@npm:3.1.0"
   checksum: 10c0/0d6f07ce6e03e9e4445bee655202153bdb8a98d67ee8dc965ac140900d7a2688343e6b4c9a72cfc9ef2f7944dfd76eef4ab2482eb7b293a68b84916bac735362
+  languageName: node
+  linkType: hard
+
+"min-indent@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "min-indent@npm:1.0.1"
+  checksum: 10c0/7e207bd5c20401b292de291f02913230cb1163abca162044f7db1d951fa245b174dc00869d40dd9a9f32a885ad6a5f3e767ee104cf278f399cb4e92d3f582d5c
   languageName: node
   linkType: hard
 
@@ -8782,7 +8893,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:^1.1.1":
+"picocolors@npm:1.1.1, picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
   checksum: 10c0/e2e3e8170ab9d7c7421969adaa7e1b31434f789afb9b3f115f6b96d91945041ac3ceb02e9ec6fe6510ff036bcc0bf91e69a1772edc0b707e12b19c0f2d6bcf58
@@ -8960,6 +9071,17 @@ __metadata:
   bin:
     prettier: bin/prettier.cjs
   checksum: 10c0/488cb2f2b99ec13da1e50074912870217c11edaddedeadc649b1244c749d15ba94e846423d062e2c4c9ae683e2d65f754de28889ba06e697ac4f988d44f45812
+  languageName: node
+  linkType: hard
+
+"pretty-format@npm:^27.0.2":
+  version: 27.5.1
+  resolution: "pretty-format@npm:27.5.1"
+  dependencies:
+    ansi-regex: "npm:^5.0.1"
+    ansi-styles: "npm:^5.0.0"
+    react-is: "npm:^17.0.1"
+  checksum: 10c0/0cbda1031aa30c659e10921fa94e0dd3f903ecbbbe7184a729ad66f2b6e7f17891e8c7d7654c458fa4ccb1a411ffb695b4f17bbcd3fe075fabe181027c4040ed
   languageName: node
   linkType: hard
 
@@ -9214,6 +9336,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-is@npm:^17.0.1":
+  version: 17.0.2
+  resolution: "react-is@npm:17.0.2"
+  checksum: 10c0/2bdb6b93fbb1820b024b496042cce405c57e2f85e777c9aabd55f9b26d145408f9f74f5934676ffdc46f3dcff656d78413a6e43968e7b3f92eea35b3052e9053
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^18.3.1":
   version: 18.3.1
   resolution: "react-is@npm:18.3.1"
@@ -9424,6 +9553,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"redent@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "redent@npm:3.0.0"
+  dependencies:
+    indent-string: "npm:^4.0.0"
+    strip-indent: "npm:^3.0.0"
+  checksum: 10c0/d64a6b5c0b50eb3ddce3ab770f866658a2b9998c678f797919ceb1b586bab9259b311407280bd80b804e2a7c7539b19238ae6a2a20c843f1a7fcff21d48c2eae
+  languageName: node
+  linkType: hard
+
 "reflect.getprototypeof@npm:^1.0.6, reflect.getprototypeof@npm:^1.0.9":
   version: 1.0.10
   resolution: "reflect.getprototypeof@npm:1.0.10"
@@ -9616,6 +9755,8 @@ __metadata:
   resolution: "revenuepilot-app@workspace:."
   dependencies:
     "@playwright/test": "npm:^1.54.2"
+    "@testing-library/dom": "npm:^10.4.1"
+    "@testing-library/jest-dom": "npm:^6.8.0"
     "@testing-library/react": "npm:^16.3.0"
     "@vitejs/plugin-react": "npm:^5.0.0"
     "@vitest/coverage-v8": "npm:^3.2.4"
@@ -10410,6 +10551,15 @@ __metadata:
   dependencies:
     ansi-regex: "npm:^6.0.1"
   checksum: 10c0/0d6d7a023de33368fd042aab0bf48f4f4077abdfd60e5393e73c7c411e85e1b3a83507c11af2e656188511475776215df9ca589b4da2295c9455cc399ce1858b
+  languageName: node
+  linkType: hard
+
+"strip-indent@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "strip-indent@npm:3.0.0"
+  dependencies:
+    min-indent: "npm:^1.0.0"
+  checksum: 10c0/ae0deaf41c8d1001c5d4fbe16cb553865c1863da4fae036683b474fa926af9fc121e155cb3fc57a68262b2ae7d5b8420aa752c97a6428c315d00efe2a3875679
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- wire the note editor's manual draft save to the auto-save endpoint with optimistic state, errors, and draft navigation
- propagate the drafts navigation callback from the protected app shell into the note editor
- add jsdom setup and new Vitest coverage for successful and failing manual draft saves

## Testing
- npm test -- NoteEditor.saveDraft.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cde0a5fa7883249d6d89c5f41b5aaf