### PR TITLE
Align finalization workflow contracts and add QA assets

### DIFF
--- a/docs/finalization_workflow_collection.postman_collection.json
+++ b/docs/finalization_workflow_collection.postman_collection.json
@@ -1,0 +1,146 @@
+{
+  "info": {
+    "name": "Finalization Workflow QA",
+    "_postman_id": "b8f4c546-4aa0-4b9d-91d4-9b1f8a8cf52d",
+    "description": "Regression collection for the six-step finalization workflow covering session creation, note validation, attestation, and dispatch.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Create Workflow Session",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{authToken}}"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/v1/workflow/sessions",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "v1", "workflow", "sessions"]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"encounterId\": \"{{encounterId}}\",\n  \"patientId\": \"{{patientId}}\",\n  \"noteId\": \"{{noteId}}\",\n  \"noteContent\": \"Clinical note text...\",\n  \"patientMetadata\": {\n    \"name\": \"{{providerName}}\",\n    \"providerName\": \"{{providerName}}\"\n  },\n  \"selectedCodes\": [\n    { \"code\": \"99213\", \"type\": \"CPT\", \"category\": \"procedure\" },\n    { \"code\": \"E11.9\", \"type\": \"ICD-10\", \"category\": \"diagnosis\" }\n  ],\n  \"complianceIssues\": [\n    { \"id\": \"comp-1\", \"title\": \"Confirm medication adherence\", \"severity\": \"warning\" }\n  ]\n}"
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "const payload = pm.response.json();",
+              "const data = payload.data || payload;",
+              "if (data.sessionId) { pm.collectionVariables.set('sessionId', data.sessionId); }",
+              "if (data.encounterId) { pm.collectionVariables.set('encounterId', data.encounterId); }"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "Update Note Content",
+      "request": {
+        "method": "PUT",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{authToken}}"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/v1/notes/{{encounterId}}/content",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "v1", "notes", "{{encounterId}}", "content"]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"sessionId\": \"{{sessionId}}\",\n  \"encounterId\": \"{{encounterId}}\",\n  \"noteId\": \"{{noteId}}\",\n  \"content\": \"Updated clinical note with > 20 words and supporting documentation.\",\n  \"codes\": [\"99213\"],\n  \"prevention\": [\"Lifestyle counseling provided\"],\n  \"diagnoses\": [\"E11.9\"],\n  \"differentials\": [\"I10\"],\n  \"compliance\": [\"Documentation complete\"]\n}"
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "const payload = pm.response.json();",
+              "const data = payload.data || payload;",
+              "if (data.validation) { pm.collectionVariables.set('lastValidation', JSON.stringify(data.validation)); }"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "Submit Attestation",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{authToken}}"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/v1/workflow/{{sessionId}}/step5/attest",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "v1", "workflow", "{{sessionId}}", "step5", "attest"]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"encounterId\": \"{{encounterId}}\",\n  \"sessionId\": \"{{sessionId}}\",\n  \"billing_validation\": {\n    \"codes_validated\": true,\n    \"documentation_level_verified\": true,\n    \"medical_necessity_confirmed\": true,\n    \"billing_compliance_checked\": true,\n    \"estimated_reimbursement\": 75.0,\n    \"payer_specific_requirements\": []\n  },\n  \"attestation\": {\n    \"physician_attestation\": true,\n    \"attestation_text\": \"Reviewed and verified\",\n    \"attestation_timestamp\": \"2024-04-01T12:00:00Z\",\n    \"attestation_ip_address\": \"203.0.113.1\",\n    \"digital_signature\": \"sig-123\",\n    \"attestedBy\": \"{{providerName}}\"\n  },\n  \"compliance_checks\": [\n    {\n      \"check_type\": \"documentation_standards\",\n      \"status\": \"pass\",\n      \"description\": \"All documentation present\",\n      \"required_actions\": []\n    }\n  ],\n  \"billing_summary\": {\n    \"primary_diagnosis\": \"E11.9\",\n    \"secondary_diagnoses\": [\"I10\"],\n    \"procedures\": [\"99213\"],\n    \"evaluation_management_level\": \"99213\",\n    \"total_rvu\": 2.0,\n    \"estimated_payment\": 75.0,\n    \"modifier_codes\": [\"25\"]\n  }\n}"
+        }
+      }
+    },
+    {
+      "name": "Dispatch Finalized Note",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{authToken}}"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/v1/workflow/{{sessionId}}/step6/dispatch",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "v1", "workflow", "{{sessionId}}", "step6", "dispatch"]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"encounterId\": \"{{encounterId}}\",\n  \"sessionId\": \"{{sessionId}}\",\n  \"destination\": \"ehr\",\n  \"deliveryMethod\": \"wizard\",\n  \"final_review\": {\n    \"all_steps_completed\": true,\n    \"physician_final_approval\": true,\n    \"quality_review_passed\": true,\n    \"compliance_verified\": true,\n    \"ready_for_dispatch\": true\n  },\n  \"dispatch_options\": {\n    \"send_to_emr\": true,\n    \"generate_patient_summary\": false,\n    \"schedule_followup\": false,\n    \"send_to_billing\": true,\n    \"notify_referrals\": false\n  },\n  \"dispatch_status\": {\n    \"dispatch_initiated\": true,\n    \"dispatch_completed\": true,\n    \"dispatch_timestamp\": \"2024-04-01T12:05:00Z\",\n    \"dispatch_confirmation_number\": \"CONF123\",\n    \"dispatch_errors\": []\n  },\n  \"post_dispatch_actions\": [\n    {\n      \"action_type\": \"billing_submission\",\n      \"status\": \"completed\",\n      \"scheduled_time\": \"2024-04-01T12:06:00Z\",\n      \"completion_time\": \"2024-04-01T12:07:00Z\",\n      \"retry_count\": 0\n    }\n  ]\n}"
+        }
+      }
+    }
+  ],
+  "variable": [
+    { "key": "baseUrl", "value": "http://localhost:8000" },
+    { "key": "authToken", "value": "" },
+    { "key": "sessionId", "value": "" },
+    { "key": "encounterId", "value": "encounter-contract" },
+    { "key": "patientId", "value": "patient-contract" },
+    { "key": "noteId", "value": "note-contract" },
+    { "key": "providerName", "value": "Dr. Quinn" }
+  ]
+}

--- a/docs/finalization_workflow_regression.md
+++ b/docs/finalization_workflow_regression.md
@@ -1,0 +1,156 @@
+# Finalization Workflow Regression Guide
+
+This guide describes how to validate the six-step finalization workflow end-to-end after the request/response contract updates for sessions, attestation, and dispatch.
+
+## ✅ Automated Regression
+
+Run the focused workflow tests from the repository root:
+
+```bash
+pytest tests/test_workflow_api.py -k "workflow or finalization"
+```
+
+This suite exercises session creation, note validation, attestation, dispatch, and verifies the normalized session payload matches the specification (including billing validation, attestation details, dispatch metadata, and final results). The new `test_finalization_workflow_roundtrip_matches_spec` case drives the entire six-step workflow with spec-compliant request bodies to ensure the backend serializers stay in lockstep with the adapter. The coverage report confirms that both lifecycle and contract flows were executed.
+
+## 🧪 Manual API QA Script
+
+Use the following ordered script (also encoded in the accompanying Postman collection) against a test environment. Replace placeholder values in `<>` with your data.
+
+1. **Create workflow session**  
+   `POST /api/v1/workflow/sessions`
+   ```json
+   {
+     "encounterId": "<encounter-id>",
+     "patientId": "<patient-id>",
+     "noteId": "<note-id>",
+     "noteContent": "Clinical note text...",
+     "patientMetadata": {
+       "name": "Dr. Quinn",
+       "providerName": "Dr. Quinn"
+     },
+     "selectedCodes": [
+       { "code": "99213", "type": "CPT", "category": "procedure" },
+       { "code": "E11.9", "type": "ICD-10", "category": "diagnosis" }
+     ],
+     "complianceIssues": [
+       { "id": "comp-1", "title": "Confirm medication adherence", "severity": "warning" }
+     ]
+   }
+   ```
+   *Verify:* response includes `sessionId`, normalized `stepStates`, and seeded reimbursement summary.
+
+2. **Update note content & capture validation**  
+   `PUT /api/v1/notes/<encounter-id>/content`
+   ```json
+   {
+     "sessionId": "<session-id>",
+     "encounterId": "<encounter-id>",
+     "noteId": "<note-id>",
+     "content": "Updated clinical note with > 20 words and supporting documentation.",
+     "codes": ["99213"],
+     "prevention": ["Lifestyle counseling provided"],
+     "diagnoses": ["E11.9"],
+     "differentials": ["I10"],
+     "compliance": ["Documentation complete"]
+   }
+   ```
+   *Verify:* `validation.canFinalize` is `true` and `session.lastValidation` mirrors the response.
+
+3. **Submit attestation**  
+   `POST /api/v1/workflow/<session-id>/step5/attest`
+   ```json
+   {
+     "encounterId": "<encounter-id>",
+     "sessionId": "<session-id>",
+     "billing_validation": {
+       "codes_validated": true,
+       "documentation_level_verified": true,
+       "medical_necessity_confirmed": true,
+       "billing_compliance_checked": true,
+       "estimated_reimbursement": 75.0,
+       "payer_specific_requirements": []
+     },
+     "attestation": {
+       "physician_attestation": true,
+       "attestation_text": "Reviewed and verified",
+       "attestation_timestamp": "2024-04-01T12:00:00Z",
+       "attestation_ip_address": "203.0.113.1",
+       "digital_signature": "sig-123",
+       "attestedBy": "Dr. Quinn"
+     },
+     "compliance_checks": [
+       {
+         "check_type": "documentation_standards",
+         "status": "pass",
+         "description": "All documentation present",
+         "required_actions": []
+       }
+     ],
+     "billing_summary": {
+       "primary_diagnosis": "E11.9",
+       "secondary_diagnoses": ["I10"],
+       "procedures": ["99213"],
+       "evaluation_management_level": "99213",
+       "total_rvu": 2.0,
+       "estimated_payment": 75.0,
+       "modifier_codes": ["25"]
+     }
+   }
+   ```
+   *Verify:* the session response now contains `attestation.billingValidation`, `attestation.attestation`, and `stepStates[4].status === "completed"`.
+
+4. **Dispatch finalized note**  
+   `POST /api/v1/workflow/<session-id>/step6/dispatch`
+   ```json
+   {
+     "encounterId": "<encounter-id>",
+     "sessionId": "<session-id>",
+     "destination": "ehr",
+     "deliveryMethod": "wizard",
+     "final_review": {
+       "all_steps_completed": true,
+       "physician_final_approval": true,
+       "quality_review_passed": true,
+       "compliance_verified": true,
+       "ready_for_dispatch": true
+     },
+     "dispatch_options": {
+       "send_to_emr": true,
+       "generate_patient_summary": false,
+       "schedule_followup": false,
+       "send_to_billing": true,
+       "notify_referrals": false
+     },
+     "dispatch_status": {
+       "dispatch_initiated": true,
+       "dispatch_completed": true,
+       "dispatch_timestamp": "2024-04-01T12:05:00Z",
+       "dispatch_confirmation_number": "CONF123",
+       "dispatch_errors": []
+     },
+     "post_dispatch_actions": [
+       {
+         "action_type": "billing_submission",
+         "status": "completed",
+         "scheduled_time": "2024-04-01T12:06:00Z",
+         "completion_time": "2024-04-01T12:07:00Z",
+         "retry_count": 0
+       }
+     ]
+   }
+   ```
+   *Verify:* `dispatch.dispatchStatus.dispatchCompleted` is `true`, `result.exportReady` is `true`, and reimbursement totals carry through.
+
+5. **Optional checks**  
+   - `GET /api/v1/workflow/sessions/<session-id>` to confirm persisted attestation/dispatch payloads.  
+   - `DELETE /api/v1/workflow/sessions/<session-id>` to clean up test data.
+
+## 📬 Postman Collection
+
+Import [`finalization_workflow_collection.postman_collection.json`](./finalization_workflow_collection.postman_collection.json) into Postman. The collection defines the sequence above with shared variables:
+
+- `{{baseUrl}}` – API base URL (e.g., `http://localhost:8000`).
+- `{{sessionId}}`, `{{encounterId}}`, `{{noteId}}` – populated from previous responses using Postman tests.
+- Authorization header stored as `{{authToken}}`.
+
+Use the “Run” button in the Postman Collection Runner to execute the full workflow and visually inspect each response before release.

--- a/revenuepilot-frontend/src/components/FinalizationWizardAdapter.tsx
+++ b/revenuepilot-frontend/src/components/FinalizationWizardAdapter.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import "finalization-wizard/dist/style.css"
 
@@ -103,6 +103,233 @@ const COMPLIANCE_SEVERITY_MAP: Record<string, WizardComplianceItem["severity"]> 
   info: "low"
 }
 
+const mapComplianceSeverityToStatus = (
+  severity?: string | null,
+  dismissed?: boolean | null
+): ComplianceCheckPayload["status"] => {
+  if (dismissed) {
+    return "not_applicable"
+  }
+  const normalized = typeof severity === "string" ? severity.toLowerCase() : ""
+  if (normalized === "critical" || normalized === "high") {
+    return "fail"
+  }
+  if (normalized === "warning" || normalized === "medium") {
+    return "warning"
+  }
+  if (normalized === "info" || normalized === "low") {
+    return "pass"
+  }
+  return "warning"
+}
+
+const deriveBillingValidation = (
+  validation: PreFinalizeCheckResponse | undefined,
+  reimbursementSummary: NoteContentUpdateResponsePayload["reimbursementSummary"] | undefined
+): BillingValidationPayload => {
+  const issues = validation?.issues && typeof validation.issues === "object" ? validation.issues : {}
+  const issueList = (key: string): unknown[] => {
+    const value = (issues as Record<string, unknown>)[key]
+    return Array.isArray(value) ? value : []
+  }
+
+  const estimated =
+    typeof validation?.estimatedReimbursement === "number"
+      ? validation.estimatedReimbursement
+      : typeof reimbursementSummary?.total === "number"
+        ? reimbursementSummary.total
+        : undefined
+
+  return {
+    codesValidated: issueList("codes").length === 0,
+    documentationLevelVerified: issueList("content").length === 0,
+    medicalNecessityConfirmed: issueList("compliance").length === 0,
+    billingComplianceChecked:
+      issueList("compliance").length === 0 && issueList("prevention").length === 0,
+    estimatedReimbursement: typeof estimated === "number" ? estimated : 0,
+    payerSpecificRequirements: []
+  }
+}
+
+const deriveComplianceChecks = (issues: ComplianceLike[] | undefined): ComplianceCheckPayload[] => {
+  if (!Array.isArray(issues)) {
+    return []
+  }
+
+  return issues
+    .map(issue => {
+      if (!issue) return null
+      const description =
+        typeof issue.description === "string" && issue.description.trim().length > 0
+          ? issue.description.trim()
+          : typeof issue.details === "string" && issue.details.trim().length > 0
+            ? issue.details.trim()
+            : typeof issue.title === "string"
+              ? issue.title.trim()
+              : undefined
+      const requiredActions: string[] = []
+      if (typeof issue.details === "string" && issue.details.trim().length > 0) {
+        requiredActions.push(issue.details.trim())
+      }
+      if (Array.isArray(issue.gaps)) {
+        issue.gaps.forEach(entry => {
+          if (typeof entry === "string" && entry.trim().length > 0) {
+            requiredActions.push(entry.trim())
+          }
+        })
+      }
+      return {
+        checkType:
+          typeof issue.category === "string" && issue.category.trim().length > 0
+            ? issue.category.trim()
+            : "documentation_standards",
+        status: mapComplianceSeverityToStatus(issue.severity, issue.dismissed),
+        description,
+        requiredActions
+      } satisfies ComplianceCheckPayload
+    })
+    .filter((entry): entry is ComplianceCheckPayload => Boolean(entry))
+}
+
+const deriveBillingSummary = (
+  codes: SessionCodeLike[] | undefined,
+  reimbursementSummary: NoteContentUpdateResponsePayload["reimbursementSummary"] | undefined
+): BillingSummaryPayload => {
+  const list = Array.isArray(codes) ? codes : []
+  const diagnoses: string[] = []
+  const procedures: string[] = []
+  const modifierCodes: string[] = []
+  let totalRvu = 0
+
+  list.forEach(item => {
+    if (!item) return
+    const codeValue = sanitizeString(item.code)
+    const category = sanitizeString(item.category)
+    if (category?.toLowerCase().includes("diagnos") || category?.toLowerCase().includes("differential")) {
+      if (codeValue) {
+        diagnoses.push(codeValue)
+      }
+    } else if (category?.toLowerCase().includes("procedure") || category?.toLowerCase().includes("code")) {
+      if (codeValue) {
+        procedures.push(codeValue)
+      }
+    } else if (codeValue && diagnoses.length === 0) {
+      diagnoses.push(codeValue)
+    }
+
+    const rawModifiers = Array.isArray((item as Record<string, unknown>).modifiers)
+      ? ((item as Record<string, unknown>).modifiers as unknown[])
+      : Array.isArray((item as Record<string, unknown>).modifierCodes)
+        ? ((item as Record<string, unknown>).modifierCodes as unknown[])
+        : []
+    rawModifiers.forEach(modifier => {
+      if (typeof modifier === "string" && modifier.trim().length > 0) {
+        modifierCodes.push(modifier.trim())
+      }
+    })
+
+    const rvuValue = (item as Record<string, unknown>).rvu
+    if (typeof rvuValue === "number" && Number.isFinite(rvuValue)) {
+      totalRvu += rvuValue
+    } else if (typeof rvuValue === "string") {
+      const parsed = Number(rvuValue)
+      if (Number.isFinite(parsed)) {
+        totalRvu += parsed
+      }
+    }
+  })
+
+  const estimatedPayment =
+    typeof reimbursementSummary?.total === "number" ? reimbursementSummary.total : undefined
+
+  return {
+    primaryDiagnosis: diagnoses[0],
+    secondaryDiagnoses: diagnoses.slice(1),
+    procedures,
+    evaluationManagementLevel: procedures[0] ?? undefined,
+    totalRvu: totalRvu > 0 ? totalRvu : 0,
+    estimatedPayment: typeof estimatedPayment === "number" ? estimatedPayment : 0,
+    modifierCodes
+  }
+}
+
+const deriveFinalReview = (session?: WorkflowSessionResponsePayload | null): FinalReviewPayload => {
+  const stepsArray: WorkflowStepStateLike[] = Array.isArray(session?.stepStates)
+    ? (session?.stepStates as WorkflowStepStateLike[])
+    : session?.stepStates && typeof session.stepStates === "object"
+      ? (Object.values(session.stepStates) as WorkflowStepStateLike[])
+      : []
+
+  const allStepsCompleted = stepsArray.every(
+    step => step && typeof step === "object" && step.status === "completed"
+  )
+  const hasBlocking = Array.isArray(session?.blockingIssues) && session.blockingIssues.length > 0
+
+  return {
+    allStepsCompleted,
+    physicianFinalApproval: true,
+    qualityReviewPassed: !hasBlocking,
+    complianceVerified: !hasBlocking,
+    readyForDispatch: allStepsCompleted && !hasBlocking
+  }
+}
+
+const deriveDispatchOptions = (existing?: WorkflowDispatchPayload): DispatchOptionsPayload => {
+  const base = existing?.dispatchOptions ?? {}
+  return {
+    sendToEmr: typeof base.sendToEmr === "boolean" ? base.sendToEmr : true,
+    generatePatientSummary:
+      typeof base.generatePatientSummary === "boolean" ? base.generatePatientSummary : false,
+    scheduleFollowup:
+      typeof base.scheduleFollowup === "boolean" ? base.scheduleFollowup : false,
+    sendToBilling: typeof base.sendToBilling === "boolean" ? base.sendToBilling : true,
+    notifyReferrals: typeof base.notifyReferrals === "boolean" ? base.notifyReferrals : false
+  }
+}
+
+const deriveDispatchStatus = (
+  timestamp: string,
+  existing?: WorkflowDispatchPayload
+): DispatchStatusPayload => {
+  const base = existing?.dispatchStatus ?? {}
+  const errors = Array.isArray(base.dispatchErrors)
+    ? base.dispatchErrors.filter(error => typeof error === "string" && error.trim().length > 0)
+    : []
+  return {
+    dispatchInitiated:
+      typeof base.dispatchInitiated === "boolean" ? base.dispatchInitiated : true,
+    dispatchCompleted:
+      typeof base.dispatchCompleted === "boolean" ? base.dispatchCompleted : true,
+    dispatchTimestamp: base.dispatchTimestamp ?? timestamp,
+    dispatchConfirmationNumber: sanitizeString(base.dispatchConfirmationNumber ?? undefined),
+    dispatchErrors: errors
+  }
+}
+
+const derivePostDispatchActions = (
+  existing?: WorkflowDispatchPayload
+): PostDispatchActionPayload[] => {
+  if (!Array.isArray(existing?.postDispatchActions)) {
+    return []
+  }
+  return existing!.postDispatchActions!
+    .map(action => {
+      if (!action) return null
+      return {
+        actionType: sanitizeString(action.actionType ?? undefined),
+        status: sanitizeString(action.status ?? undefined),
+        scheduledTime: sanitizeString(action.scheduledTime ?? undefined),
+        completionTime: sanitizeString(action.completionTime ?? undefined),
+        errorMessage: sanitizeString(action.errorMessage ?? undefined),
+        retryCount:
+          typeof action.retryCount === "number" && Number.isFinite(action.retryCount)
+            ? action.retryCount
+            : 0
+      }
+    })
+    .filter((entry): entry is PostDispatchActionPayload => Boolean(entry))
+}
+
 interface WorkflowStepStateLike {
   step?: number | string | null
   status?: string | null
@@ -130,6 +357,9 @@ interface WorkflowSessionResponsePayload {
   sessionProgress?: Record<string, unknown>
   createdAt?: string | null
   updatedAt?: string | null
+  attestation?: WorkflowAttestationPayload
+  dispatch?: WorkflowDispatchPayload
+  lastValidation?: Record<string, unknown>
 }
 
 interface NoteContentUpdateResponsePayload {
@@ -153,6 +383,202 @@ interface DispatchResponsePayload {
   result: FinalizeResult
 }
 
+interface PayerRequirementPayload {
+  payerName?: string | null
+  requirementType?: string | null
+  description?: string | null
+  isMet?: boolean | null
+  missingElements?: string[]
+}
+
+interface BillingValidationPayload {
+  codesValidated: boolean
+  documentationLevelVerified: boolean
+  medicalNecessityConfirmed: boolean
+  billingComplianceChecked: boolean
+  estimatedReimbursement?: number
+  payerSpecificRequirements?: PayerRequirementPayload[]
+}
+
+interface ComplianceCheckPayload {
+  checkType?: string | null
+  status?: "pass" | "fail" | "warning" | "not_applicable"
+  description?: string | null
+  requiredActions?: string[]
+}
+
+interface BillingSummaryPayload {
+  primaryDiagnosis?: string | null
+  secondaryDiagnoses?: string[]
+  procedures?: string[]
+  evaluationManagementLevel?: string | null
+  totalRvu?: number | null
+  estimatedPayment?: number | null
+  modifierCodes?: string[]
+}
+
+interface AttestationDetailsPayload {
+  physicianAttestation?: boolean
+  attestationText?: string | null
+  attestationTimestamp?: string | null
+  digitalSignature?: string | null
+  attestationIpAddress?: string | null
+  attestedBy?: string | null
+}
+
+interface WorkflowAttestationPayload {
+  billingValidation?: BillingValidationPayload
+  attestation?: AttestationDetailsPayload
+  complianceChecks?: ComplianceCheckPayload[]
+  billingSummary?: BillingSummaryPayload
+}
+
+interface FinalReviewPayload {
+  allStepsCompleted?: boolean
+  physicianFinalApproval?: boolean
+  qualityReviewPassed?: boolean
+  complianceVerified?: boolean
+  readyForDispatch?: boolean
+}
+
+interface DispatchOptionsPayload {
+  sendToEmr?: boolean
+  generatePatientSummary?: boolean
+  scheduleFollowup?: boolean
+  sendToBilling?: boolean
+  notifyReferrals?: boolean
+}
+
+interface DispatchStatusPayload {
+  dispatchInitiated?: boolean
+  dispatchCompleted?: boolean
+  dispatchTimestamp?: string | null
+  dispatchConfirmationNumber?: string | null
+  dispatchErrors?: string[]
+}
+
+interface PostDispatchActionPayload {
+  actionType?: string | null
+  status?: string | null
+  scheduledTime?: string | null
+  completionTime?: string | null
+  errorMessage?: string | null
+  retryCount?: number | null
+}
+
+interface WorkflowDispatchPayload {
+  destination?: string | null
+  deliveryMethod?: string | null
+  timestamp?: string | null
+  finalReview?: FinalReviewPayload
+  dispatchOptions?: DispatchOptionsPayload
+  dispatchStatus?: DispatchStatusPayload
+  postDispatchActions?: PostDispatchActionPayload[]
+}
+
+interface BackendPayerRequirementPayload {
+  payer_name?: string | null
+  requirement_type?: string | null
+  description?: string | null
+  is_met?: boolean | null
+  missing_elements: string[]
+}
+
+interface BackendBillingValidationPayload {
+  codes_validated: boolean
+  documentation_level_verified: boolean
+  medical_necessity_confirmed: boolean
+  billing_compliance_checked: boolean
+  estimated_reimbursement: number
+  payer_specific_requirements: BackendPayerRequirementPayload[]
+}
+
+interface BackendComplianceCheckPayload {
+  check_type?: string | null
+  status?: "pass" | "fail" | "warning" | "not_applicable"
+  description?: string | null
+  required_actions: string[]
+}
+
+interface BackendBillingSummaryPayload {
+  primary_diagnosis?: string | null
+  secondary_diagnoses: string[]
+  procedures: string[]
+  evaluation_management_level?: string | null
+  total_rvu: number
+  estimated_payment: number
+  modifier_codes: string[]
+}
+
+interface BackendAttestationDetailsPayload {
+  physician_attestation: boolean
+  attestation_text?: string | null
+  attestation_timestamp?: string | null
+  digital_signature?: string | null
+  attestation_ip_address?: string | null
+  attestedBy?: string | null
+}
+
+interface AttestationRequestBodyPayload {
+  encounterId: string
+  sessionId: string
+  billing_validation: BackendBillingValidationPayload
+  attestation: BackendAttestationDetailsPayload
+  compliance_checks: BackendComplianceCheckPayload[]
+  billing_summary: BackendBillingSummaryPayload
+}
+
+interface BackendFinalReviewPayload {
+  all_steps_completed: boolean
+  physician_final_approval: boolean
+  quality_review_passed: boolean
+  compliance_verified: boolean
+  ready_for_dispatch: boolean
+}
+
+interface BackendDispatchOptionsPayload {
+  send_to_emr: boolean
+  generate_patient_summary: boolean
+  schedule_followup: boolean
+  send_to_billing: boolean
+  notify_referrals: boolean
+}
+
+interface BackendDispatchStatusPayload {
+  dispatch_initiated: boolean
+  dispatch_completed: boolean
+  dispatch_timestamp?: string | null
+  dispatch_confirmation_number?: string | null
+  dispatch_errors: string[]
+}
+
+interface BackendPostDispatchActionPayload {
+  action_type?: string | null
+  status?: string | null
+  scheduled_time?: string | null
+  completion_time?: string | null
+  error_message?: string | null
+  retry_count: number
+}
+
+interface DispatchRequestBodyPayload {
+  encounterId: string
+  sessionId: string
+  destination?: string
+  deliveryMethod?: string
+  timestamp?: string
+  final_review: BackendFinalReviewPayload
+  dispatch_options: BackendDispatchOptionsPayload
+  dispatch_status: BackendDispatchStatusPayload
+  post_dispatch_actions: BackendPostDispatchActionPayload[]
+}
+
+interface DispatchContextSnapshot {
+  lastValidation?: PreFinalizeCheckResponse
+  reimbursementSummary?: NoteContentUpdateResponsePayload["reimbursementSummary"]
+  sessionAfterNoteUpdate?: WorkflowSessionResponsePayload
+}
+
 const sanitizeString = (value: unknown): string | undefined => {
   if (typeof value !== "string") {
     return undefined
@@ -160,6 +586,176 @@ const sanitizeString = (value: unknown): string | undefined => {
   const trimmed = value.trim()
   return trimmed.length > 0 ? trimmed : undefined
 }
+
+const cleanStringList = (input: unknown): string[] => {
+  if (!Array.isArray(input)) {
+    return []
+  }
+  return input
+    .map(entry => (typeof entry === "string" ? entry.trim() : ""))
+    .filter((entry): entry is string => entry.length > 0)
+}
+
+const toBackendPayerRequirement = (
+  requirement: PayerRequirementPayload | undefined
+): BackendPayerRequirementPayload => {
+  return {
+    payer_name: sanitizeString(requirement?.payerName ?? undefined) ?? undefined,
+    requirement_type: sanitizeString(requirement?.requirementType ?? undefined) ?? undefined,
+    description: sanitizeString(requirement?.description ?? undefined) ?? undefined,
+    is_met: typeof requirement?.isMet === "boolean" ? requirement.isMet : undefined,
+    missing_elements: cleanStringList(requirement?.missingElements)
+  }
+}
+
+const toBackendBillingValidation = (
+  payload: BillingValidationPayload | undefined
+): BackendBillingValidationPayload => {
+  const requirements =
+    payload?.payerSpecificRequirements?.map(entry => toBackendPayerRequirement(entry)) ?? []
+  return {
+    codes_validated: Boolean(payload?.codesValidated),
+    documentation_level_verified: Boolean(payload?.documentationLevelVerified),
+    medical_necessity_confirmed: Boolean(payload?.medicalNecessityConfirmed),
+    billing_compliance_checked: Boolean(payload?.billingComplianceChecked),
+    estimated_reimbursement:
+      typeof payload?.estimatedReimbursement === "number" && Number.isFinite(payload.estimatedReimbursement)
+        ? payload.estimatedReimbursement
+        : 0,
+    payer_specific_requirements: requirements
+  }
+}
+
+const toBackendComplianceChecks = (
+  items: ComplianceCheckPayload[] | undefined
+): BackendComplianceCheckPayload[] => {
+  if (!Array.isArray(items)) {
+    return []
+  }
+  return items.map(item => ({
+    check_type: sanitizeString(item.checkType ?? undefined) ?? undefined,
+    status: item.status ?? "warning",
+    description: sanitizeString(item.description ?? undefined) ?? undefined,
+    required_actions: cleanStringList(item.requiredActions)
+  }))
+}
+
+const toBackendBillingSummary = (
+  payload: BillingSummaryPayload | undefined
+): BackendBillingSummaryPayload => {
+  return {
+    primary_diagnosis: sanitizeString(payload?.primaryDiagnosis ?? undefined) ?? undefined,
+    secondary_diagnoses: cleanStringList(payload?.secondaryDiagnoses),
+    procedures: cleanStringList(payload?.procedures),
+    evaluation_management_level: sanitizeString(payload?.evaluationManagementLevel ?? undefined) ?? undefined,
+    total_rvu: typeof payload?.totalRvu === "number" && Number.isFinite(payload.totalRvu) ? payload.totalRvu : 0,
+    estimated_payment:
+      typeof payload?.estimatedPayment === "number" && Number.isFinite(payload.estimatedPayment)
+        ? payload.estimatedPayment
+        : 0,
+    modifier_codes: cleanStringList(payload?.modifierCodes)
+  }
+}
+
+const toBackendAttestationDetails = (
+  payload: AttestationDetailsPayload | undefined
+): BackendAttestationDetailsPayload => {
+  return {
+    physician_attestation: Boolean(payload?.physicianAttestation),
+    attestation_text: sanitizeString(payload?.attestationText ?? undefined) ?? undefined,
+    attestation_timestamp: sanitizeString(payload?.attestationTimestamp ?? undefined) ?? undefined,
+    digital_signature: sanitizeString(payload?.digitalSignature ?? undefined) ?? undefined,
+    attestation_ip_address: sanitizeString(payload?.attestationIpAddress ?? undefined) ?? undefined,
+    attestedBy: sanitizeString(payload?.attestedBy ?? undefined) ?? undefined
+  }
+}
+
+const toBackendAttestationRequest = (input: {
+  encounterId: string
+  sessionId: string
+  billingValidation: BillingValidationPayload | undefined
+  attestation: AttestationDetailsPayload | undefined
+  complianceChecks: ComplianceCheckPayload[] | undefined
+  billingSummary: BillingSummaryPayload | undefined
+}): AttestationRequestBodyPayload => {
+  return {
+    encounterId: input.encounterId,
+    sessionId: input.sessionId,
+    billing_validation: toBackendBillingValidation(input.billingValidation),
+    attestation: toBackendAttestationDetails(input.attestation),
+    compliance_checks: toBackendComplianceChecks(input.complianceChecks),
+    billing_summary: toBackendBillingSummary(input.billingSummary)
+  }
+}
+
+const toBackendFinalReview = (
+  payload: FinalReviewPayload | undefined
+): BackendFinalReviewPayload => ({
+  all_steps_completed: Boolean(payload?.allStepsCompleted),
+  physician_final_approval: Boolean(payload?.physicianFinalApproval),
+  quality_review_passed: Boolean(payload?.qualityReviewPassed),
+  compliance_verified: Boolean(payload?.complianceVerified),
+  ready_for_dispatch: Boolean(payload?.readyForDispatch)
+})
+
+const toBackendDispatchOptions = (
+  payload: DispatchOptionsPayload | undefined
+): BackendDispatchOptionsPayload => ({
+  send_to_emr: Boolean(payload?.sendToEmr),
+  generate_patient_summary: Boolean(payload?.generatePatientSummary),
+  schedule_followup: Boolean(payload?.scheduleFollowup),
+  send_to_billing: Boolean(payload?.sendToBilling),
+  notify_referrals: Boolean(payload?.notifyReferrals)
+})
+
+const toBackendDispatchStatus = (
+  payload: DispatchStatusPayload | undefined
+): BackendDispatchStatusPayload => ({
+  dispatch_initiated: payload?.dispatchInitiated !== false,
+  dispatch_completed: payload?.dispatchCompleted !== false,
+  dispatch_timestamp: sanitizeString(payload?.dispatchTimestamp ?? undefined) ?? undefined,
+  dispatch_confirmation_number: sanitizeString(payload?.dispatchConfirmationNumber ?? undefined) ?? undefined,
+  dispatch_errors: cleanStringList(payload?.dispatchErrors)
+})
+
+const toBackendPostDispatchActions = (
+  payload: PostDispatchActionPayload[] | undefined
+): BackendPostDispatchActionPayload[] => {
+  if (!Array.isArray(payload)) {
+    return []
+  }
+  return payload.map(action => ({
+    action_type: sanitizeString(action.actionType ?? undefined) ?? undefined,
+    status: sanitizeString(action.status ?? undefined) ?? undefined,
+    scheduled_time: sanitizeString(action.scheduledTime ?? undefined) ?? undefined,
+    completion_time: sanitizeString(action.completionTime ?? undefined) ?? undefined,
+    error_message: sanitizeString(action.errorMessage ?? undefined) ?? undefined,
+    retry_count:
+      typeof action.retryCount === "number" && Number.isFinite(action.retryCount) ? action.retryCount : 0
+  }))
+}
+
+const toBackendDispatchRequest = (input: {
+  encounterId: string
+  sessionId: string
+  destination?: string
+  deliveryMethod?: string
+  timestamp?: string
+  finalReview: FinalReviewPayload | undefined
+  dispatchOptions: DispatchOptionsPayload | undefined
+  dispatchStatus: DispatchStatusPayload | undefined
+  postDispatchActions: PostDispatchActionPayload[] | undefined
+}): DispatchRequestBodyPayload => ({
+  encounterId: input.encounterId,
+  sessionId: input.sessionId,
+  destination: input.destination,
+  deliveryMethod: input.deliveryMethod,
+  timestamp: input.timestamp,
+  final_review: toBackendFinalReview(input.finalReview),
+  dispatch_options: toBackendDispatchOptions(input.dispatchOptions),
+  dispatch_status: toBackendDispatchStatus(input.dispatchStatus),
+  post_dispatch_actions: toBackendPostDispatchActions(input.postDispatchActions)
+})
 
 const toWizardCodeItems = (list: SessionCodeLike[]): WizardCodeItem[] => {
   if (!Array.isArray(list)) {
@@ -281,6 +877,15 @@ export function FinalizationWizardAdapter({
 }: FinalizationWizardAdapterProps) {
   const [sessionData, setSessionData] = useState<WorkflowSessionResponsePayload | null>(null)
   const [wizardSuggestions, setWizardSuggestions] = useState<WizardCodeItem[]>([])
+  const attestationPayloadRef = useRef<AttestationRequestBodyPayload | null>(null)
+  const dispatchContextRef = useRef<DispatchContextSnapshot | null>(null)
+
+  useEffect(() => {
+    if (!isOpen) {
+      attestationPayloadRef.current = null
+      dispatchContextRef.current = null
+    }
+  }, [isOpen])
 
   const encounterId = useMemo(() => {
     const fromSession = sessionData?.encounterId
@@ -690,16 +1295,20 @@ export function FinalizationWizardAdapter({
         throw new Error("No active workflow session is available for finalization.")
       }
 
+      attestationPayloadRef.current = null
+      dispatchContextRef.current = null
+
       const trimmedNoteId = typeof noteId === "string" ? noteId.trim() : ""
       const payloadWithContext: FinalizeRequestWithContext = trimmedNoteId
         ? { ...request, noteId: trimmedNoteId }
         : request
 
-      const providerName =
+      const providerName = sanitizeString(
         sessionData?.patientMetadata && typeof sessionData.patientMetadata === "object" &&
-        typeof (sessionData.patientMetadata as Record<string, unknown>).providerName === "string"
+          typeof (sessionData.patientMetadata as Record<string, unknown>).providerName === "string"
           ? ((sessionData.patientMetadata as Record<string, unknown>).providerName as string)
           : undefined
+      )
 
       try {
         const noteResponse = await fetchWithAuth(`/api/v1/notes/${encodeURIComponent(encounterId)}/content`, {
@@ -725,6 +1334,35 @@ export function FinalizationWizardAdapter({
           reimbursementSummary: data.reimbursementSummary
         }
         onPreFinalizeResult?.(validation)
+
+        const billingValidation = deriveBillingValidation(validation, data.reimbursementSummary)
+        const complianceCheckPayload = deriveComplianceChecks(
+          Array.isArray(complianceIssues) ? complianceIssues : sessionData?.complianceIssues
+        )
+        const billingSummary = deriveBillingSummary(selectedCodesList, data.reimbursementSummary)
+        const attestationTimestamp = new Date().toISOString()
+        const attestationStatement = providerName
+          ? `Final attestation recorded by ${providerName}`
+          : "Final attestation recorded via finalization wizard"
+        const attestationDetails: AttestationDetailsPayload = {
+          physicianAttestation: true,
+          attestationText: attestationStatement,
+          attestationTimestamp,
+          attestedBy: providerName ?? undefined
+        }
+        attestationPayloadRef.current = toBackendAttestationRequest({
+          encounterId,
+          sessionId: activeSessionId,
+          billingValidation,
+          attestation: attestationDetails,
+          complianceChecks: complianceCheckPayload,
+          billingSummary
+        })
+        dispatchContextRef.current = {
+          lastValidation: validation,
+          reimbursementSummary: data.reimbursementSummary,
+          sessionAfterNoteUpdate: data.session
+        }
 
         if (!validation?.canFinalize) {
           const issueMessages: string[] = []
@@ -753,16 +1391,44 @@ export function FinalizationWizardAdapter({
         throw error
       }
 
+      let attestedSession: WorkflowSessionResponsePayload | undefined
       try {
+        const fallbackSession =
+          dispatchContextRef.current?.sessionAfterNoteUpdate ?? sessionData ?? undefined
+        const fallbackValidation = dispatchContextRef.current?.lastValidation
+        const fallbackReimbursement =
+          dispatchContextRef.current?.reimbursementSummary ??
+          (fallbackSession?.reimbursementSummary as
+            | NoteContentUpdateResponsePayload["reimbursementSummary"]
+            | undefined)
+        const fallbackCodes =
+          (Array.isArray(fallbackSession?.selectedCodes)
+            ? (fallbackSession?.selectedCodes as SessionCodeLike[])
+            : undefined) ?? selectedCodesList
+        const fallbackComplianceSource = Array.isArray(fallbackSession?.complianceIssues)
+          ? (fallbackSession?.complianceIssues as ComplianceLike[])
+          : complianceIssues
+        const attestationPayload =
+          attestationPayloadRef.current ??
+          toBackendAttestationRequest({
+            encounterId,
+            sessionId: activeSessionId,
+            billingValidation: deriveBillingValidation(fallbackValidation, fallbackReimbursement),
+            attestation: {
+              physicianAttestation: true,
+              attestationText: providerName
+                ? `Final attestation recorded by ${providerName}`
+                : "Final attestation recorded via finalization wizard",
+              attestationTimestamp: new Date().toISOString(),
+              attestedBy: providerName ?? undefined
+            },
+            complianceChecks: deriveComplianceChecks(fallbackComplianceSource),
+            billingSummary: deriveBillingSummary(fallbackCodes, fallbackReimbursement)
+          })
         const attestResponse = await fetchWithAuth(`/api/v1/workflow/${encodeURIComponent(activeSessionId)}/step5/attest`, {
           method: "POST",
           json: true,
-          body: JSON.stringify({
-            encounterId,
-            sessionId: activeSessionId,
-            attestedBy: providerName ?? undefined,
-            statement: "Attestation confirmed via finalization wizard"
-          })
+          body: JSON.stringify(attestationPayload)
         })
 
         if (!attestResponse.ok) {
@@ -770,17 +1436,27 @@ export function FinalizationWizardAdapter({
         }
 
         const attestData = (await attestResponse.json()) as WorkflowAttestationResponsePayload
-        setSessionData(attestData.session)
+        attestedSession = attestData.session
+        setSessionData(attestedSession)
+
+        const dispatchTimestamp = new Date().toISOString()
+        const sessionForDispatch = attestedSession ?? fallbackSession
+        const dispatchPayload = toBackendDispatchRequest({
+          encounterId,
+          sessionId: activeSessionId,
+          destination: "ehr",
+          deliveryMethod: "wizard",
+          timestamp: dispatchTimestamp,
+          finalReview: deriveFinalReview(sessionForDispatch),
+          dispatchOptions: deriveDispatchOptions(sessionForDispatch?.dispatch),
+          dispatchStatus: deriveDispatchStatus(dispatchTimestamp, sessionForDispatch?.dispatch),
+          postDispatchActions: derivePostDispatchActions(sessionForDispatch?.dispatch)
+        })
 
         const dispatchResponse = await fetchWithAuth(`/api/v1/workflow/${encodeURIComponent(activeSessionId)}/step6/dispatch`, {
           method: "POST",
           json: true,
-          body: JSON.stringify({
-            encounterId,
-            sessionId: activeSessionId,
-            destination: "ehr",
-            deliveryMethod: "wizard"
-          })
+          body: JSON.stringify(dispatchPayload)
         })
 
         if (!dispatchResponse.ok) {
@@ -814,7 +1490,9 @@ export function FinalizationWizardAdapter({
       noteId,
       onError,
       onPreFinalizeResult,
-      sessionData?.patientMetadata,
+      selectedCodesList,
+      complianceIssues,
+      sessionData,
       sessionData?.sessionId
     ]
   )


### PR DESCRIPTION
## Summary
- normalize workflow attestation and dispatch models to capture billing validation, compliance checks, and dispatch metadata
- update the FinalizationWizard adapter to send spec-compliant payloads and derive defaults from session state
- expand workflow contract tests and add regression documentation plus a Postman collection for end-to-end QA

## Testing
- pytest tests/test_workflow_api.py

------
https://chatgpt.com/codex/tasks/task_e_68cde0ac9de88324a0dacf776b830b01