### PR TITLE
feat(activity-log): integrate API and add tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.54.2",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@vitejs/plugin-react": "^5.0.0",
     "@vitest/coverage-v8": "^3.2.4",

--- a/revenuepilot-frontend/src/components/__tests__/ActivityLog.test.tsx
+++ b/revenuepilot-frontend/src/components/__tests__/ActivityLog.test.tsx
@@ -1,0 +1,110 @@
+import { describe, expect, it, beforeEach, vi } from "vitest"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom/vitest"
+
+import { ActivityLog } from "../ActivityLog"
+import { apiFetchJson } from "../../lib/api"
+
+vi.mock("../../lib/api", () => ({
+  apiFetchJson: vi.fn()
+}))
+
+const mockedApiFetchJson = vi.mocked(apiFetchJson)
+
+const baseProps = {
+  currentUser: {
+    id: "demo",
+    name: "Demo",
+    fullName: "Demo User",
+    role: "admin" as const,
+    specialty: "General"
+  },
+  userRole: "admin" as const
+}
+
+describe("ActivityLog", () => {
+  beforeEach(() => {
+    mockedApiFetchJson.mockReset()
+  })
+
+  it("renders activity entries returned by the API", async () => {
+    mockedApiFetchJson.mockResolvedValueOnce({
+      entries: [
+        {
+          id: 101,
+          timestamp: "2024-03-14T15:30:22Z",
+          username: "demo",
+          action: "POST /api/notes",
+          details: {
+            description: "Created new note",
+            category: "documentation",
+            severity: "success",
+            client: "10.0.0.1"
+          }
+        },
+        {
+          id: 102,
+          timestamp: "2024-03-14T15:35:10Z",
+          username: "demo",
+          action: "PATCH /api/settings",
+          details: {
+            description: "Updated preferences",
+            category: "settings",
+            severity: "info"
+          }
+        }
+      ],
+      next: null,
+      count: 2
+    })
+
+    render(<ActivityLog {...baseProps} />)
+
+    expect(await screen.findByText("Created new note")).toBeInTheDocument()
+    expect(screen.getByText("Updated preferences")).toBeInTheDocument()
+    expect(screen.getByText("2 entries")).toBeInTheDocument()
+    expect(screen.getByText("10.0.0.1")).toBeInTheDocument()
+  })
+
+  it("shows an empty state when the API returns no entries", async () => {
+    mockedApiFetchJson.mockResolvedValueOnce({ entries: [], next: null, count: 0 })
+
+    render(<ActivityLog {...baseProps} />)
+
+    expect(await screen.findByText("No activity has been recorded yet.")).toBeInTheDocument()
+  })
+
+  it("surfaces error state and allows retry", async () => {
+    mockedApiFetchJson.mockRejectedValueOnce(new Error("Server offline"))
+    mockedApiFetchJson.mockResolvedValueOnce({
+      entries: [
+        {
+          id: 301,
+          timestamp: "2024-03-15T09:00:00Z",
+          username: "demo",
+          action: "GET /api/activity/log",
+          details: {
+            description: "Manual refresh",
+            category: "system",
+            severity: "info"
+          }
+        }
+      ],
+      next: null,
+      count: 1
+    })
+
+    render(<ActivityLog {...baseProps} />)
+
+    expect(await screen.findByText("Server offline")).toBeInTheDocument()
+
+    const retryButton = screen.getByRole("button", { name: /retry/i })
+    fireEvent.click(retryButton)
+
+    expect(await screen.findByText("Manual refresh")).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.queryByText("Server offline")).not.toBeInTheDocument()
+    })
+  })
+})
+

--- a/revenuepilot-frontend/src/hooks/useActivityLog.ts
+++ b/revenuepilot-frontend/src/hooks/useActivityLog.ts
@@ -1,0 +1,452 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import type { DateRange } from "react-day-picker"
+
+import { apiFetchJson } from "../lib/api"
+
+export type ActivityCategory =
+  | "documentation"
+  | "schedule"
+  | "settings"
+  | "auth"
+  | "system"
+  | "backend"
+
+export type ActivitySeverity = "info" | "warning" | "error" | "success"
+
+export interface ActivityEntry {
+  id: string
+  timestamp: string
+  action: string
+  category: ActivityCategory
+  description: string
+  userId: string
+  userName: string
+  severity: ActivitySeverity
+  details?: Record<string, unknown>
+  ipAddress?: string
+  userAgent?: string
+}
+
+interface ApiActivityLogEntry {
+  id: number | string
+  timestamp: string
+  username?: string | null
+  action: string
+  details?: unknown
+}
+
+interface ApiActivityLogResponse {
+  entries?: ApiActivityLogEntry[]
+  next?: number | null
+  count?: number
+}
+
+const KNOWN_CATEGORIES: ActivityCategory[] = [
+  "documentation",
+  "schedule",
+  "settings",
+  "auth",
+  "system",
+  "backend"
+]
+
+const KNOWN_SEVERITIES: ActivitySeverity[] = ["info", "warning", "error", "success"]
+
+const DEFAULT_PAGE_SIZE = 200
+const MAX_PAGES = 5
+
+export interface ActivityLogFilters {
+  dateRange?: DateRange
+  category: string
+  severity: string
+  search: string
+  includeBackend: boolean
+}
+
+export interface UseActivityLogResult {
+  entries: ActivityEntry[]
+  rawEntries: ActivityEntry[]
+  loading: boolean
+  error: string | null
+  refresh: () => Promise<void>
+  lastUpdated: number | null
+}
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+const toIsoString = (value: number | string) => {
+  return typeof value === "number" ? new Date(value * 1000).toISOString() : String(value)
+}
+
+const normalizeUserName = (username?: string | null): { id: string; name: string } => {
+  if (username && username.trim().length > 0) {
+    return { id: username, name: username }
+  }
+  return { id: "system", name: "System" }
+}
+
+const pickCategory = (
+  action: string,
+  username: string | null | undefined,
+  details: Record<string, unknown> | undefined
+): ActivityCategory => {
+  const detailCategory = details?.category
+  if (typeof detailCategory === "string" && (KNOWN_CATEGORIES as string[]).includes(detailCategory)) {
+    return detailCategory as ActivityCategory
+  }
+
+  if (!username) {
+    return "backend"
+  }
+
+  const actionText = action.toLowerCase()
+  const path = typeof details?.path === "string" ? details.path.toLowerCase() : ""
+
+  if (actionText.includes("note") || actionText.includes("document")) {
+    return "documentation"
+  }
+  if (actionText.includes("schedule") || actionText.includes("appointment")) {
+    return "schedule"
+  }
+  if (actionText.includes("setting") || actionText.includes("config") || path.includes("settings")) {
+    return "settings"
+  }
+  if (
+    actionText.includes("login") ||
+    actionText.includes("logout") ||
+    actionText.includes("auth") ||
+    actionText.includes("token") ||
+    actionText.includes("register")
+  ) {
+    return "auth"
+  }
+  if (path.includes("schedule")) {
+    return "schedule"
+  }
+  if (path.includes("templates") || path.includes("settings")) {
+    return "settings"
+  }
+
+  return "system"
+}
+
+const pickSeverity = (action: string, details: Record<string, unknown> | undefined): ActivitySeverity => {
+  const detailSeverity = details?.severity
+  if (typeof detailSeverity === "string" && (KNOWN_SEVERITIES as string[]).includes(detailSeverity)) {
+    return detailSeverity as ActivitySeverity
+  }
+
+  const actionLower = action.toLowerCase()
+  const status = typeof details?.status === "string" ? details.status.toLowerCase() : ""
+
+  if (
+    actionLower.includes("fail") ||
+    actionLower.includes("error") ||
+    actionLower.includes("denied") ||
+    actionLower.includes("invalid") ||
+    status.includes("fail") ||
+    status.includes("error")
+  ) {
+    return "error"
+  }
+
+  if (actionLower.includes("warn") || status.includes("warn")) {
+    return "warning"
+  }
+
+  if (
+    actionLower.includes("success") ||
+    actionLower.includes("created") ||
+    actionLower.includes("updated") ||
+    actionLower.includes("login") ||
+    actionLower.includes("logout") ||
+    actionLower.includes("register")
+  ) {
+    return "success"
+  }
+
+  return "info"
+}
+
+const describeDetails = (action: string, details: Record<string, unknown> | undefined, fallbackUser: string) => {
+  if (!details) {
+    return action
+  }
+
+  const descriptionFields = ["description", "message", "detail", "summary"] as const
+  for (const field of descriptionFields) {
+    const value = details[field]
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value
+    }
+  }
+
+  if (typeof details.reason === "string" && details.reason.trim().length > 0) {
+    return `Reason: ${details.reason}`
+  }
+
+  const method = typeof details.method === "string" ? details.method.toUpperCase() : undefined
+  const path = typeof details.path === "string" ? details.path : undefined
+  if (method || path) {
+    return [method, path].filter(Boolean).join(" ") || action
+  }
+
+  if (typeof details.action === "string" && details.action.trim().length > 0) {
+    return details.action
+  }
+
+  if (typeof details.client === "string" && details.client.trim().length > 0) {
+    return `Request from ${details.client}`
+  }
+
+  const role = typeof details.role === "string" ? details.role : undefined
+  if (role) {
+    return `${fallbackUser} performed an action as ${role}`
+  }
+
+  return action
+}
+
+const normalizeDetails = (value: unknown): Record<string, unknown> | undefined => {
+  if (isPlainObject(value)) {
+    return value
+  }
+  return undefined
+}
+
+const mapActivityEntry = (entry: ApiActivityLogEntry): ActivityEntry => {
+  const details = normalizeDetails(entry.details)
+  const user = normalizeUserName(entry.username)
+  const category = pickCategory(entry.action, entry.username, details)
+  const severity = pickSeverity(entry.action, details)
+  const description = describeDetails(entry.action, details, user.name)
+
+  return {
+    id: String(entry.id),
+    timestamp: toIsoString(entry.timestamp),
+    action: entry.action,
+    category,
+    description,
+    userId: user.id,
+    userName: user.name,
+    severity,
+    details,
+    ipAddress: typeof details?.client === "string" ? details.client : undefined,
+    userAgent: typeof details?.userAgent === "string" ? details.userAgent : undefined
+  }
+}
+
+const fetchActivityPages = async (signal?: AbortSignal): Promise<ActivityEntry[]> => {
+  const collected: ActivityEntry[] = []
+  let cursor: number | null = null
+
+  for (let page = 0; page < MAX_PAGES; page += 1) {
+    const params = new URLSearchParams({ limit: String(DEFAULT_PAGE_SIZE) })
+    if (cursor !== null) {
+      params.set("cursor", String(cursor))
+    }
+
+    const response = await apiFetchJson<ApiActivityLogResponse>(`/api/activity/log?${params.toString()}`, {
+      signal
+    })
+
+    if (!response) {
+      break
+    }
+
+    const entries = Array.isArray(response.entries) ? response.entries : []
+    if (entries.length === 0) {
+      break
+    }
+
+    for (const rawEntry of entries) {
+      try {
+        collected.push(mapActivityEntry(rawEntry))
+      } catch {
+        // Skip malformed entries but continue processing the rest
+      }
+    }
+
+    if (response.next == null) {
+      break
+    }
+
+    if (cursor !== null && response.next === cursor) {
+      break
+    }
+
+    cursor = response.next
+  }
+
+  return collected
+}
+
+const startOfDay = (date: Date) => {
+  const copy = new Date(date)
+  copy.setHours(0, 0, 0, 0)
+  return copy
+}
+
+const endOfDay = (date: Date) => {
+  const copy = new Date(date)
+  copy.setHours(23, 59, 59, 999)
+  return copy
+}
+
+const matchesDateRange = (timestamp: string, range?: DateRange) => {
+  if (!range?.from && !range?.to) {
+    return true
+  }
+
+  const value = new Date(timestamp)
+  if (Number.isNaN(value.getTime())) {
+    return true
+  }
+
+  if (range.from && value < startOfDay(range.from)) {
+    return false
+  }
+
+  if (range.to && value > endOfDay(range.to)) {
+    return false
+  }
+
+  return true
+}
+
+const matchesSearch = (entry: ActivityEntry, term: string) => {
+  const search = term.trim().toLowerCase()
+  if (!search) {
+    return true
+  }
+
+  const haystack = [
+    entry.action,
+    entry.description,
+    entry.userName,
+    entry.category,
+    entry.severity,
+    entry.details ? JSON.stringify(entry.details) : ""
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase()
+
+  return haystack.includes(search)
+}
+
+const applyFilters = (entries: ActivityEntry[], filters: ActivityLogFilters) => {
+  return entries.filter(entry => {
+    if (!filters.includeBackend && entry.category === "backend") {
+      return false
+    }
+
+    if (filters.category !== "all" && filters.category && entry.category !== filters.category) {
+      return false
+    }
+
+    if (filters.severity !== "all" && filters.severity && entry.severity !== filters.severity) {
+      return false
+    }
+
+    if (!matchesDateRange(entry.timestamp, filters.dateRange)) {
+      return false
+    }
+
+    if (!matchesSearch(entry, filters.search)) {
+      return false
+    }
+
+    return true
+  })
+}
+
+const normalizeError = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message || "Unable to load activity log"
+  }
+  if (typeof error === "string" && error.trim().length > 0) {
+    return error
+  }
+  return "Unable to load activity log"
+}
+
+export function useActivityLog(
+  filters: ActivityLogFilters,
+  { pollIntervalMs = 60_000 }: { pollIntervalMs?: number } = {}
+): UseActivityLogResult {
+  const [rawEntries, setRawEntries] = useState<ActivityEntry[]>([])
+  const [loading, setLoading] = useState<boolean>(true)
+  const [error, setError] = useState<string | null>(null)
+  const lastUpdatedRef = useRef<number | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      abortRef.current?.abort()
+    }
+  }, [])
+
+  const loadEntries = useCallback(async () => {
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+    setLoading(true)
+
+    try {
+      const entries = await fetchActivityPages(controller.signal)
+      if (!controller.signal.aborted && mountedRef.current) {
+        setRawEntries(entries)
+        setError(null)
+        lastUpdatedRef.current = Date.now()
+      }
+    } catch (err) {
+      if (!controller.signal.aborted && mountedRef.current) {
+        setError(normalizeError(err))
+      }
+    } finally {
+      if (!controller.signal.aborted && mountedRef.current) {
+        setLoading(false)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadEntries()
+  }, [loadEntries])
+
+  useEffect(() => {
+    if (!pollIntervalMs || pollIntervalMs <= 0) {
+      return
+    }
+
+    const interval = window.setInterval(() => {
+      void loadEntries()
+    }, pollIntervalMs)
+
+    return () => {
+      window.clearInterval(interval)
+    }
+  }, [loadEntries, pollIntervalMs])
+
+  const filteredEntries = useMemo(() => applyFilters(rawEntries, filters), [rawEntries, filters])
+
+  const refresh = useCallback(async () => {
+    await loadEntries()
+  }, [loadEntries])
+
+  return {
+    entries: filteredEntries,
+    rawEntries,
+    loading,
+    error,
+    refresh,
+    lastUpdated: lastUpdatedRef.current
+  }
+}
+

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   test: {
+    environment: 'jsdom',
     exclude: [...defaultExclude, 'e2e/**'],
     coverage: {
       enabled: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@adobe/css-tools@npm:^4.4.0":
+  version: 4.4.4
+  resolution: "@adobe/css-tools@npm:4.4.4"
+  checksum: 10c0/8f3e6cfaa5e6286e6f05de01d91d060425be2ebaef490881f5fe6da8bbdb336835c5d373ea337b0c3b0a1af4be048ba18780f0f6021d30809b4545922a7e13d9
+  languageName: node
+  linkType: hard
+
 "@alloc/quick-lru@npm:^5.2.0":
   version: 5.2.0
   resolution: "@alloc/quick-lru@npm:5.2.0"
@@ -42,7 +49,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.27.1":
+"@babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/code-frame@npm:7.27.1"
   dependencies:
@@ -2457,6 +2464,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/dom@npm:^10.4.0":
+  version: 10.4.1
+  resolution: "@testing-library/dom@npm:10.4.1"
+  dependencies:
+    "@babel/code-frame": "npm:^7.10.4"
+    "@babel/runtime": "npm:^7.12.5"
+    "@types/aria-query": "npm:^5.0.1"
+    aria-query: "npm:5.3.0"
+    dom-accessibility-api: "npm:^0.5.9"
+    lz-string: "npm:^1.5.0"
+    picocolors: "npm:1.1.1"
+    pretty-format: "npm:^27.0.2"
+  checksum: 10c0/19ce048012d395ad0468b0dbcc4d0911f6f9e39464d7a8464a587b29707eed5482000dad728f5acc4ed314d2f4d54f34982999a114d2404f36d048278db815b1
+  languageName: node
+  linkType: hard
+
+"@testing-library/jest-dom@npm:^6.6.3":
+  version: 6.8.0
+  resolution: "@testing-library/jest-dom@npm:6.8.0"
+  dependencies:
+    "@adobe/css-tools": "npm:^4.4.0"
+    aria-query: "npm:^5.0.0"
+    css.escape: "npm:^1.5.1"
+    dom-accessibility-api: "npm:^0.6.3"
+    picocolors: "npm:^1.1.1"
+    redent: "npm:^3.0.0"
+  checksum: 10c0/4c5b8b433e0339e0399b940ae901a99ae00f1d5ffb7cbb295460b2c44aaad0bc7befcca7b06ceed7aa68a524970077468046c9fe52836ee26f45b807c80a7ff1
+  languageName: node
+  linkType: hard
+
 "@testing-library/react@npm:^16.3.0":
   version: 16.3.0
   resolution: "@testing-library/react@npm:16.3.0"
@@ -2481,6 +2518,13 @@ __metadata:
   version: 2.0.0
   resolution: "@tootallnate/once@npm:2.0.0"
   checksum: 10c0/073bfa548026b1ebaf1659eb8961e526be22fa77139b10d60e712f46d2f0f05f4e6c8bec62a087d41088ee9e29faa7f54838568e475ab2f776171003c3920858
+  languageName: node
+  linkType: hard
+
+"@types/aria-query@npm:^5.0.1":
+  version: 5.0.4
+  resolution: "@types/aria-query@npm:5.0.4"
+  checksum: 10c0/dc667bc6a3acc7bba2bccf8c23d56cb1f2f4defaa704cfef595437107efaa972d3b3db9ec1d66bc2711bfc35086821edd32c302bffab36f2e79b97f312069f08
   languageName: node
   linkType: hard
 
@@ -3132,6 +3176,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-styles@npm:^5.0.0":
+  version: 5.2.0
+  resolution: "ansi-styles@npm:5.2.0"
+  checksum: 10c0/9c4ca80eb3c2fb7b33841c210d2f20807f40865d27008d7c3f707b7f95cab7d67462a565e2388ac3285b71cb3d9bb2173de8da37c57692a362885ec34d6e27df
+  languageName: node
+  linkType: hard
+
 "ansi-styles@npm:^6.1.0":
   version: 6.2.3
   resolution: "ansi-styles@npm:6.2.3"
@@ -3228,6 +3279,22 @@ __metadata:
   dependencies:
     tslib: "npm:^2.0.0"
   checksum: 10c0/7720cb539497a9f760f68f98a4b30f22c6767aa0e72fa7d58279f7c164e258fc38b2699828f8de881aab0fc8e9c56d1313a3f1a965046fc0381a554dbc72b54a
+  languageName: node
+  linkType: hard
+
+"aria-query@npm:5.3.0":
+  version: 5.3.0
+  resolution: "aria-query@npm:5.3.0"
+  dependencies:
+    dequal: "npm:^2.0.3"
+  checksum: 10c0/2bff0d4eba5852a9dd578ecf47eaef0e82cc52569b48469b0aac2db5145db0b17b7a58d9e01237706d1e14b7a1b0ac9b78e9c97027ad97679dd8f91b85da1469
+  languageName: node
+  linkType: hard
+
+"aria-query@npm:^5.0.0":
+  version: 5.3.2
+  resolution: "aria-query@npm:5.3.2"
+  checksum: 10c0/003c7e3e2cff5540bf7a7893775fc614de82b0c5dde8ae823d47b7a28a9d4da1f7ed85f340bdb93d5649caa927755f0e31ecc7ab63edfdfc00c8ef07e505e03e
   languageName: node
   linkType: hard
 
@@ -4301,6 +4368,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css.escape@npm:^1.5.1":
+  version: 1.5.1
+  resolution: "css.escape@npm:1.5.1"
+  checksum: 10c0/5e09035e5bf6c2c422b40c6df2eb1529657a17df37fda5d0433d722609527ab98090baf25b13970ca754079a0f3161dd3dfc0e743563ded8cfa0749d861c1525
+  languageName: node
+  linkType: hard
+
 "cssesc@npm:^3.0.0":
   version: 3.0.0
   resolution: "cssesc@npm:3.0.0"
@@ -4620,6 +4694,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dequal@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "dequal@npm:2.0.3"
+  checksum: 10c0/f98860cdf58b64991ae10205137c0e97d384c3a4edc7f807603887b7c4b850af1224a33d88012009f150861cbee4fa2d322c4cc04b9313bee312e47f6ecaa888
+  languageName: node
+  linkType: hard
+
 "destroy@npm:1.2.0":
   version: 1.2.0
   resolution: "destroy@npm:1.2.0"
@@ -4720,6 +4801,20 @@ __metadata:
   dependencies:
     esutils: "npm:^2.0.2"
   checksum: 10c0/b6416aaff1f380bf56c3b552f31fdf7a69b45689368deca72d28636f41c16bb28ec3ebc40ace97db4c1afc0ceeb8120e8492fe0046841c94c2933b2e30a7d5ac
+  languageName: node
+  linkType: hard
+
+"dom-accessibility-api@npm:^0.5.9":
+  version: 0.5.16
+  resolution: "dom-accessibility-api@npm:0.5.16"
+  checksum: 10c0/b2c2eda4fae568977cdac27a9f0c001edf4f95a6a6191dfa611e3721db2478d1badc01db5bb4fa8a848aeee13e442a6c2a4386d65ec65a1436f24715a2f8d053
+  languageName: node
+  linkType: hard
+
+"dom-accessibility-api@npm:^0.6.3":
+  version: 0.6.3
+  resolution: "dom-accessibility-api@npm:0.6.3"
+  checksum: 10c0/10bee5aa514b2a9a37c87cd81268db607a2e933a050074abc2f6fa3da9080ebed206a320cbc123567f2c3087d22292853bdfdceaffdd4334ffe2af9510b29360
   languageName: node
   linkType: hard
 
@@ -7815,6 +7910,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lz-string@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "lz-string@npm:1.5.0"
+  bin:
+    lz-string: bin/bin.js
+  checksum: 10c0/36128e4de34791838abe979b19927c26e67201ca5acf00880377af7d765b38d1c60847e01c5ec61b1a260c48029084ab3893a3925fd6e48a04011364b089991b
+  languageName: node
+  linkType: hard
+
 "magic-string@npm:^0.30.17":
   version: 0.30.19
   resolution: "magic-string@npm:0.30.19"
@@ -8009,6 +8113,13 @@ __metadata:
   version: 3.1.0
   resolution: "mimic-response@npm:3.1.0"
   checksum: 10c0/0d6f07ce6e03e9e4445bee655202153bdb8a98d67ee8dc965ac140900d7a2688343e6b4c9a72cfc9ef2f7944dfd76eef4ab2482eb7b293a68b84916bac735362
+  languageName: node
+  linkType: hard
+
+"min-indent@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "min-indent@npm:1.0.1"
+  checksum: 10c0/7e207bd5c20401b292de291f02913230cb1163abca162044f7db1d951fa245b174dc00869d40dd9a9f32a885ad6a5f3e767ee104cf278f399cb4e92d3f582d5c
   languageName: node
   linkType: hard
 
@@ -8782,7 +8893,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:^1.1.1":
+"picocolors@npm:1.1.1, picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
   checksum: 10c0/e2e3e8170ab9d7c7421969adaa7e1b31434f789afb9b3f115f6b96d91945041ac3ceb02e9ec6fe6510ff036bcc0bf91e69a1772edc0b707e12b19c0f2d6bcf58
@@ -8960,6 +9071,17 @@ __metadata:
   bin:
     prettier: bin/prettier.cjs
   checksum: 10c0/488cb2f2b99ec13da1e50074912870217c11edaddedeadc649b1244c749d15ba94e846423d062e2c4c9ae683e2d65f754de28889ba06e697ac4f988d44f45812
+  languageName: node
+  linkType: hard
+
+"pretty-format@npm:^27.0.2":
+  version: 27.5.1
+  resolution: "pretty-format@npm:27.5.1"
+  dependencies:
+    ansi-regex: "npm:^5.0.1"
+    ansi-styles: "npm:^5.0.0"
+    react-is: "npm:^17.0.1"
+  checksum: 10c0/0cbda1031aa30c659e10921fa94e0dd3f903ecbbbe7184a729ad66f2b6e7f17891e8c7d7654c458fa4ccb1a411ffb695b4f17bbcd3fe075fabe181027c4040ed
   languageName: node
   linkType: hard
 
@@ -9214,6 +9336,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-is@npm:^17.0.1":
+  version: 17.0.2
+  resolution: "react-is@npm:17.0.2"
+  checksum: 10c0/2bdb6b93fbb1820b024b496042cce405c57e2f85e777c9aabd55f9b26d145408f9f74f5934676ffdc46f3dcff656d78413a6e43968e7b3f92eea35b3052e9053
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^18.3.1":
   version: 18.3.1
   resolution: "react-is@npm:18.3.1"
@@ -9424,6 +9553,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"redent@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "redent@npm:3.0.0"
+  dependencies:
+    indent-string: "npm:^4.0.0"
+    strip-indent: "npm:^3.0.0"
+  checksum: 10c0/d64a6b5c0b50eb3ddce3ab770f866658a2b9998c678f797919ceb1b586bab9259b311407280bd80b804e2a7c7539b19238ae6a2a20c843f1a7fcff21d48c2eae
+  languageName: node
+  linkType: hard
+
 "reflect.getprototypeof@npm:^1.0.6, reflect.getprototypeof@npm:^1.0.9":
   version: 1.0.10
   resolution: "reflect.getprototypeof@npm:1.0.10"
@@ -9616,6 +9755,8 @@ __metadata:
   resolution: "revenuepilot-app@workspace:."
   dependencies:
     "@playwright/test": "npm:^1.54.2"
+    "@testing-library/dom": "npm:^10.4.0"
+    "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react": "npm:^16.3.0"
     "@vitejs/plugin-react": "npm:^5.0.0"
     "@vitest/coverage-v8": "npm:^3.2.4"
@@ -10410,6 +10551,15 @@ __metadata:
   dependencies:
     ansi-regex: "npm:^6.0.1"
   checksum: 10c0/0d6d7a023de33368fd042aab0bf48f4f4077abdfd60e5393e73c7c411e85e1b3a83507c11af2e656188511475776215df9ca589b4da2295c9455cc399ce1858b
+  languageName: node
+  linkType: hard
+
+"strip-indent@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "strip-indent@npm:3.0.0"
+  dependencies:
+    min-indent: "npm:^1.0.0"
+  checksum: 10c0/ae0deaf41c8d1001c5d4fbe16cb553865c1863da4fae036683b474fa926af9fc121e155cb3fc57a68262b2ae7d5b8420aa752c97a6428c315d00efe2a3875679
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- replace the mock ActivityLog data source with a polling hook that calls GET /api/activity/log, maps entries, and applies client-side filters
- surface refresh, loading, and error states in the ActivityLog UI while preserving admin-only backend toggles and filter clearing
- add component tests that stub the API client for populated, empty, and error responses plus configure jsdom and testing-library dependencies

## Testing
- npm test -- ActivityLog

------
https://chatgpt.com/codex/tasks/task_e_68cde0d16d1c83248aacdd05d59407f0