### PR TITLE
Add Playwright end-to-end flow for RevenuePilot frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ backend/venv/
 backend/requirements.lock
 # Logs and coverage
 *.log
+playwright-report/
+test-results/
 
 # Electron icons
 assets/*.icns

--- a/README.md
+++ b/README.md
@@ -432,6 +432,32 @@ To run only these tests:
 pytest tests/test_ehr_integration.py -q
 ```
 
+### Frontend end-to-end smoke tests
+
+A Playwright suite now exercises the Vite-driven web frontend against a fully
+mocked API surface. The test boots the `revenuepilot-frontend` workspace,
+authenticates via the mock, loads analytics, inspects the activity log, and
+walks the documentation workflow through visit finalisation.
+
+Install the Playwright browser binaries once (Chromium is sufficient for CI):
+
+```bash
+npx playwright install --with-deps chromium
+```
+
+Then run the suite from the repository root:
+
+```bash
+npm run test:e2e
+```
+
+The command automatically launches the Express-based mock API defined in
+`tests/mocks/frontend-api-server.js` and the Vite dev server for the
+`revenuepilot-frontend` workspace. Environment variables `FRONTEND_API_PORT`
+and `FRONTEND_DEV_PORT` can be overridden when needed for local conflicts. The
+tests leave behind Playwright traces and videos for failures inside
+`playwright-report/`.
+
 ### UI Enhancements
 
 The editor displays a badge on the Export button showing the count of codes that will be sent. A classification summary row (C / P / O / M) appears beneath the patient / encounter ID inputs:

--- a/ci.sh
+++ b/ci.sh
@@ -5,3 +5,5 @@ ruff check backend
 pytest
 npm run lint
 npx vitest run --coverage
+npx playwright install --with-deps chromium
+npx playwright test

--- a/finalization-wizard/package.json
+++ b/finalization-wizard/package.json
@@ -10,7 +10,8 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
-    }
+    },
+    "./dist/style.css": "./dist/style.css"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.3",
@@ -71,6 +72,6 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "vite build && tsc --project tsconfig.build.json"
+    "build": "vite build && tsc --project tsconfig.build.json && cp src/index.css dist/style.css"
   }
 }

--- a/finalization-wizard/src/components/DualRichTextEditor.tsx
+++ b/finalization-wizard/src/components/DualRichTextEditor.tsx
@@ -325,16 +325,16 @@ export function DualRichTextEditor({
 
   type SuggestionPriority = 'high' | 'medium' | 'low';
 
-  const formatConfidence = (value?: number | null): string | null => {
+  function formatConfidence(value?: number | null): string | null {
     if (typeof value !== 'number' || !Number.isFinite(value)) {
       return null;
     }
     const percent = value > 1 ? value : value * 100;
     const normalized = Math.max(0, Math.min(100, Math.round(percent)));
     return `${normalized}%`;
-  };
+  }
 
-  const getCodeTypeLabel = (item?: WizardCodeItem): string => {
+  function getCodeTypeLabel(item?: WizardCodeItem): string {
     const explicit = typeof item?.codeType === 'string' ? item.codeType.trim() : '';
     if (explicit) {
       return explicit.toUpperCase();
@@ -347,16 +347,16 @@ export function DualRichTextEditor({
       return 'ICD-10';
     }
     return 'CODE';
-  };
+  }
 
-  const getCodeTypeBadgeClass = (codeType: string): string => {
+  function getCodeTypeBadgeClass(codeType: string): string {
     if (codeType.toUpperCase() === 'CPT') {
       return 'bg-green-50 text-green-700 border border-green-200 text-xs flex-shrink-0';
     }
     return 'bg-blue-50 text-blue-700 border border-blue-200 text-xs flex-shrink-0';
-  };
+  }
 
-  const getCodeBadgeProps = (item: WizardCodeItem, index: number) => {
+  function getCodeBadgeProps(item: WizardCodeItem, index: number) {
     if (item.stillValid === false) {
       return { text: 'Needs Update', className: 'bg-red-100 text-red-700 text-xs' };
     }
@@ -374,17 +374,17 @@ export function DualRichTextEditor({
       text: index === 0 ? 'Primary' : 'Pending Review',
       className: index === 0 ? 'bg-green-100 text-green-800 text-xs' : 'bg-slate-100 text-slate-700 text-xs',
     };
-  };
+  }
 
-  const formatTagLabel = (value: string): string => {
+  function formatTagLabel(value: string): string {
     const cleaned = value.replace(/[\-_]+/g, ' ').trim();
     if (!cleaned) {
       return value;
     }
     return cleaned.replace(/\b\w/g, char => char.toUpperCase());
-  };
+  }
 
-  const getCodeTagList = (item: WizardCodeItem): string[] => {
+  function getCodeTagList(item: WizardCodeItem): string[] {
     const tags = new Set<string>();
     const addTag = (value?: string | null) => {
       if (typeof value === 'string') {
@@ -408,9 +408,9 @@ export function DualRichTextEditor({
     addTag(typeof item.category === 'string' ? item.category : undefined);
 
     return Array.from(tags.values()).slice(0, 4);
-  };
+  }
 
-  const getSupportingText = (item: WizardCodeItem): string | undefined => {
+  function getSupportingText(item: WizardCodeItem): string | undefined {
     const candidates = [item.docSupport, item.details, item.aiReasoning];
     for (const entry of candidates) {
       if (typeof entry === 'string') {
@@ -440,7 +440,7 @@ export function DualRichTextEditor({
     }
 
     return undefined;
-  };
+  }
 
   const getCodeMetaLine = (item: WizardCodeItem): string[] => {
     const parts: string[] = [];

--- a/finalization-wizard/src/components/WorkflowWizard.tsx
+++ b/finalization-wizard/src/components/WorkflowWizard.tsx
@@ -468,9 +468,19 @@ export function FinalizationWizard({
   >(null);
 
   React.useEffect(() => {
+    if (finalizeResult) {
+      return;
+    }
+
     setFinalizeResult(null);
     setFinalizeError(null);
-  }, [normalizedSelected, normalizedSuggested, normalizedCompliance, noteContent]);
+  }, [
+    finalizeResult,
+    normalizedSelected,
+    normalizedSuggested,
+    normalizedCompliance,
+    noteContent,
+  ]);
 
   React.useEffect(() => {
     const nextDefault = incomingNoteContent || getDefaultNoteContent(patientMetadata);

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint \"src/components/**/*.{js,jsx}\" && prettier --check \"src/components/**/*.{js,jsx}\"",
-    "test:smoke": "npx playwright test e2e/smoke-login.spec.js",
+    "test:e2e": "npx playwright test",
     "mock": "node mock/server.js"
   },
   "dependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,50 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const FRONTEND_PORT = Number(process.env.FRONTEND_DEV_PORT || 4173);
+const API_PORT = Number(process.env.FRONTEND_API_PORT || 4010);
+
+export default defineConfig({
+  testDir: 'tests/e2e',
+  timeout: 5 * 60 * 1000,
+  expect: {
+    timeout: 15_000,
+  },
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['github'], ['list']] : [['list']],
+  use: {
+    baseURL: `http://127.0.0.1:${FRONTEND_PORT}`,
+    trace: 'on-first-retry',
+    video: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  webServer: [
+    {
+      command: `node tests/mocks/frontend-api-server.js`,
+      port: API_PORT,
+      reuseExistingServer: !process.env.CI,
+      timeout: 60_000,
+      env: {
+        FRONTEND_API_PORT: String(API_PORT),
+      },
+    },
+    {
+      command: `bash -c "npm --workspace finalization-wizard run build && npm --workspace revenuepilot-frontend run dev -- --host 127.0.0.1 --port ${FRONTEND_PORT} --strictPort"`,
+      port: FRONTEND_PORT,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      env: {
+        VITE_API_URL: `http://127.0.0.1:${API_PORT}`,
+        NODE_ENV: 'development',
+      },
+    },
+  ],
+  projects: [
+    {
+      name: 'chromium',
+      use: devices['Desktop Chrome'],
+    },
+  ],
+});

--- a/revenuepilot-frontend/src/components/NoteEditor.tsx
+++ b/revenuepilot-frontend/src/components/NoteEditor.tsx
@@ -376,7 +376,6 @@ export function NoteEditor({
         content:
           typeof contentOverride === "string" ? contentOverride : noteContentRef.current
       }
-
       const createPromise = (async () => {
         try {
           const response = await fetchWithAuth("/api/notes/create", {
@@ -1264,6 +1263,10 @@ export function NoteEditor({
     return undefined
   }, [visitSession?.startTime])
 
+  const totalDisplayTime = visitStarted ? currentSessionTime : pausedTime
+  const hasRecordedTime = totalDisplayTime > 0
+  const isEditorDisabled = isFinalized || !visitStarted
+
   // Calculate active issues for button state
   const activeIssues = complianceIssues.filter(issue => !issue.dismissed)
   const criticalIssues = activeIssues.filter(issue => issue.severity === 'critical')
@@ -1327,7 +1330,6 @@ export function NoteEditor({
 
   const handleSaveDraft = () => {
     // TODO: Save draft and navigate to drafts page
-    console.log("Saving draft and exiting...")
   }
 
   const canStartVisit = useMemo(() => {
@@ -1446,10 +1448,6 @@ export function NoteEditor({
     currentSessionTime,
     isFinalized
   ])
-
-  const totalDisplayTime = visitStarted ? currentSessionTime : pausedTime
-  const isEditorDisabled = isFinalized || !visitStarted
-  const hasRecordedTime = totalDisplayTime > 0
 
   return (
     <div className="flex flex-col flex-1">

--- a/tests/e2e/revenuepilot-frontend.spec.ts
+++ b/tests/e2e/revenuepilot-frontend.spec.ts
@@ -1,0 +1,196 @@
+import { expect, test } from '@playwright/test';
+
+const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+test.describe('RevenuePilot frontend integration flow', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      class MockMediaStreamTrack {
+        stop() {
+          // no-op
+        }
+      }
+
+      class MockMediaStream {
+        getTracks() {
+          return [new MockMediaStreamTrack()];
+        }
+      }
+
+      class MockMediaRecorder {
+        private _interval: ReturnType<typeof setInterval> | null = null;
+        public stream: MockMediaStream;
+        public state: 'inactive' | 'recording' = 'inactive';
+        public ondataavailable: ((event: { data: Blob }) => void) | null = null;
+        public onstop: (() => void) | null = null;
+        public onstart: (() => void) | null = null;
+
+        constructor(stream: MockMediaStream) {
+          this.stream = stream;
+        }
+
+        start(timeslice = 1000) {
+          this.state = 'recording';
+          this.onstart?.();
+          this._interval = setInterval(() => {
+            if (this.ondataavailable) {
+              const blob = new Blob(['mock-audio'], { type: 'audio/webm' });
+              this.ondataavailable({ data: blob });
+            }
+          }, Math.max(100, timeslice));
+        }
+
+        stop() {
+          if (this._interval) {
+            clearInterval(this._interval);
+            this._interval = null;
+          }
+          this.state = 'inactive';
+          this.onstop?.();
+        }
+
+        requestData() {
+          // ignored
+        }
+
+        addEventListener() {
+          // ignored
+        }
+
+        removeEventListener() {
+          // ignored
+        }
+      }
+
+      Object.defineProperty(window, 'MediaRecorder', {
+        configurable: true,
+        writable: true,
+        value: MockMediaRecorder,
+      });
+
+      Object.defineProperty(navigator, 'mediaDevices', {
+        configurable: true,
+        writable: true,
+        value: {
+          async getUserMedia() {
+            return new MockMediaStream();
+          },
+        },
+      });
+    });
+  });
+
+  test('auth handshake, analytics, activity log, and finalization wizard', async ({ page }) => {
+    await page.goto('/');
+
+    await page
+      .getByText('Signing you in', { exact: false })
+      .waitFor({ state: 'visible', timeout: 5000 })
+      .catch(() => undefined);
+
+    const sidebarNavItem = (label: string) =>
+      page
+        .locator('[data-sidebar="menu"]')
+        .getByText(label, { exact: true });
+
+    const toggleSidebar = page.locator('[data-sidebar="trigger"]');
+
+    const ensureSidebarExpanded = async () => {
+      const homeNav = sidebarNavItem('Home Dashboard');
+
+      if (await homeNav.isVisible()) {
+        return;
+      }
+
+      await toggleSidebar.waitFor({ state: 'visible' });
+      await toggleSidebar.click();
+      await expect(homeNav).toBeVisible();
+    };
+
+    await toggleSidebar.waitFor({ state: 'visible' });
+
+    await ensureSidebarExpanded();
+
+    await expect(sidebarNavItem('Analytics')).toBeVisible();
+
+    await sidebarNavItem('Analytics').click();
+    await expect(page.getByRole('heading', { name: 'Analytics Dashboard' }).first()).toBeVisible();
+    await expect(page.getByText('Daily Revenue', { exact: true })).toBeVisible();
+    await expect(page.getByText('Period total: $48,250', { exact: false })).toBeVisible();
+
+    await sidebarNavItem('Activity Log').click();
+    await expect(page.getByRole('heading', { name: 'Activity Log' }).first()).toBeVisible();
+    await expect(page.getByText('Note Created').first()).toBeVisible();
+
+    await sidebarNavItem('Documentation').click();
+
+    const patientField = page.getByLabel('Patient ID');
+    await patientField.fill('Jane');
+
+    await wait(600);
+    const patientOption = page.getByRole('button', { name: /Jane Doe/ }).first();
+    await expect(patientOption).toBeVisible();
+    await patientOption.click();
+
+    const encounterField = page.getByLabel('Encounter ID');
+    await encounterField.fill('67890');
+
+    await expect(page.getByText('Follow-up', { exact: false })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Start Visit' }).click();
+    await expect(page.getByRole('button', { name: 'Stop Visit' })).toBeVisible();
+
+    await page.waitForTimeout(2000);
+
+    const finalizeButton = page.getByRole('button', { name: 'Save & Finalize Note' });
+    await expect(finalizeButton).toBeEnabled();
+    await finalizeButton.click();
+
+    await expect(page.getByRole('heading', { name: 'Code Review' }).first()).toBeVisible();
+    await page.getByRole('button', { name: 'Next' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Suggestion Review' }).first()).toBeVisible();
+    await page.getByRole('button', { name: 'Next' }).click();
+
+    const continueToCompare = page.getByRole('button', { name: 'Continue to Compare & Edit' });
+    await expect(continueToCompare).toBeVisible();
+    await continueToCompare.click();
+
+    const acceptEnhanced = page.getByRole('button', { name: /Accept Enhanced Version/ });
+    await expect(acceptEnhanced).toBeVisible();
+    await acceptEnhanced.click();
+
+    const switchToSummary = page.getByRole('button', { name: /Switch to Summary/ });
+    await switchToSummary.click();
+
+    const acceptSummary = page.getByRole('button', { name: /Accept Summary Version/ });
+    await acceptSummary.click();
+
+    const continueToBilling = page.getByRole('button', { name: /Continue to Billing/ });
+    await expect(continueToBilling).toBeEnabled();
+    await continueToBilling.click();
+
+    await expect(page.getByRole('heading', { name: 'Billing & Attest' }).first()).toBeVisible();
+    await page.getByRole('button', { name: 'Next' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Sign & Dispatch' }).first()).toBeVisible();
+
+    const dispatchButton = page.getByRole('button', { name: 'Finalize & Dispatch' });
+    await expect(dispatchButton).toBeVisible();
+    await dispatchButton.click();
+
+    const dispatchFinalizedButton = page.getByRole('button', { name: 'Dispatch Finalized Note' });
+    await expect(dispatchFinalizedButton).toBeVisible();
+    await expect(dispatchFinalizedButton).toBeEnabled();
+    await expect(page.getByText('Step completed', { exact: false })).toContainText('100%');
+
+    const closeButton = page.getByRole('button', { name: 'Close' });
+    // Trigger the React handler directly to avoid framer-motion overlays
+    // that intermittently intercept pointer events during exit animations.
+    await closeButton.evaluate(node => (node as HTMLButtonElement).click());
+
+    await expect(page.getByRole('heading', { name: 'Finalization Wizard' })).not.toBeVisible();
+    await expect(page.getByRole('button', { name: 'Note Finalized' })).toBeDisabled();
+    await expect(page.getByText('Note finalized', { exact: false })).toBeVisible();
+  });
+});

--- a/tests/mocks/frontend-api-server.js
+++ b/tests/mocks/frontend-api-server.js
@@ -1,0 +1,754 @@
+const express = require('express');
+const cors = require('cors');
+
+const FRONTEND_ORIGIN =
+  process.env.FRONTEND_ORIGIN ||
+  process.env.FRONTEND_BASE_URL ||
+  `http://127.0.0.1:${process.env.FRONTEND_DEV_PORT || 4173}`;
+
+const app = express();
+app.use(
+  cors({
+    origin: FRONTEND_ORIGIN,
+    credentials: true,
+  }),
+);
+app.options('*', cors({ origin: FRONTEND_ORIGIN, credentials: true }));
+app.use(express.json());
+
+const PORT = Number(process.env.FRONTEND_API_PORT || 4010);
+
+const demoUser = {
+  id: 'user-100',
+  name: 'Dr. Ava Mitchell',
+  fullName: 'Dr. Ava Mitchell',
+  email: 'ava.mitchell@exampleclinic.com',
+  role: 'admin',
+  permissions: [
+    'view:analytics',
+    'view:activity-log',
+    'manage:settings',
+    'manage:builder',
+  ],
+  specialty: 'Family Medicine',
+  payer: 'Aetna Premier',
+};
+
+let sessionState = {
+  selectedCodes: {
+    codes: 2,
+    prevention: 0,
+    diagnoses: 0,
+    differentials: 0,
+  },
+  selectedCodesList: [
+    {
+      id: 1,
+      code: '99213',
+      type: 'CPT',
+      category: 'codes',
+      description: 'Established patient visit, 20 minutes',
+      rationale: 'Follow-up evaluation for chronic condition',
+      confidence: 0.92,
+    },
+    {
+      id: 2,
+      code: 'J1100',
+      type: 'HCPCS',
+      category: 'codes',
+      description: 'Injection, dexamethasone sodium phosphate, 1 mg',
+      rationale: 'Therapeutic injection administered in office',
+      confidence: 0.88,
+    },
+  ],
+  addedCodes: ['99213', 'J1100'],
+  isSuggestionPanelOpen: false,
+  analyticsPreferences: {
+    activeTab: 'billing',
+  },
+};
+
+let layoutPreferences = {
+  noteEditor: 68,
+  suggestionPanel: 32,
+};
+
+let activeVisit = {
+  sessionId: 'visit-2001',
+  status: 'inactive',
+  startTime: null,
+  endTime: null,
+  encounterId: null,
+};
+
+let workflowSession = {
+  sessionId: 'wf-3001',
+  encounterId: '67890',
+  patientId: '1000001',
+  noteId: '5001',
+  currentStep: 4,
+  stepStates: [
+    { step: 1, status: 'completed', progress: 100 },
+    { step: 2, status: 'completed', progress: 100 },
+    { step: 3, status: 'completed', progress: 100 },
+    { step: 4, status: 'in_progress', progress: 60 },
+    { step: 5, status: 'not_started', progress: 0 },
+    { step: 6, status: 'not_started', progress: 0 },
+  ],
+  selectedCodes: [
+    {
+      id: 1,
+      code: '99213',
+      type: 'CPT',
+      category: 'codes',
+      description: 'Established patient visit, 20 minutes',
+      rationale: 'Follow-up evaluation for chronic condition',
+      confidence: 0.92,
+    },
+    {
+      id: 2,
+      code: 'J1100',
+      type: 'HCPCS',
+      category: 'codes',
+      description: 'Injection, dexamethasone sodium phosphate, 1 mg',
+      rationale: 'Therapeutic injection administered in office',
+      confidence: 0.88,
+    },
+  ],
+  complianceIssues: [],
+  patientMetadata: {
+    patientId: '1000001',
+    encounterId: '67890',
+    name: 'Jane Doe',
+    age: 34,
+    sex: 'Female',
+    encounterDate: '2024-03-15',
+    providerName: demoUser.fullName,
+  },
+  noteContent:
+    'SUBJECTIVE:\nPatient presents with stable hypertension follow-up.\n\nOBJECTIVE:\nBlood pressure 124/78.\n\nASSESSMENT:\nHypertension, well controlled.\n\nPLAN:\nContinue current medications and schedule labs.',
+  reimbursementSummary: {
+    total: 185.5,
+    codes: [
+      { code: '99213', amount: 125.0 },
+      { code: 'J1100', amount: 60.5 },
+    ],
+  },
+  auditTrail: [
+    {
+      actor: demoUser.fullName,
+      action: 'session.created',
+      timestamp: new Date().toISOString(),
+      description: 'Workflow session initialized for encounter 67890',
+    },
+  ],
+  blockingIssues: [],
+};
+
+const patients = [
+  {
+    patientId: '1000001',
+    name: 'Jane Doe',
+    firstName: 'Jane',
+    lastName: 'Doe',
+    dob: '1990-05-12',
+    age: 34,
+    gender: 'Female',
+    mrn: 'MRN-2048',
+    insurance: 'Aetna Premier',
+    lastVisit: '2024-02-27',
+    allergies: ['Penicillin'],
+    medications: ['Atorvastatin 20mg daily'],
+  },
+  {
+    patientId: '1000002',
+    name: 'Michael Rivera',
+    firstName: 'Michael',
+    lastName: 'Rivera',
+    dob: '1982-11-03',
+    age: 41,
+    gender: 'Male',
+    mrn: 'MRN-2088',
+    insurance: 'Blue Shield Gold',
+    lastVisit: '2024-02-15',
+    allergies: ['None'],
+    medications: ['Lisinopril 10mg daily'],
+  },
+];
+
+const analyticsStub = {
+  usage: {
+    total_notes: 128,
+    beautify: 54,
+    suggest: 42,
+    summary: 64,
+    chart_upload: 12,
+    audio: 28,
+    avg_note_length: 512,
+    daily_trends: Array.from({ length: 7 }).map((_, idx) => ({
+      day: `2024-03-${10 + idx}`,
+      total_notes: 14 + idx,
+      beautify: 5 + (idx % 3),
+      suggest: 4 + (idx % 2),
+      summary: 6 + (idx % 4),
+      chart_upload: 2 + (idx % 2),
+      audio: 3 + (idx % 3),
+    })),
+    projected_totals: {
+      month: 240,
+      quarter: 720,
+      year: 2880,
+    },
+    event_distribution: {
+      beautify: 32,
+      suggest: 26,
+      summary: 18,
+      transcription: 14,
+      export: 10,
+    },
+  },
+  coding: {
+    total_notes: 96,
+    denials: 4,
+    deficiencies: 7,
+    accuracy: 93,
+    coding_distribution: {
+      'Level 3': 42,
+      'Level 4': 38,
+      'Level 5': 16,
+    },
+    outcome_distribution: {
+      approved: 88,
+      appealed: 5,
+      denied: 3,
+    },
+    accuracy_trend: Array.from({ length: 7 }).map((_, idx) => ({
+      day: `2024-03-${10 + idx}`,
+      total_notes: 12 + idx,
+      denials: idx % 2,
+      deficiencies: idx % 3,
+      accuracy: 90 + (idx % 5),
+    })),
+    projections: {
+      month: 275,
+      quarter: 810,
+      year: 3240,
+    },
+  },
+  revenue: {
+    total_revenue: 48250,
+    average_revenue: 378,
+    revenue_by_code: {
+      '99213': 16250,
+      '99214': 12400,
+      'J1100': 5200,
+      '93000': 4800,
+    },
+    revenue_trend: Array.from({ length: 7 }).map((_, idx) => ({
+      day: `2024-03-${10 + idx}`,
+      total_revenue: 5400 + idx * 320,
+      average_revenue: 360 + idx * 5,
+    })),
+    projections: {
+      month: 146000,
+      quarter: 438000,
+      year: 1752000,
+    },
+    revenue_distribution: {
+      Professional: 60,
+      Facility: 25,
+      Pharmacy: 15,
+    },
+  },
+  compliance: {
+    compliance_counts: {
+      documentation: 12,
+      coding: 8,
+      billing: 5,
+    },
+    notes_with_flags: 14,
+    total_flags: 26,
+    flagged_rate: 11,
+    compliance_trend: Array.from({ length: 7 }).map((_, idx) => ({
+      day: `2024-03-${10 + idx}`,
+      notes_with_flags: 2 + (idx % 3),
+      total_flags: 4 + (idx % 4),
+    })),
+    projections: {
+      month: 38,
+      quarter: 108,
+      year: 432,
+    },
+    compliance_distribution: {
+      critical: 3,
+      warning: 7,
+      info: 16,
+    },
+  },
+};
+
+app.get('/health', (_req, res) => {
+  res.json({ status: 'ok', timestamp: new Date().toISOString() });
+});
+
+app.get('/api/auth/status', (_req, res) => {
+  res.json({ authenticated: true, user: demoUser });
+});
+
+app.post('/api/auth/logout', (_req, res) => {
+  res.status(204).end();
+});
+
+app.get('/api/user/session', (_req, res) => {
+  res.json({ ...sessionState });
+});
+
+app.put('/api/user/session', (req, res) => {
+  sessionState = {
+    ...sessionState,
+    ...req.body,
+  };
+  res.json({ status: 'ok' });
+});
+
+app.get('/api/user/layout-preferences', (_req, res) => {
+  res.json({ ...layoutPreferences });
+});
+
+app.put('/api/user/layout-preferences', (req, res) => {
+  layoutPreferences = {
+    ...layoutPreferences,
+    ...req.body,
+  };
+  res.json({ status: 'ok' });
+});
+
+app.get('/api/user/profile', (_req, res) => {
+  res.json({
+    currentView: 'home',
+    clinic: 'Riverbend Medical Group',
+    preferences: {
+      language: 'en',
+      timezone: 'America/New_York',
+    },
+    uiPreferences: layoutPreferences,
+  });
+});
+
+app.get('/api/user/ui-preferences', (_req, res) => {
+  res.json({ uiPreferences: layoutPreferences });
+});
+
+app.get('/api/user/current-view', (_req, res) => {
+  res.json({ currentView: 'home' });
+});
+
+app.get('/api/notifications/count', (_req, res) => {
+  res.json({ count: 3 });
+});
+
+app.get('/api/dashboard/daily-overview', (_req, res) => {
+  res.json({
+    todaysNotes: 18,
+    completedVisits: 12,
+    pendingReviews: 4,
+    complianceScore: 97,
+    revenueToday: 14580,
+  });
+});
+
+app.get('/api/dashboard/quick-actions', (_req, res) => {
+  res.json({
+    draftCount: 3,
+    upcomingAppointments: 6,
+    urgentReviews: 1,
+    systemAlerts: [
+      { type: 'info', message: 'FHIR export schema updated overnight' },
+    ],
+  });
+});
+
+app.get('/api/dashboard/activity', (_req, res) => {
+  res.json([
+    {
+      id: 1,
+      type: 'note.finalized',
+      timestamp: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+      description: 'Finalized SOAP note for patient Jane Doe',
+      userId: demoUser.id,
+    },
+    {
+      id: 2,
+      type: 'codes.added',
+      timestamp: new Date(Date.now() - 12 * 60 * 1000).toISOString(),
+      description: 'Added CPT 99213 based on AI suggestion',
+      userId: demoUser.id,
+    },
+  ]);
+});
+
+app.get('/api/system/status', (_req, res) => {
+  res.json({
+    aiServicesStatus: 'online',
+    ehrConnectionStatus: 'online',
+    lastSyncTime: new Date(Date.now() - 2 * 60 * 1000).toISOString(),
+  });
+});
+
+app.get('/api/analytics/usage', (_req, res) => {
+  res.json(analyticsStub.usage);
+});
+
+app.get('/api/analytics/coding-accuracy', (_req, res) => {
+  res.json(analyticsStub.coding);
+});
+
+app.get('/api/analytics/revenue', (_req, res) => {
+  res.json(analyticsStub.revenue);
+});
+
+app.get('/api/analytics/compliance', (_req, res) => {
+  res.json(analyticsStub.compliance);
+});
+
+app.get('/api/analytics/drafts', (_req, res) => {
+  res.json({ drafts: 3 });
+});
+
+app.get('/api/templates/list', (_req, res) => {
+  res.json([
+    {
+      id: 'soap-template',
+      name: 'SOAP Follow-up Template',
+      description: 'Standard follow-up SOAP note structure',
+      content:
+        'SUBJECTIVE:\nChief Complaint:\nHistory of Present Illness:\nReview of Systems:\n\nOBJECTIVE:\nVital Signs:\nPhysical Examination:\n\nASSESSMENT:\nPrimary Diagnosis:\nSecondary Diagnoses:\n\nPLAN:\nTreatment:\nFollow-up:',
+    },
+    {
+      id: 'consult-template',
+      name: 'Consultation Template',
+      description: 'Detailed consultation note format',
+      content:
+        'CONSULTATION NOTE:\nReason for Consultation:\nHistory of Present Illness:\nPast Medical History:\nMedications:\nAllergies:\nFamily History:\nSocial History:\n\nASSESSMENT AND PLAN:\n',
+    },
+  ]);
+});
+
+app.get('/api/notes/versions/:id', (req, res) => {
+  res.json([
+    {
+      version: 1,
+      timestamp: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+      content: workflowSession.noteContent,
+    },
+  ]);
+});
+
+app.get('/api/patients/search', (req, res) => {
+  const query = String(req.query.q || '').toLowerCase();
+  const matches = patients.filter(patient => {
+    const haystack = [
+      patient.patientId,
+      patient.name,
+      patient.firstName,
+      patient.lastName,
+      patient.mrn,
+    ]
+      .filter(Boolean)
+      .map(value => String(value).toLowerCase());
+    return haystack.some(value => value.includes(query));
+  });
+  res.json({
+    patients: matches,
+    externalPatients: [],
+  });
+});
+
+app.get('/api/patients/:id', (req, res) => {
+  const patient = patients.find(p => p.patientId === req.params.id);
+  if (!patient) {
+    res.status(404).json({ detail: 'Patient not found' });
+    return;
+  }
+  res.json({
+    demographics: {
+      patientId: patient.patientId,
+      name: patient.name,
+      firstName: patient.firstName,
+      lastName: patient.lastName,
+      dob: patient.dob,
+      age: patient.age,
+      gender: patient.gender,
+      mrn: patient.mrn,
+      insurance: patient.insurance,
+      lastVisit: patient.lastVisit,
+    },
+    allergies: patient.allergies,
+    medications: patient.medications,
+    encounters: [
+      {
+        encounterId: 67890,
+        date: '2024-03-15',
+        type: 'Follow-up',
+        provider: demoUser.fullName,
+      },
+    ],
+  });
+});
+
+app.get('/api/encounters/validate/:id', (req, res) => {
+  const encounterId = Number(req.params.id);
+  if (!Number.isFinite(encounterId)) {
+    res.status(400).json({ errors: ['Encounter ID must be numeric'] });
+    return;
+  }
+  res.json({
+    valid: true,
+    encounter: {
+      encounterId,
+      patientId: '1000001',
+      date: '2024-03-15',
+      type: 'Follow-up',
+      provider: demoUser.fullName,
+      description: 'Post-operative follow-up and medication review',
+      patient: {
+        patientId: '1000001',
+        insurance: 'Aetna Premier',
+      },
+    },
+  });
+});
+
+app.post('/api/notes/create', (req, res) => {
+  console.log('[mock] create note', req.body);
+  const noteId = '5001';
+  workflowSession = {
+    ...workflowSession,
+    noteId,
+    noteContent: req.body?.content || workflowSession.noteContent,
+  };
+  res.json({ noteId });
+});
+
+app.put('/api/notes/auto-save', (req, res) => {
+  workflowSession = {
+    ...workflowSession,
+    noteContent: req.body?.content || workflowSession.noteContent,
+  };
+  res.json({ status: 'ok' });
+});
+
+app.post('/api/compliance/analyze', (req, res) => {
+  res.json({ compliance: [] });
+});
+
+app.post('/api/ai/codes/suggest', (req, res) => {
+  const baseContent = typeof req.body?.content === 'string' ? req.body.content : '';
+  const includesHypertension = baseContent.toLowerCase().includes('hypertension');
+  res.json({
+    suggestions: [
+      {
+        code: 'I10',
+        type: 'ICD-10',
+        description: 'Essential (primary) hypertension',
+        reasoning: 'Documented follow-up visit for hypertension management',
+        confidence: includesHypertension ? 0.96 : 0.82,
+      },
+      {
+        code: '99214',
+        type: 'CPT',
+        description: 'Office visit, established patient, 25 minutes',
+        reasoning: 'Encounter includes medication management and chronic condition counseling',
+        confidence: 0.74,
+      },
+    ],
+  });
+});
+
+app.post('/api/ai/compliance/check', (_req, res) => {
+  res.json({
+    alerts: [
+      {
+        text: 'Document patient counseling on lifestyle modifications for hypertension.',
+        category: 'documentation',
+        priority: 'medium',
+        confidence: 0.78,
+      },
+    ],
+  });
+});
+
+app.post('/api/ai/differentials/generate', (_req, res) => {
+  res.json({
+    differentials: [
+      {
+        diagnosis: 'Hypertensive heart disease',
+        icdCode: 'I11.9',
+        confidence: 0.63,
+        reasoning: 'Consider when long-standing hypertension and cardiac findings are present',
+      },
+      {
+        diagnosis: 'Secondary hypertension',
+        icdCode: 'I15.9',
+        confidence: 0.41,
+        reasoning: 'Rule out secondary causes when blood pressure remains uncontrolled',
+      },
+    ],
+  });
+});
+
+app.post('/api/ai/prevention/suggest', (_req, res) => {
+  res.json({
+    recommendations: [
+      {
+        id: 'prevent-01',
+        code: '3078F',
+        type: 'CPT II',
+        category: 'preventive',
+        recommendation: 'Document blood pressure goals and follow-up plan.',
+        priority: 'medium',
+        source: 'USPSTF',
+      },
+    ],
+  });
+});
+
+app.post('/api/visits/session', (req, res) => {
+  const encounterId = req.body?.encounter_id ?? req.body?.encounterId;
+  activeVisit = {
+    sessionId: 'visit-2001',
+    status: 'active',
+    startTime: new Date().toISOString(),
+    endTime: null,
+    encounterId,
+  };
+  res.json(activeVisit);
+});
+
+app.put('/api/visits/session', (req, res) => {
+  const action = req.body?.action;
+  if (action === 'active') {
+    activeVisit = {
+      ...activeVisit,
+      status: 'active',
+    };
+  } else if (action === 'paused') {
+    activeVisit = {
+      ...activeVisit,
+      status: 'paused',
+      endTime: new Date().toISOString(),
+    };
+  }
+  res.json(activeVisit);
+});
+
+app.post('/api/v1/workflow/sessions', (req, res) => {
+  console.log('[mock] initialise workflow session', req.body);
+  workflowSession = {
+    ...workflowSession,
+    encounterId: String(req.body?.encounterId ?? workflowSession.encounterId ?? ''),
+    patientId: String(req.body?.patientId ?? workflowSession.patientId ?? ''),
+    noteId: req.body?.noteId ?? workflowSession.noteId,
+    noteContent: typeof req.body?.noteContent === 'string' && req.body.noteContent.trim().length > 0
+      ? req.body.noteContent
+      : workflowSession.noteContent,
+    reimbursementSummary: workflowSession.reimbursementSummary,
+    blockingIssues: [],
+  };
+  res.json(workflowSession);
+});
+
+app.put('/api/v1/notes/:encounterId/content', (req, res) => {
+  workflowSession = {
+    ...workflowSession,
+    noteContent: req.body?.content ?? workflowSession.noteContent,
+    reimbursementSummary: {
+      total: workflowSession.reimbursementSummary.total,
+      codes: workflowSession.reimbursementSummary.codes,
+    },
+    stepStates: workflowSession.stepStates.map(state =>
+      state.step === 4 ? { ...state, status: 'completed', progress: 100 } : state
+    ),
+  };
+  const validation = {
+    canFinalize: true,
+    issues: {},
+    estimatedReimbursement: workflowSession.reimbursementSummary.total,
+    reimbursementSummary: workflowSession.reimbursementSummary,
+  };
+  res.json({
+    encounterId: req.params.encounterId,
+    sessionId: workflowSession.sessionId,
+    noteContent: workflowSession.noteContent,
+    reimbursementSummary: workflowSession.reimbursementSummary,
+    validation,
+    session: workflowSession,
+  });
+});
+
+app.post('/api/v1/workflow/:sessionId/step5/attest', (req, res) => {
+  workflowSession = {
+    ...workflowSession,
+    stepStates: workflowSession.stepStates.map(state =>
+      state.step === 5
+        ? { ...state, status: 'completed', progress: 100 }
+        : state
+    ),
+    auditTrail: [
+      ...workflowSession.auditTrail,
+      {
+        actor: demoUser.fullName,
+        action: 'workflow.attested',
+        timestamp: new Date().toISOString(),
+        description: `Attestation confirmed by ${demoUser.fullName}`,
+      },
+    ],
+  };
+  res.json({ session: workflowSession });
+});
+
+app.post('/api/v1/workflow/:sessionId/step6/dispatch', (req, res) => {
+  workflowSession = {
+    ...workflowSession,
+    stepStates: workflowSession.stepStates.map(state =>
+      state.step === 6
+        ? { ...state, status: 'completed', progress: 100 }
+        : state
+    ),
+    currentStep: 6,
+    auditTrail: [
+      ...workflowSession.auditTrail,
+      {
+        actor: demoUser.fullName,
+        action: 'workflow.dispatched',
+        timestamp: new Date().toISOString(),
+        description: 'Finalized note dispatched to EHR.',
+      },
+    ],
+  };
+
+  const finalizedContent = `${workflowSession.noteContent}\n\nFinalized via RevenuePilot on ${new Date().toLocaleString()}.`;
+
+  res.json({
+    session: workflowSession,
+    result: {
+      finalizedContent,
+      reimbursementSummary: workflowSession.reimbursementSummary,
+      codesSummary: workflowSession.reimbursementSummary.codes.map(item => ({
+        code: item.code,
+        amount: item.amount,
+      })),
+      exportReady: true,
+      issues: {},
+    },
+  });
+});
+
+app.use((req, res) => {
+  console.warn(`Unhandled mock endpoint: ${req.method} ${req.path}`);
+  res.json({ status: 'ok' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Mock frontend API listening on http://127.0.0.1:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add a Playwright configuration, mock API server, and end-to-end test that drives the Vite frontend through authentication, analytics, activity log, documentation, and the finalization wizard
- teach the finalization wizard to retain its finalize result so the dispatch step surfaces "Dispatch Finalized Note" and allow the NoteEditor to close the wizard cleanly from automation
- document the new workflow, wire CI to run `npm run test:e2e`, and ship required workspace build changes so the suite boots consistently

## Testing
- ./node_modules/.bin/playwright test

------
https://chatgpt.com/codex/tasks/task_e_68cde0dae250832490ec800b674b35e3