### PR TITLE
Switch Electron build to workspace frontend

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -271,12 +271,15 @@ async function startBackend() {
 }
 
 function resolveIndexHtml() {
-  const devPath = path.join(__dirname, 'dist', 'index.html'); // when running from source (electron/dist)
-  const packagedPath = path.join(__dirname, '..', 'dist', 'index.html'); // inside asar (dist)
-  if (fs.existsSync(devPath)) return devPath;
+  const localBundledPath = path.join(__dirname, 'dist', 'index.html');
+  const workspaceBundledPath = path.join(__dirname, '..', 'revenuepilot-frontend', 'build', 'index.html');
+  const packagedPath = path.join(__dirname, '..', 'dist', 'index.html');
+
+  if (fs.existsSync(localBundledPath)) return localBundledPath;
+  if (fs.existsSync(workspaceBundledPath)) return workspaceBundledPath;
   if (fs.existsSync(packagedPath)) return packagedPath;
-  console.error('Could not locate index.html. Looked in:', devPath, packagedPath);
-  return devPath; // attempt anyway so error is surfaced in logs
+  console.error('Could not locate index.html. Looked in:', localBundledPath, workspaceBundledPath, packagedPath);
+  return localBundledPath; // attempt anyway so error is surfaced in logs
 }
 
 function createWindow() {

--- a/finalization-wizard/package.json
+++ b/finalization-wizard/package.json
@@ -10,7 +10,8 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
-    }
+    },
+    "./dist/style.css": "./dist/style.css"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.3",
@@ -71,6 +72,6 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "vite build && tsc --project tsconfig.build.json"
+    "build": "vite build && tsc --project tsconfig.build.json && node scripts/postbuild.js"
   }
 }

--- a/finalization-wizard/scripts/postbuild.js
+++ b/finalization-wizard/scripts/postbuild.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+/* eslint-env node */
+
+import { copyFileSync, existsSync, mkdirSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, '..');
+const source = path.join(rootDir, 'src', 'index.css');
+const destination = path.join(rootDir, 'dist', 'style.css');
+
+if (!existsSync(source)) {
+  console.error(`Unable to find ${source}.`);
+  process.exit(1);
+}
+
+mkdirSync(path.dirname(destination), { recursive: true });
+copyFileSync(source, destination);
+console.log(`Copied ${source} to ${destination}.`);

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   "author": "RevenuePilot Team",
   "main": "electron/main.js",
   "scripts": {
-    "dev": "vite",
-    "build": "npm --workspace finalization-wizard run build && vite build",
-    "preview": "vite preview",
+    "dev": "npm --workspace revenuepilot-frontend run dev",
+    "build": "npm --workspace finalization-wizard run build && npm --workspace revenuepilot-frontend run build && node scripts/sync-frontend-build.js",
+    "preview": "npm --workspace revenuepilot-frontend run preview",
     "electron:dev": "npm run build && npm run backend:prebuild && electron electron/main.js",
     "electron:build": "npm run build && npm run fetch-icons && npm run backend:prebuild && node -r dotenv/config scripts/check-build-env.js && node -r dotenv/config ./node_modules/.bin/electron-builder -mwl",
     "electron:build:current": "npm run build && npm run fetch-icons && npm run backend:prebuild && node -r dotenv/config scripts/check-build-env.js && node -r dotenv/config ./node_modules/.bin/electron-builder",

--- a/revenuepilot-frontend/package.json
+++ b/revenuepilot-frontend/package.json
@@ -63,6 +63,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "vite build"
+    "build": "vite build",
+    "preview": "vite preview"
   }
 }

--- a/scripts/sync-frontend-build.js
+++ b/scripts/sync-frontend-build.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+/* eslint-env node */
+
+const fs = require('fs');
+const path = require('path');
+
+const workspaceRoot = path.resolve(__dirname, '..');
+const sourceDir = path.join(workspaceRoot, 'revenuepilot-frontend', 'build');
+const targetDir = path.join(workspaceRoot, 'electron', 'dist');
+
+if (!fs.existsSync(sourceDir)) {
+  console.error(`Expected frontend build output at ${sourceDir}, but it was not found. Did you run the workspace build?`);
+  process.exit(1);
+}
+
+fs.rmSync(targetDir, { recursive: true, force: true });
+fs.mkdirSync(targetDir, { recursive: true });
+fs.cpSync(sourceDir, targetDir, { recursive: true });
+
+console.log(`Copied revenuepilot-frontend build from ${sourceDir} to ${targetDir}.`);

--- a/start.ps1
+++ b/start.ps1
@@ -19,7 +19,7 @@ try {
     $env:VITE_API_URL = "http://localhost:8000"
 
     Write-Host "Starting frontend (Vite) on default port..."
-    npm run dev
+    npm --workspace revenuepilot-frontend run dev
 }
 finally {
     Write-Host "Stopping backend..."

--- a/start.sh
+++ b/start.sh
@@ -25,7 +25,7 @@ export VITE_API_URL="http://localhost:8000"
 
 echo "Starting frontend (Vite) on default port..."
 
-# Start the React development server.  This will block until you exit it (Ctrl+C).
-npm run dev
+# Start the React development server from the workspace. This blocks until exit (Ctrl+C).
+npm --workspace revenuepilot-frontend run dev
 
 # When the frontend exits, the trap will kill the backend.

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,12 +1,29 @@
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { defineConfig, loadConfigFromFile, mergeConfig } from 'vite';
 
-// Vite configuration for the RevenuePilot app. The React plugin enables
-// fast refresh and JSX/TSX support.
-export default defineConfig(({ mode }) => ({
-  base: mode === 'development' ? '/' : './', // relative paths in packaged build
-  plugins: [react()],
-  build: {
-    outDir: 'electron/dist',
-  },
-}));
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const frontendRoot = path.resolve(__dirname, 'revenuepilot-frontend');
+const frontendConfigPath = path.join(frontendRoot, 'vite.config.ts');
+
+export default defineConfig(async ({ command, mode }) => {
+  const { config: workspaceConfig = {} } = await loadConfigFromFile(
+    { command, mode },
+    frontendConfigPath
+  );
+
+  const resolvedWorkspaceConfig =
+    typeof workspaceConfig === 'function'
+      ? await workspaceConfig({ command, mode })
+      : workspaceConfig;
+
+  return mergeConfig(resolvedWorkspaceConfig, {
+    root: frontendRoot,
+    base: command === 'serve' ? '/' : './',
+    build: {
+      ...(resolvedWorkspaceConfig.build ?? {}),
+      outDir: path.resolve(__dirname, 'electron', 'dist'),
+      emptyOutDir: true,
+    },
+  });
+});


### PR DESCRIPTION
## Summary
- point the root npm scripts and helper start scripts at the revenuepilot-frontend workspace and copy its build output into electron/dist for packaging
- expose the finalization-wizard CSS bundle through a postbuild step so the frontend can import it when building
- reuse the workspace Vite configuration from the root and update Electron to load the new workspace bundle paths

## Testing
- npm run dev
- npm run build
- npm run electron:build *(fails: missing dmg-license module in the electron-builder toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68cde0e8836083249bb9576e566e6861