### PR TITLE
Implement streaming chart uploads with progress tracking

### DIFF
--- a/revenuepilot-frontend/src/ProtectedApp.tsx
+++ b/revenuepilot-frontend/src/ProtectedApp.tsx
@@ -7,7 +7,7 @@ import { Analytics } from "./components/Analytics"
 import { Settings } from "./components/Settings"
 import { ActivityLog } from "./components/ActivityLog"
 import { Drafts } from "./components/Drafts"
-import { Schedule } from "./components/Schedule"
+import { Schedule, type ScheduleChartUploadStatus } from "./components/Schedule"
 import { Builder } from "./components/Builder"
 import { NoteEditor } from "./components/NoteEditor"
 import { SuggestionPanel } from "./components/SuggestionPanel"
@@ -148,6 +148,7 @@ export function ProtectedApp() {
   const [scheduleRefreshKey, setScheduleRefreshKey] = useState(0)
   const [scheduleFilters, setScheduleFilters] = useState<ScheduleFiltersSnapshot | null>(null)
   const [draftCount, setDraftCount] = useState<number | null>(null)
+  const [chartUploadStatuses, setChartUploadStatuses] = useState<Record<string, ScheduleChartUploadStatus>>({})
 
   const normalizeText = useCallback((value?: string | null, fallback = "") => {
     if (!value) {
@@ -612,12 +613,160 @@ export function ProtectedApp() {
     setDraftCount(summary.total)
   }, [])
 
-  const handleUploadChart = (patientId: string) => {
-    console.log(`Uploading chart for patient ${patientId}`)
-    // In a real app, this would open the chart upload wizard
-    // For now, we'll just log it - the wizard will be built later
-    alert(`Chart upload wizard for patient ${patientId} will be implemented in the next phase.`)
-  }
+  const handleUploadChart = useCallback((patientId: string) => {
+    const input = document.createElement("input")
+    input.type = "file"
+    input.accept = ".pdf,.txt,.rtf,.doc,.docx,.json,.xml"
+
+    const cleanup = () => {
+      input.value = ""
+      input.remove()
+    }
+
+    const uploadFile = async (file: File) => {
+      const boundary = `----RevenuePilotUpload${Math.random().toString(16).slice(2)}`
+      const encoder = new TextEncoder()
+      const safeFileName = file.name.replace(/"/g, "%22") || "chart-upload"
+      const prefixBytes = encoder.encode(
+        `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="${safeFileName}"\r\nContent-Type: ${
+          file.type || "application/octet-stream"
+        }\r\n\r\n`
+      )
+      const suffixBytes = encoder.encode("\r\n--" + boundary + "--\r\n")
+      const totalBytes = Math.max(prefixBytes.byteLength + file.size + suffixBytes.byteLength, 1)
+      let uploadedBytes = 0
+      const reader = file.stream().getReader()
+
+      const updateProgress = (progress: number, status: ScheduleChartUploadStatus["status"] = "uploading", error?: string) => {
+        const boundedProgress = Math.max(0, Math.min(100, Math.round(progress)))
+        setChartUploadStatuses(prev => ({
+          ...prev,
+          [patientId]: {
+            status,
+            progress: boundedProgress,
+            fileName: file.name,
+            error
+          }
+        }))
+      }
+
+      updateProgress(0)
+
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(prefixBytes)
+          uploadedBytes += prefixBytes.byteLength
+          updateProgress((uploadedBytes / totalBytes) * 100)
+
+          const pump = (): void => {
+            reader
+              .read()
+              .then(({ done, value }) => {
+                if (done) {
+                  controller.enqueue(suffixBytes)
+                  uploadedBytes += suffixBytes.byteLength
+                  updateProgress((uploadedBytes / totalBytes) * 100)
+                  controller.close()
+                  return
+                }
+
+                if (value) {
+                  controller.enqueue(value)
+                  uploadedBytes += value.byteLength
+                  updateProgress((uploadedBytes / totalBytes) * 100)
+                }
+
+                pump()
+              })
+              .catch(error => {
+                controller.error(error)
+              })
+          }
+
+          pump()
+        },
+        cancel(reason) {
+          reader.cancel(reason).catch(() => undefined)
+        }
+      })
+
+      const controller = new AbortController()
+
+      try {
+        const response = await apiFetch("/api/charts/upload", {
+          method: "POST",
+          body: stream,
+          headers: {
+            "Content-Type": `multipart/form-data; boundary=${boundary}`
+          },
+          signal: controller.signal
+        })
+
+        if (!response.ok) {
+          const message = await response.text()
+          throw new Error(message || "Unable to upload chart.")
+        }
+
+        try {
+          await response.json()
+        } catch {
+          // Ignore JSON parsing issues – upload succeeded
+        }
+
+        updateProgress(100, "success")
+
+        setAppointmentsState(prev => {
+          if (!prev.data) {
+            return prev
+          }
+          return {
+            ...prev,
+            data: prev.data.map(appointment =>
+              appointment.patientId === patientId
+                ? { ...appointment, fileUpToDate: true }
+                : appointment
+            )
+          }
+        })
+
+        try {
+          await apiFetchJson("/api/activity/log", {
+            method: "POST",
+            jsonBody: {
+              action: "chart.upload",
+              category: "chart",
+              details: {
+                patientId,
+                fileName: file.name,
+                size: file.size
+              }
+            }
+          })
+        } catch (error) {
+          console.error("Failed to log chart upload", error)
+        }
+
+        triggerScheduleRefresh()
+      } catch (error) {
+        if ((error as DOMException)?.name === "AbortError") {
+          return
+        }
+        const message = error instanceof Error ? error.message : "Unable to upload chart."
+        updateProgress(0, "error", message)
+      }
+    }
+
+    input.addEventListener("change", () => {
+      const file = input.files?.[0]
+      if (!file) {
+        cleanup()
+        return
+      }
+      void uploadFile(file).finally(cleanup)
+    })
+
+    input.click()
+  }, [triggerScheduleRefresh])
 
   // Calculate user's draft count for navigation badge
   const getUserDraftCount = () => {
@@ -899,6 +1048,7 @@ export function ProtectedApp() {
                   currentUser={currentUser}
                   onStartVisit={handleStartVisit}
                   onUploadChart={handleUploadChart}
+                  uploadStatuses={chartUploadStatuses}
                   appointments={appointmentsState.data ?? []}
                   loading={appointmentsState.loading}
                   error={appointmentsState.error}

--- a/revenuepilot-frontend/src/components/__tests__/ProtectedApp.chartUpload.test.tsx
+++ b/revenuepilot-frontend/src/components/__tests__/ProtectedApp.chartUpload.test.tsx
@@ -1,0 +1,279 @@
+import { describe, expect, it, beforeAll, beforeEach, vi } from "vitest"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom/vitest"
+
+const mockedApiFetch = vi.fn()
+const mockedApiFetchJson = vi.fn()
+
+vi.mock("../../contexts/AuthContext", () => ({
+  useAuth: () => ({
+    user: {
+      id: "user-1",
+      name: "Test Clinician",
+      role: "user"
+    },
+    hasPermission: () => true
+  })
+}))
+
+const sessionActions = {
+  addCode: vi.fn(),
+  removeCode: vi.fn(),
+  changeCodeCategory: vi.fn(),
+  setSuggestionPanelOpen: vi.fn(),
+  setLayout: vi.fn(),
+  refresh: vi.fn(),
+  reset: vi.fn()
+}
+
+vi.mock("../../contexts/SessionContext", () => ({
+  useSession: () => ({
+    state: {
+      selectedCodes: { codes: 0, prevention: 0, diagnoses: 0, differentials: 0 },
+      selectedCodesList: [],
+      addedCodes: [],
+      isSuggestionPanelOpen: false,
+      layout: { noteEditor: 70, suggestionPanel: 30 }
+    },
+    hydrated: true,
+    syncing: false,
+    actions: sessionActions
+  })
+}))
+
+vi.mock(
+  "finalization-wizard",
+  () => ({
+    FinalizationWizard: () => null
+  }),
+  { virtual: true }
+)
+
+vi.mock(
+  "finalization-wizard/dist/style.css",
+  () => ({}),
+  { virtual: true }
+)
+
+vi.mock("../../components/FinalizationWizardAdapter", () => ({
+  FinalizationWizardAdapter: () => null
+}))
+
+vi.mock("../../components/Schedule", () => {
+  const React = require("react") as typeof import("react")
+  return {
+    Schedule: ({ onUploadChart, uploadStatuses }: { onUploadChart?: (patientId: string) => void; uploadStatuses?: Record<string, unknown> }) =>
+      React.createElement(
+        React.Fragment,
+        null,
+        React.createElement(
+          "button",
+          {
+            type: "button",
+            onClick: () => onUploadChart?.("PT-0001")
+          },
+          "Upload Chart"
+        ),
+        React.createElement(
+          "pre",
+          { "data-testid": "upload-status" },
+          JSON.stringify(uploadStatuses ?? {})
+        )
+      )
+  }
+})
+
+vi.mock("../../lib/api", async () => {
+  const actual = await vi.importActual<typeof import("../../lib/api")>("../../lib/api")
+  return {
+    ...actual,
+    apiFetch: mockedApiFetch,
+    apiFetchJson: mockedApiFetchJson
+  }
+})
+
+function resolveUrl(input: unknown): string {
+  if (typeof input === "string") {
+    return input
+  }
+  if (typeof URL !== "undefined" && input instanceof URL) {
+    return input.toString()
+  }
+  if (typeof Request !== "undefined" && input instanceof Request) {
+    return input.url
+  }
+  return String(input)
+}
+
+describe("ProtectedApp chart upload flow", () => {
+  beforeAll(() => {
+    class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    vi.stubGlobal("ResizeObserver", ResizeObserver)
+
+    if (!window.matchMedia) {
+      Object.defineProperty(window, "matchMedia", {
+        writable: true,
+        value: vi.fn().mockImplementation(() => ({
+          matches: false,
+          media: "",
+          onchange: null,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          dispatchEvent: vi.fn()
+        }))
+      })
+    }
+  })
+
+  beforeEach(() => {
+    mockedApiFetch.mockReset()
+    mockedApiFetchJson.mockReset()
+    Object.values(sessionActions).forEach(action => action.mockReset?.())
+  })
+
+  it("uploads a chart, logs the activity, and refreshes the schedule", async () => {
+    const { ProtectedApp } = await import("../../ProtectedApp")
+    const start = new Date()
+    const end = new Date(start.getTime() + 30 * 60 * 1000)
+    const scheduleResponses = [
+      {
+        appointments: [
+          {
+            id: 1,
+            patient: "Test Patient",
+            reason: "Follow-up visit",
+            start: start.toISOString(),
+            end: end.toISOString(),
+            provider: "Test Clinician",
+            status: "Scheduled"
+          }
+        ]
+      },
+      {
+        appointments: [
+          {
+            id: 1,
+            patient: "Test Patient",
+            reason: "Follow-up visit",
+            start: start.toISOString(),
+            end: end.toISOString(),
+            provider: "Test Clinician",
+            status: "Completed"
+          }
+        ]
+      }
+    ]
+
+    let scheduleFetchCount = 0
+
+    mockedApiFetchJson.mockImplementation(async (input, options) => {
+      const url = resolveUrl(input)
+      if (url === "/api/user/current-view") {
+        return { currentView: "schedule" }
+      }
+      if (url === "/api/schedule/appointments") {
+        const response = scheduleResponses[Math.min(scheduleFetchCount, scheduleResponses.length - 1)]
+        scheduleFetchCount += 1
+        return response
+      }
+      if (url === "/api/analytics/drafts") {
+        return { drafts: 0 }
+      }
+      if (url === "/api/activity/log" && options?.method === "POST") {
+        return { status: "logged" }
+      }
+      return null
+    })
+
+    mockedApiFetch.mockResolvedValue(
+      new Response(JSON.stringify({ filename: "chart.txt", size: 12 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      })
+    )
+
+    const createdInputs: HTMLInputElement[] = []
+    const originalCreateElement = document.createElement.bind(document)
+    const createElementSpy = vi.spyOn(document, "createElement").mockImplementation(tagName => {
+      const element = originalCreateElement(tagName) as HTMLElement
+      if (tagName === "input") {
+        createdInputs.push(element as HTMLInputElement)
+      }
+      return element
+    })
+
+    render(<ProtectedApp />)
+
+    await screen.findByRole("heading", { name: /patient schedule/i })
+    const uploadButton = await screen.findByRole("button", { name: /upload chart/i })
+    fireEvent.click(uploadButton)
+
+    expect(createdInputs.length).toBeGreaterThan(0)
+    const input = createdInputs.find(element => element.accept?.includes(".pdf")) ?? createdInputs[createdInputs.length - 1]
+    expect(input).toBeTruthy()
+    const file = new File(["chart data"], "chart.txt", { type: "text/plain" })
+    const inputElement = input as HTMLInputElement
+    Object.defineProperty(file, "stream", {
+      writable: true,
+      value: () =>
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("chart data"))
+            controller.close()
+          }
+        })
+    })
+    Object.defineProperty(inputElement, "files", {
+      value: [file],
+      writable: false
+    })
+    inputElement.dispatchEvent(new Event("change", { bubbles: true }))
+
+    await waitFor(() => {
+      const status = JSON.parse(screen.getByTestId("upload-status").textContent ?? "{}") as Record<string, { status: string }>
+      expect(status["PT-0001"]).toBeTruthy()
+      expect(status["PT-0001"].status).toBe("uploading")
+    })
+
+    await waitFor(() => {
+      expect(mockedApiFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/api/charts/upload"),
+        expect.objectContaining({ method: "POST" })
+      )
+    })
+
+    await waitFor(() => {
+      const status = JSON.parse(screen.getByTestId("upload-status").textContent ?? "{}") as Record<string, { status: string; progress: number }>
+      expect(status["PT-0001"].status).toBe("success")
+      expect(status["PT-0001"].progress).toBe(100)
+    })
+
+    await waitFor(() => {
+      expect(scheduleFetchCount).toBeGreaterThanOrEqual(2)
+    })
+
+    await waitFor(() => {
+      const logCall = mockedApiFetchJson.mock.calls.find(([request]) => resolveUrl(request) === "/api/activity/log")
+      expect(logCall).toBeTruthy()
+      expect(logCall?.[1]).toMatchObject({
+        method: "POST",
+        jsonBody: expect.objectContaining({
+          action: "chart.upload",
+          details: expect.objectContaining({
+            patientId: "PT-0001",
+            fileName: "chart.txt"
+          })
+        })
+      })
+    })
+
+    createElementSpy.mockRestore()
+  })
+})
+


### PR DESCRIPTION
## Summary
- replace the chart upload alert in ProtectedApp with a streaming upload handler that tracks per-patient progress, logs activity, and triggers schedule refreshes
- surface chart upload status in the schedule card with uploading, success, and error states while disabling the upload button appropriately
- add a focused Vitest suite that drives the chart upload flow, verifies API calls, activity logging, and status propagation via a stubbed Schedule component

## Testing
- npx vitest run revenuepilot-frontend/src/components/__tests__/ProtectedApp.chartUpload.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cebd41d3e883248da7b2a476e31c05