### PR TITLE
Support websocket token fallbacks

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1801,11 +1801,46 @@ def require_roles(*roles: str):
 async def ws_require_role(websocket: WebSocket, role: str) -> Dict[str, Any]:
     """Authenticate a websocket connection against a required role."""
 
-    auth = websocket.headers.get("Authorization")
-    if not auth or not auth.lower().startswith("bearer "):
+    def _normalise_token(candidate: str | None) -> str | None:
+        if not candidate:
+            return None
+        value = candidate.strip()
+        if not value:
+            return None
+        if value.lower().startswith("bearer "):
+            _, _, remainder = value.partition(" ")
+            value = remainder.strip()
+        return value or None
+
+    token: str | None = None
+    auth_header = websocket.headers.get("Authorization")
+    if auth_header and auth_header.lower().startswith("bearer "):
+        token = _normalise_token(auth_header)
+
+    if not token:
+        token = _normalise_token(websocket.query_params.get("token"))
+
+    if not token:
+        candidates: List[str] = []
+        header_protocols = websocket.headers.get("sec-websocket-protocol")
+        if header_protocols:
+            candidates.extend(
+                [part.strip() for part in header_protocols.split(",") if part.strip()]
+            )
+        scope_protocols = websocket.scope.get("subprotocols") or []
+        for proto in scope_protocols:
+            if proto and proto not in candidates:
+                candidates.append(proto)
+        for proto in candidates:
+            if proto.lower().startswith("bearer "):
+                token = _normalise_token(proto)
+                if token:
+                    break
+
+    if not token:
         await websocket.close(code=1008)
         raise WebSocketDisconnect()
-    token = auth.split()[1]
+
     credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
     try:
         data = get_current_user(credentials, required_role=role)

--- a/revenuepilot-frontend/src/components/NavigationSidebar.tsx
+++ b/revenuepilot-frontend/src/components/NavigationSidebar.tsx
@@ -20,7 +20,7 @@ import { Avatar, AvatarFallback } from "./ui/avatar"
 import { getPrimaryNavItems, secondaryNavItems, bottomNavItems } from "./navigation/NavigationConfig"
 import { NotificationsPanel } from "./navigation/NotificationsPanel"
 import { Notification } from "./navigation/NotificationUtils"
-import { apiFetch, apiFetchJson } from "../lib/api"
+import { apiFetch, apiFetchJson, getStoredToken, resolveWebsocketUrl } from "../lib/api"
 import { isViewKey, mapServerViewToViewKey, mapViewKeyToServerView } from "../lib/navigation"
 import type { ViewKey } from "../lib/navigation"
 
@@ -687,9 +687,15 @@ function NavigationSidebarContent({ currentView, onNavigate, currentUser, userDr
       }
 
       try {
-        const protocol = window.location.protocol === "https:" ? "wss" : "ws"
-        const url = `${protocol}://${window.location.host}/ws/notifications`
-        ws = new WebSocket(url)
+        const token = getStoredToken()
+        const wsTarget = new URL(resolveWebsocketUrl("/ws/notifications"))
+        if (token) {
+          wsTarget.searchParams.set("token", token)
+        }
+        const protocols = token ? ["authorization", `Bearer ${token}`] : undefined
+        ws = protocols
+          ? new WebSocket(wsTarget.toString(), protocols)
+          : new WebSocket(wsTarget.toString())
       } catch (error) {
         setNotificationsError(prev => prev ?? "Unable to connect to notifications channel.")
         startPolling()

--- a/revenuepilot-frontend/src/components/__tests__/NavigationSidebar.notifications.test.tsx
+++ b/revenuepilot-frontend/src/components/__tests__/NavigationSidebar.notifications.test.tsx
@@ -1,0 +1,99 @@
+import { render, waitFor } from "@testing-library/react"
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest"
+
+import { NavigationSidebar } from "../NavigationSidebar"
+import { SidebarProvider } from "../ui/sidebar"
+import * as api from "../../lib/api"
+
+describe("NavigationSidebar websocket authentication", () => {
+  const matchMediaMock = vi.fn().mockReturnValue({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn()
+  })
+
+  beforeEach(() => {
+    matchMediaMock.mockClear()
+    vi.stubGlobal("matchMedia", matchMediaMock)
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      writable: true,
+      value: 1024
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it("appends the stored token when connecting to the notifications websocket", async () => {
+    const token = "abc123-token"
+    const getStoredTokenSpy = vi.spyOn(api, "getStoredToken").mockReturnValue(token)
+    vi.spyOn(api, "resolveWebsocketUrl").mockImplementation((path: string) => {
+      const relative = path.startsWith("/") ? path : `/${path}`
+      return `ws://example.test${relative}`
+    })
+    vi.spyOn(api, "apiFetchJson").mockImplementation(async (input: RequestInfo | URL) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : (input as Request).url
+      if (url === "/api/user/current-view") {
+        return { currentView: null }
+      }
+      if (url === "/api/notifications/count") {
+        return { count: 0 }
+      }
+      if (url === "/api/user/profile") {
+        return { currentView: null, clinic: null, preferences: {}, uiPreferences: {} }
+      }
+      if (url === "/api/user/ui-preferences") {
+        return { uiPreferences: {} }
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+    vi.spyOn(api, "apiFetch").mockResolvedValue(new Response(null, { status: 200 }))
+
+    const wsInstances: Array<{ onclose: ((event?: any) => void) | null }> = []
+    const WebSocketMock = vi.fn().mockImplementation((url: string, protocols?: string[]) => {
+      const instance = {
+        readyState: 1,
+        url,
+        protocols,
+        onopen: null as ((event?: any) => void) | null,
+        onclose: null as ((event?: any) => void) | null,
+        onmessage: null as ((event: MessageEvent) => void) | null,
+        onerror: null as ((event?: any) => void) | null,
+        send: vi.fn(),
+        close(this: any) {
+          this.readyState = 3
+          this.onclose?.()
+        }
+      }
+      wsInstances.push(instance)
+      return instance as unknown as WebSocket
+    })
+    vi.stubGlobal("WebSocket", WebSocketMock)
+
+    render(
+      <SidebarProvider>
+        <NavigationSidebar userDraftCount={0} />
+      </SidebarProvider>
+    )
+
+    await waitFor(() => {
+      expect(WebSocketMock).toHaveBeenCalledTimes(1)
+    })
+
+    expect(getStoredTokenSpy).toHaveBeenCalled()
+    const [url, protocols] = WebSocketMock.mock.calls[0]
+    expect(url).toBe("ws://example.test/ws/notifications?token=abc123-token")
+    expect(protocols).toEqual(["authorization", "Bearer abc123-token"])
+
+    // ensure cleanup does not throw when the component unmounts
+    wsInstances.forEach(instance => instance.onclose?.())
+  })
+})

--- a/tests/test_websocket_auth.py
+++ b/tests/test_websocket_auth.py
@@ -1,0 +1,68 @@
+import asyncio
+import sqlite3
+
+import pytest
+from starlette.datastructures import Headers, QueryParams, URL
+
+from backend import main, migrations
+
+
+class FakeWebSocket:
+    def __init__(
+        self,
+        *,
+        auth_header: str | None = None,
+        query_token: str | None = None,
+        protocols: list[str] | None = None,
+    ) -> None:
+        self.headers = Headers({})
+        if auth_header:
+            self.headers = Headers({"Authorization": auth_header})
+        self.query_params = QueryParams({})
+        if query_token is not None:
+            self.query_params = QueryParams({"token": query_token})
+        self.scope = {"subprotocols": protocols or []}
+        self.client = type("Client", (), {"host": "testclient"})()
+        self.url = URL("ws://testserver/ws/notifications")
+        self.closed_code: int | None = None
+
+    async def close(self, code: int = 1000) -> None:
+        self.closed_code = code
+
+
+def _setup_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    db = sqlite3.connect(":memory:", check_same_thread=False)
+    db.row_factory = sqlite3.Row
+    db.execute(
+        "CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password_hash TEXT, role TEXT)"
+    )
+    migrations.ensure_notifications_table(db)
+    migrations.ensure_notification_counters_table(db)
+    pwd = main.hash_password("pw")
+    db.execute(
+        "INSERT INTO users (username, password_hash, role) VALUES (?,?,?)",
+        ("alice", pwd, "user"),
+    )
+    db.commit()
+    monkeypatch.setattr(main, "db_conn", db)
+    monkeypatch.setattr(main, "notification_counts", main.NotificationStore())
+
+
+def test_ws_require_role_accepts_query_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    _setup_db(monkeypatch)
+    token = main.create_token("alice", "user")
+    ws = FakeWebSocket(query_token=token)
+
+    data = asyncio.run(main.ws_require_role(ws, "user"))
+    assert data["sub"] == "alice"
+    assert ws.closed_code is None
+
+
+def test_ws_require_role_accepts_subprotocol(monkeypatch: pytest.MonkeyPatch) -> None:
+    _setup_db(monkeypatch)
+    token = main.create_token("alice", "user")
+    ws = FakeWebSocket(protocols=["authorization", f"Bearer {token}"])
+
+    data = asyncio.run(main.ws_require_role(ws, "user"))
+    assert data["sub"] == "alice"
+    assert ws.closed_code is None


### PR DESCRIPTION
## Summary
- allow websocket authentication to read bearer tokens from query parameters or accepted subprotocols when headers are unavailable
- ensure the notifications sidebar websocket appends stored tokens using the shared URL helpers
- add targeted backend and frontend tests to exercise the websocket authentication flow

## Testing
- pytest tests/test_websocket_auth.py --no-cov
- npm test -- NavigationSidebar.notifications.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ceca37cc5c8324b1870b37c7ae33ac