### PR TITLE
Persist notifications and sync UI feed

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -130,6 +130,7 @@ from backend.migrations import (  # type: ignore
     ensure_compliance_rules_table,
     ensure_confidence_scores_table,
     ensure_notification_counters_table,
+    ensure_notification_events_table,
     ensure_compliance_rule_catalog_table,
     ensure_cpt_codes_table,
     ensure_icd10_codes_table,
@@ -684,6 +685,19 @@ notification_subscribers: Dict[str, List[WebSocket]] = defaultdict(list)
 class NotificationStore:
     """SQLite-backed mapping interface for notification counters."""
 
+    def __contains__(self, username: object) -> bool:  # pragma: no cover - trivial lookup
+        if not isinstance(username, str):
+            return False
+        ensure_notifications_table(db_conn)
+        try:
+            row = db_conn.execute(
+                "SELECT 1 FROM notifications WHERE username=?",
+                (username,),
+            ).fetchone()
+        except sqlite3.Error:
+            return False
+        return bool(row)
+
     def __getitem__(self, username: str) -> int:
         return self.get(username, 0)
 
@@ -733,6 +747,238 @@ def _timestamp_to_iso(value: Any) -> str | None:
         return datetime.fromtimestamp(float(value), timezone.utc).isoformat()
     except Exception:
         return None
+
+
+def _parse_timestamp(value: Any) -> float:
+    """Best-effort conversion of *value* to a Unix timestamp."""
+
+    if value is None:
+        return time.time()
+    if isinstance(value, (int, float)):
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return time.time()
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            try:
+                normalised = value.strip()
+                if normalised.endswith("Z"):
+                    normalised = normalised[:-1] + "+00:00"
+                return datetime.fromisoformat(normalised).timestamp()
+            except Exception:
+                return time.time()
+    return time.time()
+
+
+def _normalise_notification_event_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Coerce an inbound notification payload into stored schema."""
+
+    raw_id = (
+        payload.get("notificationId")
+        or payload.get("eventId")
+        or payload.get("id")
+        or uuid.uuid4()
+    )
+    event_id = str(raw_id)
+
+    title = payload.get("title")
+    if not isinstance(title, str) or not title.strip():
+        title = payload.get("type")
+    title_str = str(title).strip() if title else "Notification"
+
+    message_source = payload.get("message")
+    if not isinstance(message_source, str) or not message_source.strip():
+        for candidate in ("description", "detail", "text"):
+            value = payload.get(candidate)
+            if isinstance(value, str) and value.strip():
+                message_source = value
+                break
+    message_str = (
+        str(message_source).strip()
+        if isinstance(message_source, str) and message_source.strip()
+        else "You have a new notification."
+    )
+
+    severity_value = payload.get("severity") or payload.get("type") or "info"
+    severity_str = str(severity_value).strip().lower() or "info"
+
+    timestamp = (
+        payload.get("timestamp")
+        or payload.get("created_at")
+        or payload.get("createdAt")
+    )
+    created_at = _parse_timestamp(timestamp)
+
+    return {
+        "id": event_id,
+        "title": title_str,
+        "message": message_str,
+        "severity": severity_str,
+        "created_at": created_at,
+    }
+
+
+def _sync_unread_notification_count(
+    username: str, *, user_id: int | None = None
+) -> int:
+    """Recompute unread notification count for *username* from stored events."""
+
+    ensure_notification_events_table(db_conn)
+    if user_id is None:
+        user_id = _get_user_db_id(username)
+    if user_id is None:
+        return set_notification_count(username, 0)
+    row = db_conn.execute(
+        "SELECT COUNT(*) AS unread FROM notification_events WHERE user_id=? AND is_read=0",
+        (user_id,),
+    ).fetchone()
+    unread = int(row["unread"]) if row and row["unread"] is not None else 0
+    return set_notification_count(username, unread)
+
+
+def _persist_notification_event(
+    username: str,
+    payload: Dict[str, Any],
+    *,
+    mark_unread: bool,
+) -> tuple[Dict[str, Any], int]:
+    """Insert or update a notification event for *username*."""
+
+    ensure_notification_events_table(db_conn)
+    record = _normalise_notification_event_payload(payload)
+    user_id = _get_user_db_id(username)
+    if user_id is None:
+        enriched = {
+            "id": record["id"],
+            "title": record["title"],
+            "message": record["message"],
+            "severity": record["severity"],
+            "timestamp": _iso_timestamp(record["created_at"]),
+            "isRead": not mark_unread,
+        }
+        return enriched, current_notification_count(username)
+
+    now = time.time()
+    existing = db_conn.execute(
+        """
+        SELECT created_at, is_read, read_at
+          FROM notification_events
+         WHERE event_id=? AND user_id=?
+        """,
+        (record["id"], user_id),
+    ).fetchone()
+
+    if existing:
+        is_read = int(existing["is_read"]) if existing["is_read"] is not None else 0
+        read_at = existing["read_at"]
+        if mark_unread:
+            is_read = 0
+            read_at = None
+        db_conn.execute(
+            """
+            UPDATE notification_events
+               SET title=?,
+                   message=?,
+                   severity=?,
+                   updated_at=?,
+                   is_read=?,
+                   read_at=?
+             WHERE event_id=? AND user_id=?
+            """,
+            (
+                record["title"],
+                record["message"],
+                record["severity"],
+                now,
+                is_read,
+                read_at,
+                record["id"],
+                user_id,
+            ),
+        )
+        created_at = (
+            existing["created_at"] if existing["created_at"] is not None else record["created_at"]
+        )
+    else:
+        is_read = 0 if mark_unread else 1
+        read_at = None if mark_unread else now
+        created_at = record["created_at"]
+        db_conn.execute(
+            """
+            INSERT INTO notification_events (
+                event_id,
+                user_id,
+                title,
+                message,
+                severity,
+                created_at,
+                updated_at,
+                is_read,
+                read_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                record["id"],
+                user_id,
+                record["title"],
+                record["message"],
+                record["severity"],
+                created_at,
+                now,
+                is_read,
+                read_at,
+            ),
+        )
+
+    db_conn.commit()
+
+    unread = _sync_unread_notification_count(username, user_id=user_id)
+
+    row = db_conn.execute(
+        """
+        SELECT created_at, is_read, read_at, severity, title, message
+          FROM notification_events
+         WHERE event_id=? AND user_id=?
+        """,
+        (record["id"], user_id),
+    ).fetchone()
+
+    created_at = row["created_at"] if row and row["created_at"] is not None else created_at
+    is_read = bool(row["is_read"]) if row else bool(not mark_unread)
+    read_at = row["read_at"] if row else (None if mark_unread else now)
+    severity = row["severity"] if row and row["severity"] else record["severity"]
+    title = row["title"] if row and row["title"] else record["title"]
+    message = row["message"] if row and row["message"] else record["message"]
+
+    enriched = {
+        "id": record["id"],
+        "title": title,
+        "message": message,
+        "severity": severity,
+        "timestamp": _iso_timestamp(created_at),
+        "isRead": is_read,
+    }
+    if read_at:
+        enriched["readAt"] = _iso_timestamp(read_at)
+
+    return enriched, unread
+
+
+def _serialise_notification_row(row: sqlite3.Row) -> Dict[str, Any]:
+    """Convert a notification row into an API-friendly dictionary."""
+
+    return {
+        "id": row["event_id"],
+        "title": row["title"],
+        "message": row["message"],
+        "severity": row["severity"],
+        "timestamp": _iso_timestamp(row["created_at"]),
+        "isRead": bool(row["is_read"]),
+        "readAt": _timestamp_to_iso(row["read_at"]),
+    }
 
 
 def _get_user_db_id(username: str) -> int | None:
@@ -866,6 +1112,7 @@ ensure_compliance_issues_table(db_conn)
 ensure_compliance_rules_table(db_conn)
 ensure_confidence_scores_table(db_conn)
 ensure_notification_counters_table(db_conn)
+ensure_notification_events_table(db_conn)
 patients.configure_database(db_conn)
 
 # Keep the compliance ORM bound to the active database connection.
@@ -3744,7 +3991,117 @@ async def put_user_session(
 async def get_notification_count(
     user=Depends(require_role("user"))
 ) -> Dict[str, int]:
-    return {"count": current_notification_count(user["sub"])}
+    count = _sync_unread_notification_count(user["sub"])
+    return {"count": count}
+
+
+@app.get("/api/notifications")
+async def list_notifications(
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    user=Depends(require_role("user")),
+) -> Dict[str, Any]:
+    username = user["sub"]
+    ensure_notification_events_table(db_conn)
+    user_id = _get_user_db_id(username)
+    if user_id is None:
+        set_notification_count(username, 0)
+        return {
+            "items": [],
+            "total": 0,
+            "limit": limit,
+            "offset": offset,
+            "nextOffset": None,
+            "unreadCount": 0,
+        }
+
+    rows = db_conn.execute(
+        """
+        SELECT event_id, title, message, severity, created_at, is_read, read_at
+          FROM notification_events
+         WHERE user_id=?
+         ORDER BY created_at DESC, id DESC
+         LIMIT ? OFFSET ?
+        """,
+        (user_id, limit, offset),
+    ).fetchall()
+    total_row = db_conn.execute(
+        "SELECT COUNT(*) AS total FROM notification_events WHERE user_id=?",
+        (user_id,),
+    ).fetchone()
+    total = int(total_row["total"]) if total_row and total_row["total"] is not None else 0
+    unread = _sync_unread_notification_count(username, user_id=user_id)
+    items = [_serialise_notification_row(row) for row in rows or []]
+    next_offset = offset + limit if offset + limit < total else None
+    return {
+        "items": items,
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+        "nextOffset": next_offset,
+        "unreadCount": unread,
+    }
+
+
+@app.post("/api/notifications/{event_id}/read")
+async def mark_notification_read(
+    event_id: str,
+    user=Depends(require_role("user")),
+) -> Dict[str, Any]:
+    username = user["sub"]
+    ensure_notification_events_table(db_conn)
+    user_id = _get_user_db_id(username)
+    if user_id is None:
+        raise HTTPException(status_code=404, detail="Notification not found")
+    row = db_conn.execute(
+        "SELECT is_read FROM notification_events WHERE event_id=? AND user_id=?",
+        (event_id, user_id),
+    ).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Notification not found")
+    if not row["is_read"]:
+        now = time.time()
+        db_conn.execute(
+            """
+            UPDATE notification_events
+               SET is_read=1,
+                   read_at=?,
+                   updated_at=?
+             WHERE event_id=? AND user_id=?
+            """,
+            (now, now, event_id, user_id),
+        )
+        db_conn.commit()
+    unread = _sync_unread_notification_count(username, user_id=user_id)
+    await _broadcast_notification_count(username)
+    return {"status": "ok", "unreadCount": unread}
+
+
+@app.post("/api/notifications/read-all")
+async def mark_all_notifications_read(
+    user=Depends(require_role("user")),
+) -> Dict[str, Any]:
+    username = user["sub"]
+    ensure_notification_events_table(db_conn)
+    user_id = _get_user_db_id(username)
+    if user_id is None:
+        set_notification_count(username, 0)
+        return {"status": "ok", "unreadCount": 0}
+    now = time.time()
+    db_conn.execute(
+        """
+        UPDATE notification_events
+           SET is_read=1,
+               read_at=COALESCE(read_at, ?),
+               updated_at=?
+         WHERE user_id=? AND is_read=0
+        """,
+        (now, now, user_id),
+    )
+    db_conn.commit()
+    unread = _sync_unread_notification_count(username, user_id=user_id)
+    await _broadcast_notification_count(username)
+    return {"status": "ok", "unreadCount": unread}
 
 
 class NoteRequest(BaseModel):
@@ -9249,21 +9606,29 @@ async def _push_notification_event(
 ) -> None:
     """Dispatch a notification payload to ``/ws/notifications`` for *username*."""
 
+    stored, count = _persist_notification_event(
+        username,
+        payload,
+        mark_unread=increment,
+    )
     enriched = {**payload}
     enriched.setdefault("channel", "notifications")
     enriched.setdefault("event", "notification")
-    enriched.setdefault("timestamp", _iso_timestamp())
-    count = (
-        increment_notification_count(username)
-        if increment
-        else current_notification_count(username)
-    )
+    enriched.setdefault("title", stored.get("title"))
+    enriched.setdefault("message", stored.get("message"))
+    enriched.setdefault("severity", stored.get("severity"))
+    enriched.setdefault("timestamp", stored.get("timestamp", _iso_timestamp()))
+    enriched.setdefault("isRead", stored.get("isRead", False))
+    if "readAt" not in enriched and stored.get("readAt"):
+        enriched["readAt"] = stored["readAt"]
+    enriched["id"] = stored.get("id")
     enriched["unreadCount"] = count
     session_id = notifications_manager.latest_session(username)
     if session_id:
         await notifications_manager.push(session_id, enriched)
     else:
         await notifications_manager.push_user(username, enriched)
+    await _broadcast_notification_count(username)
 
 
 async def _notify_note_auto_save(username: str, note_id: Optional[int]) -> None:

--- a/backend/migrations.py
+++ b/backend/migrations.py
@@ -639,6 +639,37 @@ def ensure_notification_counters_table(conn: sqlite3.Connection) -> None:
     conn.commit()
 
 
+def ensure_notification_events_table(conn: sqlite3.Connection) -> None:
+    """Ensure the notification_events table persists individual notifications."""
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS notification_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_id TEXT NOT NULL UNIQUE,
+            user_id INTEGER NOT NULL,
+            title TEXT NOT NULL,
+            message TEXT NOT NULL,
+            severity TEXT NOT NULL,
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            is_read INTEGER NOT NULL DEFAULT 0,
+            read_at REAL,
+            FOREIGN KEY(user_id) REFERENCES users(id)
+        )
+        """
+    )
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_notification_events_user ON notification_events(user_id, created_at DESC)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_notification_events_unread ON notification_events(user_id, is_read)"
+    )
+
+    conn.commit()
+
+
 def ensure_compliance_rule_catalog_table(conn: sqlite3.Connection) -> None:
     """Ensure the compliance rule catalogue table exists."""
 

--- a/revenuepilot-frontend/src/components/__tests__/NavigationSidebar.notifications.test.tsx
+++ b/revenuepilot-frontend/src/components/__tests__/NavigationSidebar.notifications.test.tsx
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it, vi, afterEach } from "vitest"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom/vitest"
+
+import { NavigationSidebar } from "../NavigationSidebar"
+import { SidebarProvider } from "../ui/sidebar"
+import { apiFetch, apiFetchJson, resolveWebsocketUrl } from "../../lib/api"
+
+declare global {
+  interface Window {
+    WebSocket: typeof WebSocket
+  }
+}
+
+vi.mock("../../lib/api", () => {
+  return {
+    apiFetchJson: vi.fn(),
+    apiFetch: vi.fn(),
+    resolveWebsocketUrl: vi.fn()
+  }
+})
+
+const mockedApiFetchJson = vi.mocked(apiFetchJson)
+const mockedApiFetch = vi.mocked(apiFetch)
+const mockedResolveWebsocketUrl = vi.mocked(resolveWebsocketUrl)
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = []
+  static OPEN = 1
+  static CLOSED = 3
+
+  readyState = MockWebSocket.OPEN
+  onopen: (() => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onerror: (() => void) | null = null
+  onclose: (() => void) | null = null
+
+  constructor(public url: string) {
+    MockWebSocket.instances.push(this)
+  }
+
+  send() {}
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.(new Event("close"))
+  }
+}
+
+describe("NavigationSidebar notifications", () => {
+  const notificationsEndpoint = `/api/notifications?limit=20&offset=0`
+
+  beforeEach(() => {
+    MockWebSocket.instances = []
+    vi.stubGlobal("WebSocket", MockWebSocket as unknown as typeof WebSocket)
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn()
+      }))
+    )
+
+    mockedApiFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+      text: async () => ""
+    } as unknown as Response)
+
+    const baseNotifications = [
+      {
+        id: "notif-1",
+        title: "Compliance alert",
+        message: "Review required",
+        severity: "high",
+        timestamp: "2024-03-14T08:30:00Z",
+        isRead: false
+      },
+      {
+        id: "notif-2",
+        title: "Reminder",
+        message: "Team standup at 4pm",
+        severity: "info",
+        timestamp: "2024-03-13T08:30:00Z",
+        isRead: true
+      }
+    ]
+
+    let currentNotifications = [...baseNotifications]
+
+    mockedApiFetchJson.mockImplementation(async (url: string, options?: { method?: string }) => {
+      if (url.startsWith("/api/user/current-view")) {
+        return { currentView: null }
+      }
+      if (url === notificationsEndpoint) {
+        return {
+          items: currentNotifications,
+          total: currentNotifications.length,
+          limit: 20,
+          offset: 0,
+          unreadCount: currentNotifications.filter(item => !item.isRead).length
+        }
+      }
+      if (url.startsWith("/api/user/profile")) {
+        return { currentView: null, clinic: null, preferences: {}, uiPreferences: {} }
+      }
+      if (url.startsWith("/api/user/ui-preferences")) {
+        return { uiPreferences: {} }
+      }
+      if (url.startsWith("/api/notifications/") && url.endsWith("/read") && options?.method === "POST") {
+        const id = decodeURIComponent(url.split("/").slice(-2)[0] ?? "")
+        currentNotifications = currentNotifications.map(item =>
+          item.id === id ? { ...item, isRead: true } : item
+        )
+        return { unreadCount: currentNotifications.filter(item => !item.isRead).length }
+      }
+      if (url === "/api/notifications/read-all" && options?.method === "POST") {
+        currentNotifications = currentNotifications.map(item => ({ ...item, isRead: true }))
+        return { unreadCount: 0 }
+      }
+
+      throw new Error(`Unexpected apiFetchJson call: ${url}`)
+    })
+
+    mockedResolveWebsocketUrl.mockReturnValue("ws://localhost/ws/notifications")
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.resetAllMocks()
+  })
+
+  function renderSidebar() {
+    return render(
+      <SidebarProvider>
+        <NavigationSidebar currentView="dashboard" userDraftCount={0} />
+      </SidebarProvider>
+    )
+  }
+
+  it("loads notifications and displays unread count", async () => {
+    renderSidebar()
+
+    await waitFor(() => {
+      expect(mockedApiFetchJson.mock.calls.some(call => call[0] === notificationsEndpoint)).toBe(true)
+    })
+
+    const navTriggers = await screen.findAllByText("Notifications", { selector: 'span.font-medium' })
+    const navTrigger = navTriggers[navTriggers.length - 1]
+    expect(navTrigger).toBeInTheDocument()
+
+    const badges = await screen.findAllByText("1", { selector: '[data-slot="badge"]' })
+    expect(badges.length).toBeGreaterThan(0)
+
+    fireEvent.click(navTrigger)
+
+    expect(await screen.findByText("Compliance alert")).toBeInTheDocument()
+    expect(screen.getByText("Review required")).toBeInTheDocument()
+  })
+
+  it("marks a notification as read via the API", async () => {
+    renderSidebar()
+
+    await waitFor(() => {
+      expect(mockedApiFetchJson.mock.calls.some(call => call[0] === notificationsEndpoint)).toBe(true)
+    })
+
+    const navTriggers = await screen.findAllByText("Notifications", { selector: 'span.font-medium' })
+    const navTrigger = navTriggers[navTriggers.length - 1]
+    fireEvent.click(navTrigger)
+
+    const cards = await screen.findAllByText("Compliance alert", { selector: 'h4', timeout: 2000 })
+    fireEvent.click(cards[0])
+
+    await waitFor(() => {
+      expect(mockedApiFetchJson).toHaveBeenCalledWith(
+        "/api/notifications/notif-1/read",
+        expect.objectContaining({ method: "POST" })
+      )
+    })
+
+    await waitFor(() => {
+      const calls = mockedApiFetchJson.mock.calls.filter(call => call[0] === notificationsEndpoint)
+      expect(calls.length).toBeGreaterThan(1)
+    })
+  })
+
+  it("adds websocket notifications to the feed", async () => {
+    renderSidebar()
+
+    await waitFor(() => {
+      expect(mockedApiFetchJson.mock.calls.some(call => call[0] === notificationsEndpoint)).toBe(true)
+    })
+
+    const navTriggers = await screen.findAllByText("Notifications", { selector: 'span.font-medium' })
+    const navTrigger = navTriggers[navTriggers.length - 1]
+    fireEvent.click(navTrigger)
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances.length).toBeGreaterThan(0)
+    })
+
+    const socket = MockWebSocket.instances[0]
+    socket.onopen?.()
+
+    socket.onmessage?.({
+      data: JSON.stringify({
+        channel: "notifications",
+        event: "notification",
+        id: "notif-3",
+        title: "New task",
+        message: "Review the latest submission",
+        severity: "warning",
+        timestamp: "2024-03-15T10:00:00Z",
+        unreadCount: 2
+      })
+    } as MessageEvent)
+
+    expect(
+      await screen.findByText("New task", undefined, { timeout: 2000 })
+    ).toBeInTheDocument()
+    expect(screen.getByText("Review the latest submission")).toBeInTheDocument()
+  })
+})

--- a/revenuepilot-frontend/src/components/navigation/NotificationUtils.tsx
+++ b/revenuepilot-frontend/src/components/navigation/NotificationUtils.tsx
@@ -1,11 +1,13 @@
+export type NotificationVisualSeverity = 'info' | 'warning' | 'success' | 'error'
+
 export interface Notification {
   id: string
   title: string
   message: string
-  type: 'info' | 'warning' | 'success' | 'error'
+  severity: string
   timestamp: string
   isRead: boolean
-  priority: 'high' | 'medium' | 'low'
+  readAt?: string | null
 }
 
 export const mockNotifications: Notification[] = [
@@ -13,48 +15,57 @@ export const mockNotifications: Notification[] = [
     id: '1',
     title: 'Patient Chart Upload Required',
     message: 'Michael Rodriguez (PT-2024-0143) chart needs to be uploaded before visit.',
-    type: 'warning',
+    severity: 'warning',
     timestamp: '2024-03-14T08:30:00Z',
-    isRead: false,
-    priority: 'high'
+    isRead: false
   },
   {
     id: '2',
     title: 'Coding Accuracy Alert',
     message: 'Review suggested ICD-10 code J06.9 for improved reimbursement.',
-    type: 'info',
+    severity: 'info',
     timestamp: '2024-03-14T07:45:00Z',
-    isRead: false,
-    priority: 'medium'
+    isRead: false
   },
   {
     id: '3',
     title: 'Draft Auto-Saved',
     message: 'Your note for Sarah Chen has been automatically saved.',
-    type: 'success',
+    severity: 'success',
     timestamp: '2024-03-14T07:15:00Z',
-    isRead: true,
-    priority: 'low'
+    isRead: true
   },
   {
     id: '4',
     title: 'System Maintenance',
     message: 'Scheduled maintenance window tonight 11 PM - 2 AM EST.',
-    type: 'info',
+    severity: 'info',
     timestamp: '2024-03-14T06:00:00Z',
-    isRead: true,
-    priority: 'medium'
+    isRead: true
   },
   {
     id: '5',
     title: 'Quality Score Update',
     message: 'Your documentation quality score increased to 94%.',
-    type: 'success',
+    severity: 'success',
     timestamp: '2024-03-13T18:30:00Z',
-    isRead: true,
-    priority: 'low'
+    isRead: true
   }
 ]
+
+export function getVisualSeverity(severity: string | null | undefined): NotificationVisualSeverity {
+  const normalised = typeof severity === 'string' ? severity.toLowerCase() : 'info'
+  if (normalised === 'error' || normalised === 'critical') {
+    return 'error'
+  }
+  if (normalised === 'warning' || normalised === 'high') {
+    return 'warning'
+  }
+  if (normalised === 'success') {
+    return 'success'
+  }
+  return 'info'
+}
 
 export const formatTime = (timestamp: string) => {
   const date = new Date(timestamp)
@@ -70,8 +81,9 @@ export const formatTime = (timestamp: string) => {
   }
 }
 
-export const getNotificationBorderColor = (type: Notification['type']) => {
-  switch (type) {
+export const getNotificationBorderColor = (severity: string | null | undefined) => {
+  const visual = getVisualSeverity(severity)
+  switch (visual) {
     case 'warning':
       return 'border-l-orange-400'
     case 'error':
@@ -80,5 +92,19 @@ export const getNotificationBorderColor = (type: Notification['type']) => {
       return 'border-l-green-400'
     default:
       return 'border-l-blue-400'
+  }
+}
+
+export const getNotificationColorClasses = (severity: string | null | undefined) => {
+  const visual = getVisualSeverity(severity)
+  switch (visual) {
+    case 'warning':
+      return 'text-orange-600 bg-orange-50 border-orange-200'
+    case 'error':
+      return 'text-red-600 bg-red-50 border-red-200'
+    case 'success':
+      return 'text-green-600 bg-green-50 border-green-200'
+    default:
+      return 'text-blue-600 bg-blue-50 border-blue-200'
   }
 }

--- a/revenuepilot-frontend/src/components/navigation/NotificationsPanel.tsx
+++ b/revenuepilot-frontend/src/components/navigation/NotificationsPanel.tsx
@@ -9,7 +9,13 @@ import {
   FileAlert
 } from "lucide-react"
 import { Badge } from "../ui/badge"
-import { Notification, formatTime, getNotificationBorderColor } from "./NotificationUtils"
+import {
+  Notification,
+  formatTime,
+  getNotificationBorderColor,
+  getNotificationColorClasses,
+  getVisualSeverity
+} from "./NotificationUtils"
 
 interface NotificationsPanelProps {
   isOpen: boolean
@@ -48,8 +54,9 @@ export function NotificationsPanel({
 
   if (!isOpen) return null
 
-  const getNotificationIcon = (type: Notification['type']) => {
-    switch (type) {
+  const getNotificationIcon = (severity: string) => {
+    const visual = getVisualSeverity(severity)
+    switch (visual) {
       case 'warning':
         return <AlertCircle className="w-4 h-4 text-orange-500" />
       case 'error':
@@ -58,19 +65,6 @@ export function NotificationsPanel({
         return <CheckCircle className="w-4 h-4 text-green-500" />
       default:
         return <Bell className="w-4 h-4 text-blue-500" />
-    }
-  }
-
-  const getNotificationTypeColor = (type: Notification['type']) => {
-    switch (type) {
-      case 'warning':
-        return 'text-orange-600 bg-orange-50 border-orange-200'
-      case 'error':
-        return 'text-red-600 bg-red-50 border-red-200'
-      case 'success':
-        return 'text-green-600 bg-green-50 border-green-200'
-      default:
-        return 'text-blue-600 bg-blue-50 border-blue-200'
     }
   }
 
@@ -140,17 +134,17 @@ export function NotificationsPanel({
                   animate={{ opacity: 1, y: 0 }}
                   transition={{ delay: index * 0.03 }}
                   className={`relative p-4 transition-all duration-200 cursor-pointer group ${
-                    !notification.isRead 
-                      ? 'bg-gradient-to-r from-blue-50/60 to-blue-50/30 hover:from-blue-50/80 hover:to-blue-50/50' 
+                    !notification.isRead
+                      ? 'bg-gradient-to-r from-blue-50/60 to-blue-50/30 hover:from-blue-50/80 hover:to-blue-50/50'
                       : 'bg-white hover:bg-stone-50/70'
                   } ${index % 2 === 1 ? 'bg-stone-25/30' : ''} border-l-4 ${
-                    !notification.isRead ? 'border-l-blue-400' : getNotificationBorderColor(notification.type).replace('border-l-', 'border-l-')
+                    !notification.isRead ? 'border-l-blue-400' : getNotificationBorderColor(notification.severity)
                   }`}
                   onClick={() => onMarkAsRead(notification.id)}
                 >
                   <div className="flex items-start gap-3">
-                    <div className={`flex-shrink-0 w-9 h-9 rounded-xl flex items-center justify-center border-2 shadow-sm ${getNotificationTypeColor(notification.type)}`}>
-                      {getNotificationIcon(notification.type)}
+                    <div className={`flex-shrink-0 w-9 h-9 rounded-xl flex items-center justify-center border-2 shadow-sm ${getNotificationColorClasses(notification.severity)}`}>
+                      {getNotificationIcon(notification.severity)}
                     </div>
                     <div className="flex-1 min-w-0">
                       <div className="flex items-start justify-between gap-3 mb-2">
@@ -175,11 +169,11 @@ export function NotificationsPanel({
                         {notification.message}
                       </p>
                       <div className="flex items-center justify-between">
-                        <Badge 
-                          variant="outline" 
-                          className={`text-xs px-2 py-1 font-medium border-2 ${getNotificationTypeColor(notification.type)} border-current shadow-sm`}
+                        <Badge
+                          variant="outline"
+                          className={`text-xs px-2 py-1 font-medium border-2 ${getNotificationColorClasses(notification.severity)} border-current shadow-sm`}
                         >
-                          {notification.priority.toUpperCase()}
+                          {(notification.severity || 'info').toUpperCase()}
                         </Badge>
                         {!notification.isRead && (
                           <span className="text-xs text-blue-700 font-medium opacity-0 group-hover:opacity-100 transition-opacity bg-blue-100/60 px-2 py-1 rounded-full">

--- a/tests/test_notification_api.py
+++ b/tests/test_notification_api.py
@@ -1,0 +1,130 @@
+import asyncio
+import sqlite3
+from typing import Tuple
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend import main, migrations
+
+
+class DummyNotificationsManager:
+    def __init__(self) -> None:
+        self.sent: list[Tuple[str, dict]] = []
+
+    def latest_session(self, username: str) -> None:
+        return None
+
+    async def push(self, session_id: str, payload: dict) -> None:
+        self.sent.append(("push", payload))
+
+    async def push_user(self, username: str, payload: dict) -> None:
+        self.sent.append(("push_user", payload))
+
+
+@pytest.fixture
+def notification_client(monkeypatch):
+    db = sqlite3.connect(":memory:", check_same_thread=False)
+    db.row_factory = sqlite3.Row
+    db.execute(
+        "CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password_hash TEXT, role TEXT)"
+    )
+    migrations.ensure_notification_counters_table(db)
+    migrations.ensure_notification_events_table(db)
+    pwd = main.hash_password("pw")
+    db.execute(
+        "INSERT INTO users (username, password_hash, role) VALUES (?,?,?)",
+        ("alice", pwd, "user"),
+    )
+    db.commit()
+    monkeypatch.setattr(main, "db_conn", db)
+    main.notification_counts = main.NotificationStore()
+    manager = DummyNotificationsManager()
+    monkeypatch.setattr(main, "notifications_manager", manager)
+    client = TestClient(main.app)
+    token = main.create_token("alice", "user")
+    yield client, token, manager
+    client.close()
+
+
+def _auth_headers(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_notifications_lifecycle(notification_client):
+    client, token, manager = notification_client
+
+    resp = client.get("/api/notifications", headers=_auth_headers(token))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["items"] == []
+    assert data["unreadCount"] == 0
+
+    asyncio.run(
+        main._push_notification_event(
+            "alice",
+            {"title": "Compliance alert", "message": "Review required", "severity": "high"},
+            increment=True,
+        )
+    )
+    assert manager.sent
+    event_payload = manager.sent[-1][1]
+    assert event_payload["unreadCount"] == 1
+    assert event_payload["id"]
+
+    resp = client.get("/api/notifications", headers=_auth_headers(token))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["unreadCount"] == 1
+    assert len(data["items"]) == 1
+    first = data["items"][0]
+    assert first["title"] == "Compliance alert"
+    assert first["message"] == "Review required"
+    assert not first["isRead"]
+
+    resp = client.get("/api/notifications/count", headers=_auth_headers(token))
+    assert resp.json()["count"] == 1
+
+    resp = client.post(
+        f"/api/notifications/{first['id']}/read",
+        headers=_auth_headers(token),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["unreadCount"] == 0
+
+    resp = client.get("/api/notifications", headers=_auth_headers(token))
+    data = resp.json()
+    assert data["unreadCount"] == 0
+    assert data["items"][0]["isRead"] is True
+
+    asyncio.run(
+        main._push_notification_event(
+            "alice",
+            {"title": "Reminder", "message": "Second item", "severity": "info"},
+            increment=True,
+        )
+    )
+    asyncio.run(
+        main._push_notification_event(
+            "alice",
+            {"title": "Follow up", "message": "Third item", "severity": "warning"},
+            increment=True,
+        )
+    )
+
+    resp = client.get("/api/notifications", headers=_auth_headers(token))
+    data = resp.json()
+    assert data["unreadCount"] == 2
+    assert sum(1 for item in data["items"] if not item["isRead"]) == 2
+
+    resp = client.post("/api/notifications/read-all", headers=_auth_headers(token))
+    assert resp.status_code == 200
+    assert resp.json()["unreadCount"] == 0
+
+    resp = client.get("/api/notifications", headers=_auth_headers(token))
+    data = resp.json()
+    assert data["unreadCount"] == 0
+    assert all(item["isRead"] for item in data["items"])
+
+    resp = client.get("/api/notifications/count", headers=_auth_headers(token))
+    assert resp.json()["count"] == 0


### PR DESCRIPTION
## Summary
- persist individual notifications in SQLite via a new notification_events table and expose REST endpoints for listing notifications plus marking them read
- keep websocket payloads and unread counters aligned with the stored events
- sync the NavigationSidebar with the backend notifications API/websocket feed and add focused frontend and backend regression coverage

## Testing
- pytest --no-cov tests/test_notification_api.py tests/test_user_profile_api.py -q
- yarn test NavigationSidebar.notifications


------
https://chatgpt.com/codex/tasks/task_e_68ceca26ff408324b2d76ff77d4842fc