### PR TITLE
Integrate login experience into workspace shell

### DIFF
--- a/revenuepilot-frontend/src/App.tsx
+++ b/revenuepilot-frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { Button } from "./components/ui/button"
+import { LoginExperience } from "./components/LoginExperience"
 import { AuthProvider, useAuth } from "./contexts/AuthContext"
 import { SessionProvider, useSession } from "./contexts/SessionContext"
 import { ProtectedApp } from "./ProtectedApp"
@@ -27,7 +28,7 @@ function FullscreenMessage({ title, description, actionLabel, onAction }: Fullsc
 }
 
 function AppShell() {
-  const { status, checking, refresh } = useAuth()
+  const { status, checking } = useAuth()
   const { hydrated, actions } = useSession()
 
   if (checking) {
@@ -40,14 +41,7 @@ function AppShell() {
   }
 
   if (status !== "authenticated") {
-    return (
-      <FullscreenMessage
-        title="Authentication required"
-        description="Your session has ended. Please sign in again to continue."
-        actionLabel="Retry"
-        onAction={() => refresh()}
-      />
-    )
+    return <LoginExperience />
   }
 
   if (!hydrated) {

--- a/revenuepilot-frontend/src/components/LoginExperience.tsx
+++ b/revenuepilot-frontend/src/components/LoginExperience.tsx
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useState } from "react"
+
+import { useAuth } from "../contexts/AuthContext"
+import { ForgotPasswordForm } from "./auth/ForgotPasswordForm"
+import { LoginForm } from "./auth/LoginForm"
+import { ThemeToggle } from "./ThemeToggle"
+
+type View = "login" | "forgot-password"
+
+export function LoginExperience() {
+  const { refresh } = useAuth()
+  const [view, setView] = useState<View>("login")
+  const [isOffline, setIsOffline] = useState(() =>
+    typeof navigator !== "undefined" ? !navigator.onLine : false
+  )
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return
+    }
+
+    const handleOnline = () => setIsOffline(false)
+    const handleOffline = () => setIsOffline(true)
+
+    window.addEventListener("online", handleOnline)
+    window.addEventListener("offline", handleOffline)
+
+    return () => {
+      window.removeEventListener("online", handleOnline)
+      window.removeEventListener("offline", handleOffline)
+    }
+  }, [])
+
+  const handleLoginSuccess = useCallback(() => {
+    void refresh()
+  }, [refresh])
+
+  const handleForgotPassword = useCallback(() => {
+    setView("forgot-password")
+  }, [])
+
+  const handleBackToLogin = useCallback(() => {
+    setView("login")
+  }, [])
+
+  return (
+    <>
+      {view === "forgot-password" ? (
+        <ForgotPasswordForm onBackToLogin={handleBackToLogin} />
+      ) : (
+        <LoginForm
+          mode={isOffline ? "offline" : "default"}
+          hasOfflineSession={false}
+          onSuccess={handleLoginSuccess}
+          onForgotPassword={handleForgotPassword}
+        />
+      )}
+      <ThemeToggle />
+    </>
+  )
+}

--- a/revenuepilot-frontend/src/components/ThemeToggle.tsx
+++ b/revenuepilot-frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react"
+import { Moon, Sun } from "lucide-react"
+
+import { Button } from "./auth/Button"
+
+export function ThemeToggle() {
+  const [isDark, setIsDark] = useState(false)
+
+  useEffect(() => {
+    const savedTheme = typeof window !== "undefined" ? window.localStorage.getItem("theme") : null
+    const prefersDark =
+      typeof window !== "undefined" && window.matchMedia
+        ? window.matchMedia("(prefers-color-scheme: dark)").matches
+        : false
+
+    if (savedTheme === "dark" || (!savedTheme && prefersDark)) {
+      setIsDark(true)
+      document.documentElement.classList.add("dark")
+    }
+  }, [])
+
+  const toggleTheme = () => {
+    const next = !isDark
+    setIsDark(next)
+
+    if (next) {
+      document.documentElement.classList.add("dark")
+      window.localStorage.setItem("theme", "dark")
+    } else {
+      document.documentElement.classList.remove("dark")
+      window.localStorage.setItem("theme", "light")
+    }
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={toggleTheme}
+      className="fixed top-4 left-4 z-50"
+      aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+    >
+      {isDark ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+    </Button>
+  )
+}

--- a/revenuepilot-frontend/src/components/auth/Alert.tsx
+++ b/revenuepilot-frontend/src/components/auth/Alert.tsx
@@ -1,0 +1,60 @@
+import { AlertCircle, Info, CheckCircle, AlertTriangle, X } from "lucide-react"
+import { type ReactNode } from "react"
+
+import { cn } from "../ui/utils"
+
+interface AlertProps {
+  tone: "error" | "warning" | "info" | "success"
+  dismissible?: boolean
+  onDismiss?: () => void
+  children: ReactNode
+  className?: string
+}
+
+const iconMap = {
+  error: AlertCircle,
+  warning: AlertTriangle,
+  info: Info,
+  success: CheckCircle
+} as const
+
+const toneClasses: Record<AlertProps["tone"], string> = {
+  error: "bg-destructive/10 border-destructive/20 text-destructive",
+  warning:
+    "bg-amber-50 dark:bg-amber-950/20 border-amber-200 dark:border-amber-800/30 text-amber-800 dark:text-amber-200",
+  info:
+    "bg-blue-50 dark:bg-blue-950/20 border-blue-200 dark:border-blue-800/30 text-blue-800 dark:text-blue-200",
+  success:
+    "bg-green-50 dark:bg-green-950/20 border-green-200 dark:border-green-800/30 text-green-800 dark:text-green-200"
+}
+
+export function Alert({ tone, dismissible = false, onDismiss, children, className }: AlertProps) {
+  const Icon = iconMap[tone]
+
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "flex items-start gap-3 p-4 border rounded-lg",
+        toneClasses[tone],
+        className
+      )}
+    >
+      <Icon className="w-5 h-5 flex-shrink-0 mt-0.5" />
+      
+      <div className="flex-1 text-sm leading-relaxed">
+        {children}
+      </div>
+      
+      {dismissible && onDismiss && (
+        <button
+          onClick={onDismiss}
+          className="flex-shrink-0 p-0.5 rounded hover:bg-black/5 dark:hover:bg-white/10 transition-colors"
+          aria-label="Dismiss alert"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      )}
+    </div>
+  )
+}

--- a/revenuepilot-frontend/src/components/auth/Badge.tsx
+++ b/revenuepilot-frontend/src/components/auth/Badge.tsx
@@ -1,0 +1,30 @@
+import { type ReactNode } from "react"
+
+import { cn } from "../ui/utils"
+
+interface BadgeProps {
+  tone: "info" | "warning"
+  children: ReactNode
+  className?: string
+}
+
+const toneClasses: Record<BadgeProps["tone"], string> = {
+  info:
+    "bg-blue-100 dark:bg-blue-950/30 text-blue-800 dark:text-blue-200 border-blue-200 dark:border-blue-800",
+  warning:
+    "bg-amber-100 dark:bg-amber-950/30 text-amber-800 dark:text-amber-200 border-amber-200 dark:border-amber-800"
+}
+
+export function Badge({ tone, children, className }: BadgeProps) {
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center px-3 py-1.5 text-sm font-medium border rounded-full",
+        toneClasses[tone],
+        className
+      )}
+    >
+      {children}
+    </div>
+  )
+}

--- a/revenuepilot-frontend/src/components/auth/Button.tsx
+++ b/revenuepilot-frontend/src/components/auth/Button.tsx
@@ -1,0 +1,102 @@
+import { Loader2 } from "lucide-react"
+import { type ReactNode } from "react"
+
+import { cn } from "../ui/utils"
+
+interface ButtonProps {
+  variant?: "primary" | "secondary" | "link" | "ghost"
+  state?: "default" | "hover" | "pressed" | "loading" | "disabled"
+  size?: "sm" | "md" | "lg"
+  iconLeft?: ReactNode
+  iconRight?: ReactNode
+  children: ReactNode
+  onClick?: () => void
+  type?: "button" | "submit" | "reset"
+  disabled?: boolean
+  loading?: boolean
+  className?: string
+  fullWidth?: boolean
+}
+
+export function Button({
+  variant = "primary",
+  state = "default",
+  size = "md",
+  iconLeft,
+  iconRight,
+  children,
+  onClick,
+  type = "button",
+  disabled = false,
+  loading = false,
+  className,
+  fullWidth = false
+}: ButtonProps) {
+  const isDisabled = disabled || state === "disabled" || loading
+  const isLoading = loading || state === "loading"
+
+  const baseClasses = cn(
+    "inline-flex items-center justify-center font-medium transition-all duration-200",
+    "focus:outline-none focus:ring-2 focus:ring-ring/20 focus:ring-offset-2",
+    "disabled:pointer-events-none disabled:opacity-50",
+    fullWidth && "w-full"
+  )
+
+  const sizeClasses = cn(
+    size === "sm" && "px-3 py-2 text-sm rounded-md gap-1.5",
+    size === "md" && "px-4 py-2.5 text-sm rounded-lg gap-2",
+    size === "lg" && "px-6 py-3.5 text-base rounded-lg gap-2"
+  )
+
+  const variantClasses = cn(
+    variant === "primary" && [
+      "bg-gradient-to-r from-primary to-primary/90 text-primary-foreground border border-primary/20 shadow-lg shadow-primary/25",
+      "hover:from-primary/90 hover:to-primary/80 hover:shadow-xl hover:shadow-primary/30 hover:-translate-y-0.5",
+      "active:from-primary/80 active:to-primary/70 active:translate-y-0 active:shadow-md",
+      "focus:ring-primary/30"
+    ],
+    variant === "secondary" && [
+      "bg-gradient-to-r from-secondary to-secondary/95 text-secondary-foreground border border-border/50 shadow-sm",
+      "hover:from-secondary/90 hover:to-secondary/85 hover:border-border/70 hover:shadow-md",
+      "active:from-secondary/80 active:to-secondary/75",
+      "focus:ring-secondary/20"
+    ],
+    variant === "ghost" && [
+      "bg-transparent text-foreground border border-transparent",
+      "hover:bg-gradient-to-r hover:from-accent/50 hover:to-accent/40 active:from-accent/60 active:to-accent/50",
+      "focus:ring-accent/20"
+    ],
+    variant === "link" && [
+      "bg-transparent text-primary border-none p-0 h-auto",
+      "hover:text-primary/80 active:text-primary/60 underline-offset-4 hover:underline",
+      "focus:ring-primary/20 focus:ring-offset-0"
+    ]
+  )
+
+  return (
+    <button
+      type={type}
+      onClick={onClick}
+      disabled={isDisabled}
+      className={cn(
+        baseClasses,
+        variant !== "link" && sizeClasses,
+        variantClasses,
+        className
+      )}
+    >
+      {isLoading ? (
+        <>
+          <Loader2 className="w-4 h-4 animate-spin" />
+          {variant !== "link" && children}
+        </>
+      ) : (
+        <>
+          {iconLeft && <span className="flex-shrink-0">{iconLeft}</span>}
+          {children}
+          {iconRight && <span className="flex-shrink-0">{iconRight}</span>}
+        </>
+      )}
+    </button>
+  )
+}

--- a/revenuepilot-frontend/src/components/auth/Card.tsx
+++ b/revenuepilot-frontend/src/components/auth/Card.tsx
@@ -1,0 +1,80 @@
+import { type ReactNode } from "react"
+
+import { cn } from "../ui/utils"
+
+interface CardProps {
+  size?: "md" | "lg"
+  children: ReactNode
+  className?: string
+}
+
+export function Card({ size = "md", children, className }: CardProps) {
+  return (
+    <div
+      className={cn(
+        "bg-card/95 backdrop-blur-sm border border-border/50 rounded-2xl shadow-xl shadow-primary/5",
+        "ring-1 ring-border/20",
+        size === "lg" ? "p-8" : "p-6",
+        "w-full max-w-md mx-auto",
+        className
+      )}
+    >
+      {children}
+    </div>
+  )
+}
+
+interface CardHeaderProps {
+  logo?: ReactNode
+  title: string
+  subtitle?: string
+  className?: string
+}
+
+export function CardHeader({ logo, title, subtitle, className }: CardHeaderProps) {
+  return (
+    <div className={cn("text-center mb-6", className)}>
+      {logo && (
+        <div className="flex justify-center mb-4">
+          {logo}
+        </div>
+      )}
+
+      <h1 className="text-card-foreground mb-2">
+        {title}
+      </h1>
+
+      {subtitle && (
+        <p className="text-muted-foreground">
+          {subtitle}
+        </p>
+      )}
+    </div>
+  )
+}
+
+interface CardContentProps {
+  children: ReactNode
+  className?: string
+}
+
+export function CardContent({ children, className }: CardContentProps) {
+  return (
+    <div className={cn("space-y-4", className)}>
+      {children}
+    </div>
+  )
+}
+
+interface CardFooterProps {
+  children: ReactNode
+  className?: string
+}
+
+export function CardFooter({ children, className }: CardFooterProps) {
+  return (
+    <div className={cn("mt-6 pt-6 border-t border-border", className)}>
+      {children}
+    </div>
+  )
+}

--- a/revenuepilot-frontend/src/components/auth/Checkbox.tsx
+++ b/revenuepilot-frontend/src/components/auth/Checkbox.tsx
@@ -1,0 +1,56 @@
+import { Check } from "lucide-react"
+import { type MouseEvent } from "react"
+
+import { cn } from "../ui/utils"
+
+interface CheckboxProps {
+  checked: boolean
+  onChange: (checked: boolean) => void
+  label: string
+  disabled?: boolean
+  id?: string
+  className?: string
+}
+
+export function Checkbox({ checked, onChange, label, disabled = false, id, className }: CheckboxProps) {
+  const handleToggle = (event?: MouseEvent<HTMLButtonElement | HTMLLabelElement>) => {
+    event?.preventDefault()
+    if (!disabled) {
+      onChange(!checked)
+    }
+  }
+
+  return (
+    <div className={cn("flex items-center space-x-2", className)}>
+      <button
+        type="button"
+        role="checkbox"
+        aria-checked={checked}
+        aria-labelledby={`${id}-label`}
+        onClick={handleToggle}
+        disabled={disabled}
+        className={cn(
+          "flex items-center justify-center w-4 h-4 border rounded transition-all duration-200",
+          "focus:outline-none focus:ring-2 focus:ring-ring/20 focus:ring-offset-2",
+          checked
+            ? "bg-primary border-primary text-primary-foreground"
+            : "border-border bg-background hover:border-primary/50",
+          disabled && "opacity-50 cursor-not-allowed"
+        )}
+      >
+        {checked && <Check className="w-3 h-3" />}
+      </button>
+
+      <label
+        id={`${id}-label`}
+        className={cn(
+          "text-sm text-foreground cursor-pointer select-none",
+          disabled && "opacity-50 cursor-not-allowed"
+        )}
+        onClick={handleToggle}
+      >
+        {label}
+      </label>
+    </div>
+  )
+}

--- a/revenuepilot-frontend/src/components/auth/FooterLinks.tsx
+++ b/revenuepilot-frontend/src/components/auth/FooterLinks.tsx
@@ -1,0 +1,45 @@
+import { Fragment } from "react"
+
+import { cn } from "../ui/utils"
+import { Button } from "./Button"
+
+interface FooterLinksProps {
+  className?: string
+}
+
+const FOOTER_LINKS = [
+  { label: "Privacy Policy", href: "#" },
+  { label: "Terms of Service", href: "#" },
+  { label: "HIPAA Notice", href: "#" }
+]
+
+export function FooterLinks({ className }: FooterLinksProps) {
+  const handleOpen = (href: string) => {
+    window.open(href, "_blank", "noopener")
+  }
+
+  return (
+    <div className={cn("text-center space-y-2", className)}>
+      <div className="flex flex-wrap justify-center items-center gap-1 text-sm">
+        {FOOTER_LINKS.map((link, index) => (
+          <Fragment key={link.label}>
+            <Button
+              variant="link"
+              onClick={() => handleOpen(link.href)}
+              className="text-xs text-muted-foreground hover:text-foreground p-0 h-auto"
+            >
+              {link.label}
+            </Button>
+            {index < FOOTER_LINKS.length - 1 && (
+              <span className="text-muted-foreground">•</span>
+            )}
+          </Fragment>
+        ))}
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        Protected by industry-standard encryption
+      </p>
+    </div>
+  )
+}

--- a/revenuepilot-frontend/src/components/auth/ForgotPasswordForm.tsx
+++ b/revenuepilot-frontend/src/components/auth/ForgotPasswordForm.tsx
@@ -1,0 +1,301 @@
+import { useCallback, useMemo, useState } from "react"
+import { ArrowLeft, Mail, CheckCircle } from "lucide-react"
+
+import { apiFetch } from "../../lib/api"
+import { Alert } from "./Alert"
+import { Button } from "./Button"
+import { Card, CardContent, CardFooter, CardHeader } from "./Card"
+import { FooterLinks } from "./FooterLinks"
+import { TextField } from "./TextField"
+
+type ForgotPasswordState = "input" | "loading" | "success" | "error"
+type ErrorType = "invalid_email" | "user_not_found" | "server_error" | "rate_limited" | null
+
+interface ForgotPasswordFormProps {
+  onBackToLogin: () => void
+  multiTenant?: boolean
+}
+
+interface ForgotPasswordResponse {
+  error?: string
+  detail?: string
+  message?: string
+  [key: string]: unknown
+}
+
+function normalizeString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : ""
+}
+
+function isValidEmail(value: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)
+}
+
+function mapErrorType(response: Response, data: ForgotPasswordResponse | null): ErrorType {
+  if (response.status === 404) {
+    return "user_not_found"
+  }
+  if (response.status === 429) {
+    return "rate_limited"
+  }
+
+  const message = normalizeString(data?.error ?? data?.detail ?? data?.message)
+  if (message) {
+    const lower = message.toLowerCase()
+    if (lower.includes("not found")) {
+      return "user_not_found"
+    }
+    if (lower.includes("rate")) {
+      return "rate_limited"
+    }
+  }
+
+  return "server_error"
+}
+
+export function ForgotPasswordForm({ onBackToLogin, multiTenant = false }: ForgotPasswordFormProps) {
+  const [state, setState] = useState<ForgotPasswordState>("input")
+  const [errorType, setErrorType] = useState<ErrorType>(null)
+  const [clinicCode, setClinicCode] = useState("")
+  const [email, setEmail] = useState("")
+  const [submittedEmail, setSubmittedEmail] = useState("")
+
+  const canSubmit = useMemo(() => {
+    if (!isValidEmail(normalizeString(email))) {
+      return false
+    }
+    if (multiTenant && !normalizeString(clinicCode)) {
+      return false
+    }
+    return true
+  }, [email, multiTenant, clinicCode])
+
+  const getErrorMessage = useCallback((type: ErrorType) => {
+    switch (type) {
+      case "invalid_email":
+        return "Please enter a valid email address."
+      case "user_not_found":
+        return "No account found with this email address."
+      case "server_error":
+        return "Service unavailable. Please try again later."
+      case "rate_limited":
+        return "Too many requests. Please wait before trying again."
+      default:
+        return ""
+    }
+  }, [])
+
+  const submitRequest = useCallback(
+    async (targetEmail: string) => {
+      const payload: Record<string, unknown> = { email: targetEmail }
+      if (multiTenant) {
+        payload.clinicCode = normalizeString(clinicCode)
+      }
+
+      const response = await apiFetch("/api/auth/forgot-password", {
+        method: "POST",
+        jsonBody: payload,
+        skipAuth: true
+      })
+
+      const data = (await response.json().catch(() => null)) as ForgotPasswordResponse | null
+
+      if (!response.ok) {
+        throw mapErrorType(response, data)
+      }
+    },
+    [clinicCode, multiTenant]
+  )
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent) => {
+      event.preventDefault()
+
+      if (!canSubmit) {
+        setErrorType("invalid_email")
+        setState("error")
+        return
+      }
+
+      setState("loading")
+      setErrorType(null)
+
+      try {
+        const trimmedEmail = normalizeString(email)
+        setSubmittedEmail(trimmedEmail)
+        await submitRequest(trimmedEmail)
+        setState("success")
+      } catch (error) {
+        const mapped = typeof error === "string" ? (error as ErrorType) : null
+        setErrorType(mapped ?? "server_error")
+        setState("error")
+      }
+    },
+    [canSubmit, email, submitRequest]
+  )
+
+  const handleTryAgain = useCallback(() => {
+    setState("input")
+    setErrorType(null)
+  }, [])
+
+  const handleResendEmail = useCallback(async () => {
+    if (!submittedEmail) {
+      return
+    }
+
+    setState("loading")
+    setErrorType(null)
+
+    try {
+      await submitRequest(submittedEmail)
+      setState("success")
+    } catch (error) {
+      const mapped = typeof error === "string" ? (error as ErrorType) : null
+      setErrorType(mapped ?? "server_error")
+      setState("error")
+    }
+  }, [submitRequest, submittedEmail])
+
+  if (state === "success") {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-4 relative z-10">
+        <div className="w-full max-w-md">
+          <Card size="lg">
+            <CardContent>
+              <div className="text-center space-y-6">
+                <div className="w-20 h-20 bg-gradient-to-br from-primary/10 to-accent/10 dark:from-primary/20 dark:to-accent/15 rounded-2xl flex items-center justify-center mx-auto border border-primary/20 shadow-lg shadow-primary/10">
+                  <CheckCircle className="w-10 h-10 text-primary dark:text-primary" />
+                </div>
+
+                <div>
+                  <h1 className="text-card-foreground mb-2">Check your email</h1>
+                  <p className="text-muted-foreground mb-4">We've sent password reset instructions to:</p>
+                  <p className="font-medium text-foreground">{submittedEmail}</p>
+                </div>
+
+                <div className="space-y-3">
+                  <p className="text-sm text-muted-foreground">
+                    Didn't receive the email? Check your spam folder or try again.
+                  </p>
+
+                  <div className="flex flex-col gap-3">
+                    <Button
+                      variant="secondary"
+                      size="lg"
+                      fullWidth
+                      onClick={handleResendEmail}
+                      disabled={state === "loading"}
+                      loading={state === "loading"}
+                    >
+                      Resend email
+                    </Button>
+
+                    <Button variant="link" onClick={onBackToLogin} iconLeft={<ArrowLeft className="w-4 h-4" />}>
+                      Back to sign in
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+
+            <CardFooter>
+              <FooterLinks />
+            </CardFooter>
+          </Card>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4 relative z-10">
+      <div className="w-full max-w-md">
+        <Card size="lg">
+          <CardHeader
+            logo={
+              <div className="w-16 h-16 bg-primary/10 rounded-xl flex items-center justify-center">
+                <Mail className="w-8 h-8 text-primary" />
+              </div>
+            }
+            title="Reset your password"
+            subtitle="Enter your email and we'll send you reset instructions"
+          />
+
+          <CardContent>
+            {state === "error" && errorType && (
+              <Alert tone="error" className="mb-4">
+                {getErrorMessage(errorType)}
+              </Alert>
+            )}
+
+            <form onSubmit={handleSubmit} className="space-y-4">
+              {multiTenant && (
+                <TextField
+                  type="text"
+                  label="Clinic Code"
+                  placeholder="Enter your clinic code"
+                  value={clinicCode}
+                  onChange={setClinicCode}
+                  required
+                  disabled={state === "loading"}
+                  id="clinic-code"
+                  state={
+                    state === "error" && errorType === "invalid_email" && !normalizeString(clinicCode)
+                      ? "error"
+                      : "default"
+                  }
+                />
+              )}
+
+              <TextField
+                type="email"
+                label="Email Address"
+                placeholder="Enter your email address"
+                value={email}
+                onChange={setEmail}
+                iconLeft="mail"
+                required
+                disabled={state === "loading"}
+                id="email"
+                autoComplete="email"
+                state={
+                  state === "error" && errorType === "invalid_email" && !isValidEmail(normalizeString(email))
+                    ? "error"
+                    : "default"
+                }
+              />
+
+              <Button
+                type="submit"
+                variant="primary"
+                size="lg"
+                fullWidth
+                loading={state === "loading"}
+                disabled={state === "loading" || !canSubmit}
+              >
+                Send reset link
+              </Button>
+            </form>
+
+            <div className="mt-6 text-center flex flex-col gap-3">
+              {state === "error" && (
+                <Button variant="secondary" fullWidth onClick={handleTryAgain} disabled={state === "loading"}>
+                  Try again
+                </Button>
+              )}
+
+              <Button variant="link" onClick={onBackToLogin} iconLeft={<ArrowLeft className="w-4 h-4" />}>
+                Back to sign in
+              </Button>
+            </div>
+          </CardContent>
+
+          <CardFooter>
+            <FooterLinks />
+          </CardFooter>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/revenuepilot-frontend/src/components/auth/LoginForm.tsx
+++ b/revenuepilot-frontend/src/components/auth/LoginForm.tsx
@@ -1,0 +1,457 @@
+import { useCallback, useMemo, useState } from "react"
+import { Shield, WifiOff } from "lucide-react"
+
+import { apiFetch, persistAuthTokens } from "../../lib/api"
+import { Alert } from "./Alert"
+import { Badge } from "./Badge"
+import { Button } from "./Button"
+import { Card, CardContent, CardFooter, CardHeader } from "./Card"
+import { Checkbox } from "./Checkbox"
+import { FooterLinks } from "./FooterLinks"
+import { MFADialog } from "./MFADialog"
+import { TextField } from "./TextField"
+import { Toast } from "./Toast"
+import { Toggle } from "./Toggle"
+
+type LoginState = "default" | "loading" | "error" | "mfa" | "success"
+type ErrorType = "invalid_credentials" | "account_locked" | "server_error" | "mfa_error" | null
+type MFADialogState = "codeEntry" | "verifying" | "error"
+
+type ToastType = "success" | "error" | "info"
+
+interface LoginFormProps {
+  mode?: "default" | "offline" | "maintenance"
+  multiTenant?: boolean
+  hasOfflineSession?: boolean
+  onSuccess?: () => void
+  onForgotPassword?: () => void
+}
+
+interface LoginResponsePayload {
+  token?: string
+  access_token?: string
+  refreshToken?: string
+  refresh_token?: string
+  requiresMFA?: boolean
+  mfaSessionToken?: string
+  mfa_session_token?: string
+  [key: string]: unknown
+}
+
+function normalizeString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : ""
+}
+
+function extractTokens(payload: LoginResponsePayload | null | undefined) {
+  const accessToken = normalizeString(payload?.token ?? payload?.access_token)
+  const refreshToken = normalizeString(payload?.refreshToken ?? payload?.refresh_token)
+  return {
+    accessToken: accessToken || null,
+    refreshToken: refreshToken || null
+  }
+}
+
+function resolveErrorType(response: Response, data: unknown, fallback: ErrorType = "server_error"): ErrorType {
+  if (response.status === 401) {
+    return "invalid_credentials"
+  }
+  if (response.status === 423) {
+    return "account_locked"
+  }
+  if (response.status === 429) {
+    return "server_error"
+  }
+  if (typeof data === "object" && data !== null) {
+    const detail = normalizeString((data as Record<string, unknown>).detail)
+    const error = normalizeString((data as Record<string, unknown>).error)
+    const message = detail || error || normalizeString((data as Record<string, unknown>).message)
+    if (message) {
+      const lower = message.toLowerCase()
+      if (lower.includes("invalid")) {
+        return "invalid_credentials"
+      }
+      if (lower.includes("lock")) {
+        return "account_locked"
+      }
+      if (lower.includes("mfa")) {
+        return "mfa_error"
+      }
+    }
+  }
+  return fallback
+}
+
+export function LoginForm({
+  mode = "default",
+  multiTenant = false,
+  hasOfflineSession = false,
+  onSuccess,
+  onForgotPassword
+}: LoginFormProps) {
+  const [loginState, setLoginState] = useState<LoginState>("default")
+  const [errorType, setErrorType] = useState<ErrorType>(null)
+  const [mfaState, setMfaState] = useState<MFADialogState>("codeEntry")
+  const [mfaSessionToken, setMfaSessionToken] = useState<string | null>(null)
+
+  const [clinicCode, setClinicCode] = useState("")
+  const [emailOrUsername, setEmailOrUsername] = useState("")
+  const [password, setPassword] = useState("")
+  const [rememberMe, setRememberMe] = useState(false)
+  const [workOffline, setWorkOffline] = useState(false)
+
+  const [toast, setToast] = useState<{ type: ToastType; message: string; visible: boolean }>({
+    type: "info",
+    message: "",
+    visible: false
+  })
+
+  const isOfflineMode = mode === "offline"
+  const isMaintenanceMode = mode === "maintenance"
+
+  const canSignIn = useMemo(
+    () => !isMaintenanceMode && (!isOfflineMode || hasOfflineSession),
+    [isMaintenanceMode, isOfflineMode, hasOfflineSession]
+  )
+
+  const validateForm = useCallback(() => {
+    if (multiTenant && !normalizeString(clinicCode)) return false
+    if (!normalizeString(emailOrUsername)) return false
+    if (!normalizeString(password)) return false
+    return true
+  }, [multiTenant, clinicCode, emailOrUsername, password])
+
+  const showToast = useCallback((type: ToastType, message: string) => {
+    setToast({ type, message, visible: true })
+  }, [])
+
+  const hideToast = useCallback(() => {
+    setToast(prev => ({ ...prev, visible: false }))
+  }, [])
+
+  const handleAuthenticationSuccess = useCallback(
+    (payload: LoginResponsePayload | null | undefined) => {
+      const { accessToken, refreshToken } = extractTokens(payload ?? undefined)
+      if (!accessToken) {
+        throw new Error("Authentication response missing access token")
+      }
+      setMfaSessionToken(null)
+      persistAuthTokens({ accessToken, refreshToken: refreshToken || undefined, remember: rememberMe })
+      showToast("success", "Welcome back!")
+      setLoginState("success")
+      setTimeout(() => onSuccess?.(), 50)
+    },
+    [onSuccess, rememberMe, showToast]
+  )
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent) => {
+      event.preventDefault()
+
+      if (!validateForm() || !canSignIn) {
+        return
+      }
+
+      setLoginState("loading")
+      setErrorType(null)
+      setMfaSessionToken(null)
+
+      try {
+        const payload: Record<string, unknown> = {
+          username: normalizeString(emailOrUsername),
+          password,
+          rememberMe
+        }
+        if (multiTenant) {
+          payload.clinicCode = normalizeString(clinicCode)
+        }
+
+        const response = await apiFetch("/api/auth/login", {
+          method: "POST",
+          jsonBody: payload,
+          skipAuth: true
+        })
+        const data = (await response.json().catch(() => null)) as LoginResponsePayload | null
+
+        if (!response.ok) {
+          setErrorType(resolveErrorType(response, data))
+          setLoginState("error")
+          return
+        }
+
+        if (data?.requiresMFA) {
+          const sessionToken = normalizeString(data.mfaSessionToken ?? data.mfa_session_token)
+          setMfaSessionToken(sessionToken || null)
+          setLoginState("mfa")
+          setMfaState("codeEntry")
+          return
+        }
+
+        handleAuthenticationSuccess(data)
+      } catch (error) {
+        console.error("Login request failed", error)
+        setErrorType("server_error")
+        setLoginState("error")
+      }
+    },
+    [
+      emailOrUsername,
+      password,
+      rememberMe,
+      multiTenant,
+      clinicCode,
+      validateForm,
+      canSignIn,
+      handleAuthenticationSuccess
+    ]
+  )
+
+  const handleMFAVerify = useCallback(
+    async (code: string) => {
+      if (!mfaSessionToken) {
+        setErrorType("mfa_error")
+        setMfaState("error")
+        return
+      }
+
+      setMfaState("verifying")
+
+      try {
+        const response = await apiFetch("/api/auth/verify-mfa", {
+          method: "POST",
+          jsonBody: {
+            code,
+            mfaSessionToken
+          },
+          skipAuth: true
+        })
+        const data = (await response.json().catch(() => null)) as LoginResponsePayload | null
+
+        if (!response.ok) {
+          setErrorType(resolveErrorType(response, data, "mfa_error"))
+          setMfaState("error")
+          return
+        }
+
+        handleAuthenticationSuccess(data)
+      } catch (error) {
+        console.error("MFA verification failed", error)
+        setErrorType("mfa_error")
+        setMfaState("error")
+      }
+    },
+    [handleAuthenticationSuccess, mfaSessionToken]
+  )
+
+  const handleMFACancel = useCallback(() => {
+    setLoginState("default")
+    setMfaState("codeEntry")
+    setErrorType(null)
+  }, [])
+
+  const handleMFAResend = useCallback(async () => {
+    if (!mfaSessionToken) {
+      showToast("error", "Unable to resend code right now")
+      return
+    }
+
+    try {
+      await apiFetch("/api/auth/resend-mfa", {
+        method: "POST",
+        jsonBody: { mfaSessionToken },
+        skipAuth: true
+      })
+      showToast("info", "Verification code sent")
+      setMfaState("codeEntry")
+      setErrorType(null)
+    } catch (error) {
+      console.error("Failed to resend MFA code", error)
+      showToast("error", "Failed to send code")
+    }
+  }, [mfaSessionToken, showToast])
+
+  const handleOfflineWork = useCallback(() => {
+    showToast("info", "Working offline with limited features")
+    setTimeout(() => onSuccess?.(), 1000)
+  }, [onSuccess, showToast])
+
+  return (
+    <>
+      <div className="min-h-screen flex items-center justify-center p-4 relative z-10">
+        <div className="w-full max-w-md">
+          {isOfflineMode && (
+            <div className="mb-4 flex justify-center">
+              <Badge tone="warning" className="gap-2">
+                <WifiOff className="w-4 h-4" />
+                You're offline
+              </Badge>
+            </div>
+          )}
+
+          {isMaintenanceMode && (
+            <div className="mb-4">
+              <Alert tone="warning">
+                System maintenance in progress. Sign in may be temporarily unavailable.
+              </Alert>
+            </div>
+          )}
+
+          <Card size="lg">
+            <CardHeader
+              logo={
+                <div className="w-16 h-16 bg-primary/10 rounded-xl flex items-center justify-center">
+                  <Shield className="w-8 h-8 text-primary" />
+                </div>
+              }
+              title="Sign in"
+              subtitle="Access your workspace"
+            />
+
+            <CardContent>
+              {loginState === "error" && errorType && (
+                <Alert tone="error" className="mb-4">
+                  {(() => {
+                    switch (errorType) {
+                      case "invalid_credentials":
+                        return "That email/username or password didn't match."
+                      case "account_locked":
+                        return "Too many attempts. Try again in 15 minutes."
+                      case "server_error":
+                        return "Service unavailable. Please try again."
+                      case "mfa_error":
+                        return "That code wasn't recognized. Try again."
+                      default:
+                        return ""
+                    }
+                  })()}
+                </Alert>
+              )}
+
+              <form onSubmit={handleSubmit} className="space-y-4">
+                {multiTenant && (
+                  <TextField
+                    type="text"
+                    label="Clinic Code"
+                    placeholder="Enter your clinic code"
+                    value={clinicCode}
+                    onChange={setClinicCode}
+                    required
+                    disabled={loginState === "loading"}
+                    id="clinic-code"
+                  />
+                )}
+
+                <TextField
+                  type="email"
+                  label="Email or Username"
+                  placeholder="Enter your email or username"
+                  value={emailOrUsername}
+                  onChange={setEmailOrUsername}
+                  iconLeft="user"
+                  required
+                  disabled={loginState === "loading"}
+                  id="email-username"
+                />
+
+                <TextField
+                  type="password"
+                  label="Password"
+                  placeholder="Enter your password"
+                  value={password}
+                  onChange={setPassword}
+                  iconLeft="lock"
+                  required
+                  disabled={loginState === "loading"}
+                  id="password"
+                />
+
+                <Checkbox
+                  checked={rememberMe}
+                  onChange={setRememberMe}
+                  label="Remember me on this device"
+                  disabled={loginState === "loading"}
+                  id="remember-me"
+                />
+
+                {isOfflineMode && hasOfflineSession && (
+                  <div className="p-4 bg-muted/50 rounded-lg">
+                    <Toggle
+                      checked={workOffline}
+                      onChange={setWorkOffline}
+                      label="Work offline (limited features)"
+                      disabled={loginState === "loading"}
+                      id="work-offline"
+                    />
+                    <p className="text-xs text-muted-foreground mt-2">
+                      Access cached data and continue working without internet
+                    </p>
+                  </div>
+                )}
+
+                <Button
+                  type="submit"
+                  variant="primary"
+                  size="lg"
+                  fullWidth
+                  loading={loginState === "loading"}
+                  disabled={!validateForm() || loginState === "loading" || !canSignIn}
+                >
+                  {isOfflineMode && workOffline ? "Continue offline" : "Sign in"}
+                </Button>
+
+                {isOfflineMode && hasOfflineSession && workOffline && (
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="lg"
+                    fullWidth
+                    onClick={handleOfflineWork}
+                    disabled={loginState === "loading"}
+                  >
+                    Continue offline
+                  </Button>
+                )}
+
+                {isOfflineMode && !hasOfflineSession && (
+                  <p className="text-sm text-muted-foreground text-center">
+                    Please connect to the internet to sign in
+                  </p>
+                )}
+              </form>
+
+              <div className="mt-6 text-center">
+                <Button
+                  variant="link"
+                  className="text-sm"
+                  onClick={onForgotPassword}
+                  disabled={loginState === "loading"}
+                >
+                  Forgot password?
+                </Button>
+              </div>
+            </CardContent>
+
+            <CardFooter>
+              <FooterLinks />
+            </CardFooter>
+          </Card>
+        </div>
+      </div>
+
+      <MFADialog
+        state={mfaState}
+        isOpen={loginState === "mfa"}
+        onVerify={handleMFAVerify}
+        onCancel={handleMFACancel}
+        onResend={handleMFAResend}
+        errorMessage={errorType === "mfa_error" ? "That code wasn't recognized. Try again." : undefined}
+      />
+
+      <Toast
+        type={toast.type}
+        message={toast.message}
+        isVisible={toast.visible}
+        onClose={hideToast}
+      />
+    </>
+  )
+}

--- a/revenuepilot-frontend/src/components/auth/MFADialog.tsx
+++ b/revenuepilot-frontend/src/components/auth/MFADialog.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useMemo, useState } from "react"
+import { X } from "lucide-react"
+
+import { Alert } from "./Alert"
+import { Button } from "./Button"
+import { TextField } from "./TextField"
+
+type MFADialogState = "codeEntry" | "verifying" | "error"
+
+interface MFADialogProps {
+  state: MFADialogState
+  onVerify: (code: string) => void | Promise<void>
+  onCancel: () => void
+  onResend: () => void
+  isOpen: boolean
+  errorMessage?: string
+}
+
+export function MFADialog({
+  state,
+  onVerify,
+  onCancel,
+  onResend,
+  isOpen,
+  errorMessage
+}: MFADialogProps) {
+  const [code, setCode] = useState("")
+  const [canResend, setCanResend] = useState(false)
+  const [resendTimer, setResendTimer] = useState(30)
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    const timer = window.setInterval(() => {
+      setResendTimer(prev => {
+        if (prev <= 1) {
+          setCanResend(true)
+          return 0
+        }
+        return prev - 1
+      })
+    }, 1000)
+
+    return () => window.clearInterval(timer)
+  }, [isOpen])
+
+  useEffect(() => {
+    if (isOpen) {
+      setCode("")
+      setCanResend(false)
+      setResendTimer(30)
+    }
+  }, [isOpen])
+
+  const canSubmit = useMemo(() => code.length === 6 && state !== "verifying", [code.length, state])
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault()
+    if (canSubmit) {
+      void onVerify(code)
+    }
+  }
+
+  const handleResend = () => {
+    if (canResend) {
+      onResend()
+      setCanResend(false)
+      setResendTimer(30)
+    }
+  }
+
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div 
+        className="bg-card border border-border rounded-xl shadow-2xl w-full max-w-sm"
+        role="dialog"
+        aria-labelledby="mfa-title"
+        aria-describedby="mfa-description"
+      >
+        <div className="flex items-center justify-between p-6 border-b border-border">
+          <h2 id="mfa-title" className="text-card-foreground">
+            Verify it's you
+          </h2>
+          <button
+            onClick={onCancel}
+            className="p-1 rounded hover:bg-accent transition-colors"
+            aria-label="Close dialog"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+        
+        <form onSubmit={handleSubmit} className="p-6">
+          <p id="mfa-description" className="text-muted-foreground mb-4 text-sm">
+            Enter the 6-digit code from your authenticator app
+          </p>
+          
+          {state === "error" && errorMessage && (
+            <Alert tone="error" className="mb-4">
+              {errorMessage}
+            </Alert>
+          )}
+
+          <TextField
+            type="code"
+            value={code}
+            onChange={setCode}
+            placeholder="000000"
+            maxLength={6}
+            pattern="[0-9]{6}"
+            autoComplete="one-time-code"
+            disabled={state === "verifying"}
+            state={state === "error" ? "error" : "default"}
+            id="mfa-code"
+            className="mb-4"
+          />
+
+          <div className="flex gap-3 mb-4">
+            <Button
+              type="submit"
+              variant="primary"
+              fullWidth
+              loading={state === "verifying"}
+              disabled={!canSubmit}
+            >
+              Verify
+            </Button>
+
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={onCancel}
+              disabled={state === "verifying"}
+            >
+              Cancel
+            </Button>
+          </div>
+
+          <div className="text-center">
+            <Button
+              type="button"
+              variant="link"
+              onClick={handleResend}
+              disabled={!canResend || state === "verifying"}
+              className="text-sm"
+            >
+              {canResend
+                ? "Resend code"
+                : `Resend code in ${resendTimer}s`
+              }
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/revenuepilot-frontend/src/components/auth/TextField.tsx
+++ b/revenuepilot-frontend/src/components/auth/TextField.tsx
@@ -1,0 +1,188 @@
+import { useState } from "react"
+import { Eye, EyeOff, User, Lock, Mail } from "lucide-react"
+
+import { cn } from "../ui/utils"
+
+interface TextFieldProps {
+  type?: "text" | "email" | "password" | "code"
+  state?: "default" | "focus" | "error" | "disabled"
+  size?: "md" | "lg"
+  iconLeft?: "none" | "user" | "lock" | "mail"
+  iconRight?: "none" | "visibility" | "visibility_off"
+  label?: string
+  placeholder?: string
+  helperText?: string
+  errorMessage?: string
+  value?: string
+  onChange?: (value: string) => void
+  onFocus?: () => void
+  onBlur?: () => void
+  disabled?: boolean
+  required?: boolean
+  id?: string
+  name?: string
+  maxLength?: number
+  pattern?: string
+  autoComplete?: string
+  className?: string
+}
+
+const iconMap = {
+  user: User,
+  lock: Lock,
+  mail: Mail
+} as const
+
+export function TextField({
+  type = "text",
+  state = "default",
+  size = "md",
+  iconLeft = "none",
+  iconRight = "none",
+  label,
+  placeholder,
+  helperText,
+  errorMessage,
+  value,
+  onChange,
+  onFocus,
+  onBlur,
+  disabled = false,
+  required = false,
+  id,
+  name,
+  maxLength,
+  pattern,
+  autoComplete,
+  className
+}: TextFieldProps) {
+  const [showPassword, setShowPassword] = useState(false)
+  const [isFocused, setIsFocused] = useState(false)
+
+  const LeftIcon = iconLeft !== "none" ? iconMap[iconLeft] : null
+  const isPassword = type === "password"
+  const inputType = isPassword && showPassword ? "text" : type
+
+  const hasError = state === "error" || Boolean(errorMessage)
+  const isDisabled = disabled || state === "disabled"
+
+  const containerClasses = cn(
+    "relative w-full",
+    size === "lg" ? "mb-6" : "mb-4",
+    className
+  )
+
+  const inputClasses = cn(
+    "w-full border rounded-xl transition-all duration-200 focus:outline-none focus:ring-2",
+    "bg-input-background text-foreground placeholder:text-muted-foreground",
+    "shadow-sm hover:shadow-md focus:shadow-lg",
+    size === "lg" ? "px-4 py-3.5" : "px-3.5 py-3",
+    LeftIcon && (size === "lg" ? "pl-11" : "pl-10"),
+    (isPassword || iconRight !== "none") && (size === "lg" ? "pr-11" : "pr-10"),
+    hasError && "border-destructive bg-destructive/5 focus:ring-destructive/20",
+    !hasError && isFocused && "border-primary/60 bg-background focus:ring-primary/20 ring-1 ring-primary/10",
+    !hasError && !isFocused && "border-border/60 hover:border-border",
+    isDisabled && "opacity-50 cursor-not-allowed bg-muted",
+    type === "code" && "text-center tracking-wider font-mono"
+  )
+
+  const iconClasses = cn(
+    "absolute top-1/2 -translate-y-1/2 text-muted-foreground transition-colors",
+    size === "lg" ? "w-5 h-5" : "w-4 h-4",
+    hasError && "text-destructive",
+    isFocused && !hasError && "text-primary"
+  )
+
+  const handleFocus = () => {
+    setIsFocused(true)
+    onFocus?.()
+  }
+
+  const handleBlur = () => {
+    setIsFocused(false)
+    onBlur?.()
+  }
+
+  return (
+    <div className={containerClasses}>
+      {label && (
+        <label
+          htmlFor={id}
+          className={cn(
+            "block mb-2 text-foreground",
+            required && "after:content-['*'] after:text-destructive after:ml-1"
+          )}
+        >
+          {label}
+        </label>
+      )}
+
+      <div className="relative">
+        {LeftIcon && (
+          <LeftIcon
+            className={cn(
+              iconClasses,
+              size === "lg" ? "left-3.5" : "left-3"
+            )}
+          />
+        )}
+
+        <input
+          id={id}
+          name={name}
+          type={inputType}
+          value={value}
+          onChange={event => onChange?.(event.target.value)}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          placeholder={placeholder}
+          disabled={isDisabled}
+          required={required}
+          maxLength={maxLength}
+          pattern={pattern}
+          autoComplete={autoComplete}
+          className={inputClasses}
+          aria-invalid={hasError}
+          aria-describedby={
+            hasError ? `${id}-error` : helperText ? `${id}-helper` : undefined
+          }
+        />
+        
+        {isPassword && (
+          <button
+            type="button"
+            onClick={() => setShowPassword(!showPassword)}
+            className={cn(
+              iconClasses,
+              size === "lg" ? "right-3.5" : "right-3",
+              "hover:text-foreground focus:text-foreground"
+            )}
+            aria-label={showPassword ? "Hide password" : "Show password"}
+            tabIndex={-1}
+          >
+            {showPassword ? <EyeOff /> : <Eye />}
+          </button>
+        )}
+      </div>
+      
+      {hasError && errorMessage && (
+        <p
+          id={`${id}-error`}
+          className="mt-1.5 text-sm text-destructive"
+          role="alert"
+        >
+          {errorMessage}
+        </p>
+      )}
+      
+      {!hasError && helperText && (
+        <p
+          id={`${id}-helper`}
+          className="mt-1.5 text-sm text-muted-foreground"
+        >
+          {helperText}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/revenuepilot-frontend/src/components/auth/Toast.tsx
+++ b/revenuepilot-frontend/src/components/auth/Toast.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from "react"
+import { CheckCircle, AlertCircle, Info, X } from "lucide-react"
+
+import { cn } from "../ui/utils"
+
+interface ToastProps {
+  type: "success" | "error" | "info"
+  message: string
+  isVisible: boolean
+  onClose: () => void
+  duration?: number
+}
+
+const iconMap = {
+  success: CheckCircle,
+  error: AlertCircle,
+  info: Info
+} as const
+
+const typeClasses: Record<ToastProps["type"], string> = {
+  success:
+    "bg-green-50 dark:bg-green-950/90 border-green-200 dark:border-green-800 text-green-800 dark:text-green-200",
+  error:
+    "bg-red-50 dark:bg-red-950/90 border-red-200 dark:border-red-800 text-red-800 dark:text-red-200",
+  info:
+    "bg-blue-50 dark:bg-blue-950/90 border-blue-200 dark:border-blue-800 text-blue-800 dark:text-blue-200"
+}
+
+export function Toast({ type, message, isVisible, onClose, duration = 5000 }: ToastProps) {
+  const [shouldRender, setShouldRender] = useState(isVisible)
+  const Icon = iconMap[type]
+
+  useEffect(() => {
+    if (isVisible) {
+      setShouldRender(true)
+      const timer = window.setTimeout(() => {
+        onClose()
+      }, duration)
+      return () => window.clearTimeout(timer)
+    }
+
+    const timer = window.setTimeout(() => {
+      setShouldRender(false)
+    }, 300)
+    return () => window.clearTimeout(timer)
+  }, [isVisible, duration, onClose])
+
+  if (!shouldRender) return null
+
+  return (
+    <div
+      className={cn(
+        "fixed top-4 right-4 z-50 flex items-center gap-3 p-4 border rounded-lg shadow-lg",
+        "transition-all duration-300 transform",
+        typeClasses[type],
+        isVisible ? "translate-x-0 opacity-100" : "translate-x-full opacity-0"
+      )}
+      role="alert"
+    >
+      <Icon className="w-5 h-5 flex-shrink-0" />
+      <span className="text-sm font-medium">{message}</span>
+      <button
+        onClick={onClose}
+        className="p-0.5 rounded hover:bg-black/10 dark:hover:bg-white/10 transition-colors"
+        aria-label="Close notification"
+      >
+        <X className="w-4 h-4" />
+      </button>
+    </div>
+  )
+}

--- a/revenuepilot-frontend/src/components/auth/Toggle.tsx
+++ b/revenuepilot-frontend/src/components/auth/Toggle.tsx
@@ -1,0 +1,59 @@
+import { type MouseEvent } from "react"
+
+import { cn } from "../ui/utils"
+
+interface ToggleProps {
+  checked: boolean
+  onChange: (checked: boolean) => void
+  label: string
+  disabled?: boolean
+  id?: string
+  className?: string
+}
+
+export function Toggle({ checked, onChange, label, disabled = false, id, className }: ToggleProps) {
+  const handleToggle = (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault()
+    if (!disabled) {
+      onChange(!checked)
+    }
+  }
+
+  return (
+    <div className={cn("flex items-center justify-between", className)}>
+      <label
+        htmlFor={id}
+        className={cn(
+          "text-sm text-foreground cursor-pointer",
+          disabled && "opacity-50 cursor-not-allowed"
+        )}
+      >
+        {label}
+      </label>
+
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        id={id}
+        onClick={handleToggle}
+        disabled={disabled}
+        className={cn(
+          "relative inline-flex h-5 w-9 items-center rounded-full transition-colors duration-200",
+          "focus:outline-none focus:ring-2 focus:ring-ring/20 focus:ring-offset-2",
+          checked
+            ? "bg-primary"
+            : "bg-switch-background",
+          disabled && "opacity-50 cursor-not-allowed"
+        )}
+      >
+        <span
+          className={cn(
+            "inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform duration-200",
+            checked ? "translate-x-4.5" : "translate-x-0.5"
+          )}
+        />
+      </button>
+    </div>
+  )
+}

--- a/revenuepilot-frontend/src/contexts/AuthContext.tsx
+++ b/revenuepilot-frontend/src/contexts/AuthContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react"
-import { apiFetch } from "../lib/api"
+import { apiFetch, clearStoredTokens } from "../lib/api"
 
 export type AuthStatus = "authenticated" | "unauthenticated"
 
@@ -138,6 +138,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       }
     } finally {
       refreshController.current?.abort()
+      clearStoredTokens()
       setState({
         status: "unauthenticated",
         user: null,


### PR DESCRIPTION
## Summary
- integrate the authentication experience into the workspace shell so unauthenticated users see the DesignLoginSystem flows
- add API-driven login, MFA, toast, and forgot-password components that persist tokens through the shared helpers
- extend the shared API utilities with token storage helpers and clear credentials on logout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf243fb7d08324809959e93f2787ab