### PR TITLE
Finish finalization wizard session integration

### DIFF
--- a/revenuepilot-frontend/src/features/finalization/workflowTypes.ts
+++ b/revenuepilot-frontend/src/features/finalization/workflowTypes.ts
@@ -1,0 +1,78 @@
+import type {
+  PatientMetadata,
+  VisitTranscriptEntry,
+} from "./WorkflowWizard"
+
+export type WorkflowStepStatus =
+  | "not_started"
+  | "in_progress"
+  | "completed"
+  | "blocked"
+
+export interface WorkflowStepState {
+  step?: number | string | null
+  status?: WorkflowStepStatus | string | null
+  progress?: number | null
+  startedAt?: string | null
+  completedAt?: string | null
+  updatedAt?: string | null
+  notes?: string | null
+  blockingIssues?: string[]
+}
+
+export interface WorkflowReimbursementSummary {
+  total?: number
+  codes?: Array<Record<string, unknown>>
+}
+
+export interface WorkflowSessionResponsePayload {
+  sessionId: string
+  encounterId?: string | null
+  patientId?: string | null
+  noteId?: string | null
+  currentStep?: number | null
+  stepStates?: WorkflowStepState[] | Record<string, WorkflowStepState>
+  selectedCodes?: Array<Record<string, unknown>>
+  complianceIssues?: Array<Record<string, unknown>>
+  patientMetadata?: Record<string, unknown> | PatientMetadata
+  noteContent?: string | null
+  reimbursementSummary?: WorkflowReimbursementSummary
+  auditTrail?: Array<Record<string, unknown>>
+  patientQuestions?: Array<Record<string, unknown>>
+  blockingIssues?: string[]
+  sessionProgress?: Record<string, unknown>
+  createdAt?: string | null
+  updatedAt?: string | null
+  attestation?: Record<string, unknown>
+  dispatch?: Record<string, unknown>
+  lastValidation?: Record<string, unknown>
+  transcriptEntries?: VisitTranscriptEntry[]
+  [key: string]: unknown
+}
+
+export interface PreFinalizeCheckResponse {
+  canFinalize: boolean
+  issues?: Record<string, unknown>
+  requiredFields?: string[]
+  missingDocumentation?: string[]
+  stepValidation?: Record<string, unknown>
+  complianceIssues?: Array<Record<string, unknown>>
+  estimatedReimbursement?: number
+  reimbursementSummary?: WorkflowReimbursementSummary
+}
+
+export interface FinalizeNoteResponse extends PreFinalizeCheckResponse {
+  finalizedContent: string
+  codesSummary: Array<Record<string, unknown>>
+  exportReady: boolean
+  exportStatus?: string
+  complianceCertification?: Record<string, unknown>
+  finalizedNoteId?: string
+  estimatedReimbursement?: number
+}
+
+export interface StoredFinalizationSession
+  extends WorkflowSessionResponsePayload {
+  lastPreFinalize?: PreFinalizeCheckResponse
+  lastFinalizeResult?: FinalizeNoteResponse
+}

--- a/revenuepilot-frontend/vite.config.ts
+++ b/revenuepilot-frontend/vite.config.ts
@@ -1,10 +1,17 @@
 
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const rootDir = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [react()],
   resolve: {
+    alias: {
+      '@': resolve(rootDir, 'src'),
+    },
     extensions: ['.js', '.jsx', '.ts', '.tsx', '.json'],
   },
   build: {


### PR DESCRIPTION
## Summary
- add shared finalization workflow type definitions and wire them into the wizard adapter
- extend the session context with persistence for stored finalization sessions and related actions
- refactor the finalization wizard adapter to remove legacy backend helpers, hydrate/resume sessions, and invoke pre-finalize/finalize endpoints
- configure a Vite path alias for `@/` imports so the frontend build succeeds

## Testing
- npm --workspace revenuepilot-frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68cf4d0a3e908324925cf0808912209b