### PR TITLE
Integrate backend coding insights and debounced auto-save

### DIFF
--- a/revenuepilot-frontend/src/components/SelectedCodesBar.tsx
+++ b/revenuepilot-frontend/src/components/SelectedCodesBar.tsx
@@ -663,6 +663,10 @@ export function SelectedCodesBar({ selectedCodes, onUpdateCodes, selectedCodesLi
       }
     }
 
+    const globalWarnings = Array.isArray(combinationResult?.warnings)
+      ? combinationResult.warnings.filter(warning => typeof warning === "string" && warning.trim().length > 0)
+      : []
+
     return (Array.isArray(selectedCodesList) ? selectedCodesList : []).map(codeItem => {
       const normalized = typeof codeItem?.code === "string" ? codeItem.code.trim().toUpperCase() : ""
       const detail = normalized ? codeDetails[normalized] : undefined
@@ -714,9 +718,26 @@ export function SelectedCodesBar({ selectedCodes, onUpdateCodes, selectedCodesLi
         treatmentNotes: detail?.rationale ?? codeItem?.rationale ?? "Clinical assessment and appropriate treatment plan documented.",
         documentationRequirements: formatDocumentationSummary(documentation),
         documentation,
+        documentationNeeds: {
+          required: Array.isArray(documentation?.required) ? documentation.required : [],
+          recommended: Array.isArray(documentation?.recommended) ? documentation.recommended : [],
+          examples: Array.isArray(documentation?.examples) ? documentation.examples : [],
+          summary: formatDocumentationSummary(documentation)
+        },
         hasConflict,
         conflictDetails: conflictInfo,
-        billingBreakdown: breakdown
+        billingBreakdown: breakdown,
+        billingInfo: {
+          reimbursement,
+          rvu: rvuValue,
+          breakdown
+        },
+        validationFlags: {
+          hasConflicts: hasConflict,
+          conflicts: conflictInfo.conflicts,
+          contextIssues: conflictInfo.contextIssues,
+          warnings: globalWarnings
+        }
       }
     })
   }, [
@@ -729,7 +750,8 @@ export function SelectedCodesBar({ selectedCodes, onUpdateCodes, selectedCodesLi
     ensureCurrency,
     formatDocumentationSummary,
     sanitizeConfidence,
-    selectedCodesList
+    selectedCodesList,
+    combinationResult
   ])
 
   const computedCounts = useMemo(() => {


### PR DESCRIPTION
## Summary
- add reusable auto-save helper that throttles note persistence and surfaces backend acknowledgements
- trigger POST /api/notes/auto-save from the editor with debounced saves and improved status messaging
- extend SelectedCodesBar transformations with documentation needs, billing metadata, and validation flags sourced from backend APIs

## Testing
- npm --workspace revenuepilot-frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68cf559db1b48324835bb80e5656e138