### PR TITLE
Document integration checklist and restore QA scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,25 @@ The script creates admin, analyst, and clinician accounts using the credentials 
 
 Once the database is bootstrapped, start the backend (`uvicorn backend.main:app --reload --port 8000` or via `./start.sh`). After the API reports a successful startup, launch the frontend (`npm run dev` with `VITE_API_URL` set) so the React contexts can hydrate from the populated backend.
 
+#### Integration checklist
+
+Complete this quick checklist before testing new frontend builds against the live API:
+
+1. Review the environment variable table above and export any overrides required for your setup (`REVENUEPILOT_DB_PATH`, `JWT_SECRET`, role credentials, etc.).
+2. Prime the SQLite database with current reference data and seeded users:
+   ```bash
+   python scripts/bootstrap_database.py
+   ```
+3. Point the Vite frontend at the running API instance:
+   ```bash
+   export VITE_API_URL=http://localhost:8000
+   ```
+   Adjust the URL when targeting remote backends.
+4. Start the FastAPI server (`./start.sh` or `uvicorn backend.main:app --reload --port 8000`) and wait for the startup log indicating migrations completed.
+5. Launch the frontend (`npm run dev`) with the environment above so components hydrate against real data rather than mock fixtures.
+
+Run through this list whenever you refresh the database or swap between mock and live services—the hydration step depends on both the seeded data and the API URL.
+
 ### JWT secret
 
 Authentication tokens issued by the backend are signed with a secret. In production the `JWT_SECRET` environment variable **must** be set before starting the server. If it is missing while `ENVIRONMENT` is anything other than `development`, the application will raise an error at startup. For local development the default `dev-secret` is used so you can run the app without additional configuration.
@@ -389,6 +408,8 @@ These JSON files drive the dynamic shields.io badges at the top of this README. 
 npm run test:coverage
 pytest --cov=backend --cov-report=json:coverage/python-coverage-raw.json
 ```
+
+End-to-end quality gates are back through the workspace scripts. Execute `npm run test:e2e` to drive the Playwright suite once the backend endpoints are running—the tests rely on real API hydration and now cover the newly wired flows alongside the Vitest and pytest coverage checks above.
 
 Then convert the Python JSON to badge format (replicating the CI step) if desired.
 

--- a/ci.sh
+++ b/ci.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 ruff check backend
-pytest
+pytest --cov=backend --cov-report=term
 npm run lint
-npx vitest run --coverage
+npm run test:coverage
 npx playwright install --with-deps chromium
-npx playwright test
+npm run test:e2e

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "backend:prebuild": "node scripts/backend-prebuild.js",
     "update-server": "node -r dotenv/config scripts/update-server.js",
     "setup-env": "node scripts/setup-env.js",
-    "test": "vitest run",
-    "test:coverage": "vitest run --coverage",
+    "test": "npm --workspace revenuepilot-frontend run test",
+    "test:coverage": "npm --workspace revenuepilot-frontend run test:coverage",
     "lint": "eslint \"src/components/**/*.{js,jsx}\" && prettier --check \"src/components/**/*.{js,jsx}\"",
-    "test:e2e": "npx playwright test",
+    "test:e2e": "npm --workspace revenuepilot-frontend run test:e2e",
     "mock": "node mock/server.js"
   },
   "dependencies": {

--- a/revenuepilot-frontend/package.json
+++ b/revenuepilot-frontend/package.json
@@ -63,6 +63,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "npx vitest --config ../vitest.config.js",
+    "test:coverage": "npx vitest run --config ../vitest.config.js --coverage",
+    "test:e2e": "npx playwright test -c ../playwright.config.ts"
   }
 }


### PR DESCRIPTION
## Summary
- document a repeatable integration checklist in the README so the frontend hydrates against seeded backend data
- route root QA scripts through the frontend workspace and update ci.sh so pytest collects coverage while npm scripts execute vitest and Playwright gates
- add vitest and Playwright helpers to the revenuepilot-frontend workspace to back the shared quality gates

## Testing
- `npm run test:coverage` *(fails: existing NoteEditor unit tests require SessionProvider context; unchanged in this patch)*
- `pytest --cov=backend --cov-report=term`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68d02af1164483248c4232ccc57bf8e1