### PR TITLE
Add specialty selectors to suggestion panel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -772,6 +772,7 @@ function App() {
                       onTranscriptChange={handleTranscriptChange}
                       specialty={settingsState.specialty}
                       payer={settingsState.payer}
+                      settingsState={settingsState}
                       patientId={patientID}
                       onPatientIdChange={(v) => setPatientID(v)}
                       onSpecialtyChange={(v) => {

--- a/src/components/NoteEditor.jsx
+++ b/src/components/NoteEditor.jsx
@@ -118,12 +118,15 @@ const NoteEditor = forwardRef(function NoteEditor(
     mode = 'draft',
     specialty,
     payer,
+    onSpecialtyChange,
+    onPayerChange,
     defaultTemplateId,
     onTemplateChange,
     codes = [],
     patientId = '',
     encounterId = '',
     role = '',
+    settingsState = null,
   },
   ref,
 ) {
@@ -816,13 +819,15 @@ const NoteEditor = forwardRef(function NoteEditor(
                   }
                 }
                 loading={suggestLoading}
-                settingsState={null}
+                settingsState={settingsState}
                 text={value}
                 fetchSuggestions={(text) =>
                   getSuggestions(text, { specialty, payer }).then(
                     setSuggestions,
                   )
                 }
+                onSpecialtyChange={onSpecialtyChange}
+                onPayerChange={onPayerChange}
                 onInsert={(text) => {
                   const match = text.match(/^([A-Z0-9.]+)/i);
                   const codeOnly = match ? match[1] : text;
@@ -1071,12 +1076,14 @@ const NoteEditor = forwardRef(function NoteEditor(
             }
           }
           loading={suggestLoading}
-          settingsState={null}
+          settingsState={settingsState}
           /* Provide text so internal debounce logic may run if needed */
           text={localValue}
           fetchSuggestions={(text) =>
             getSuggestions(text, { specialty, payer }).then(setSuggestions)
           }
+          onSpecialtyChange={onSpecialtyChange}
+          onPayerChange={onPayerChange}
           onInsert={(text) => {
             const match = text.match(/^([A-Z0-9.]+)/i);
             const codeOnly = match ? match[1] : text;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -237,6 +237,31 @@ textarea:focus {
   padding-left: 0.75rem; /* ensure visual separation from editor */
 }
 
+.suggestion-panel__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 0.25rem;
+}
+
+.suggestion-panel__controls label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  color: var(--text);
+}
+
+.suggestion-panel__controls select {
+  min-width: 140px;
+  padding: 0.3rem 0.5rem;
+  border: 1px solid var(--disabled);
+  border-radius: 4px;
+  background: var(--panel-bg);
+  color: var(--text);
+  font-size: 0.75rem;
+}
+
 .suggestion-panel .card {
   padding: 0.5rem;
   font-size: 0.875rem;


### PR DESCRIPTION
## Summary
- add local specialty and payer state to the suggestion panel, render dropdown controls, and debounce refetches with the selected context
- wire NoteEditor and App so the panel receives settings plus persistence callbacks and style the new controls
- extend the SuggestionPanel test suite to cover the new inputs and callback notifications

## Testing
- npm test *(fails: useSession must be used within a SessionProvider in existing Vitest suite)*
- npx vitest run src/components/__tests__/SuggestionPanel.test.jsx --config vitest.config.js


------
https://chatgpt.com/codex/tasks/task_e_68d0394db1048324b3e5198dc957bbab