### PR TITLE
Add realtime visit streams and collaborative note handling

### DIFF
--- a/e2e/visit-session-streams.spec.js
+++ b/e2e/visit-session-streams.spec.js
@@ -1,0 +1,145 @@
+/* eslint-env node */
+import { test, expect, _electron as electron } from '@playwright/test';
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+test('visit session streams render live websocket data', async () => {
+  const app = await electron.launch({ args: ['electron/main.js'] });
+  const win = await app.firstWindow();
+
+  await win.waitForEvent('domcontentloaded');
+
+  await win.addInitScript(() => {
+    const sockets = [];
+    class MockSocket {
+      constructor(url) {
+        this.url = url;
+        this.readyState = WebSocket.CONNECTING;
+        this.listeners = {};
+        sockets.push(this);
+        setTimeout(() => {
+          this.readyState = WebSocket.OPEN;
+          this.emit('open', {});
+        }, 0);
+      }
+      addEventListener(type, handler) {
+        if (!this.listeners[type]) this.listeners[type] = [];
+        this.listeners[type].push(handler);
+      }
+      emit(type, payload) {
+        (this.listeners[type] || []).forEach((handler) => handler(payload));
+      }
+      send() {}
+      close() {
+        this.readyState = WebSocket.CLOSED;
+        this.emit('close', { code: 1000 });
+      }
+    }
+    window.__mockSockets = sockets;
+    window.WebSocket = MockSocket;
+  });
+
+  await win.route('**/health', (route) => route.fulfill({ status: 200, body: 'ok' }));
+  await win.route('**/login', (route) =>
+    route.fulfill({
+      json: {
+        access_token: 'token',
+        refresh_token: 'refresh',
+        settings: { theme: 'modern', categories: {} },
+      },
+    }),
+  );
+  await win.route('**/settings', (route) =>
+    route.fulfill({ json: { theme: 'modern', categories: {} } }),
+  );
+  await win.route('**/beautify', (route) =>
+    route.fulfill({ json: { beautified: 'Beautified content' } }),
+  );
+  await win.route('**/suggest', (route) =>
+    route.fulfill({
+      json: {
+        codes: [{ code: '99213', description: 'Office visit' }],
+        compliance: [],
+        publicHealth: [],
+        differentials: [],
+        followUp: null,
+      },
+    }),
+  );
+  await win.route('**/api/visits/session', (route) => {
+    if (route.request().method() === 'POST') {
+      return route.fulfill({
+        json: {
+          sessionId: 11,
+          status: 'started',
+          startTime: '2024-01-01T00:00:00Z',
+        },
+      });
+    }
+    return route.fulfill({
+      json: {
+        sessionId: 11,
+        status: 'pause',
+        startTime: '2024-01-01T00:00:00Z',
+        endTime: null,
+      },
+    });
+  });
+
+  await win.fill('input[type="text"]', 'demo');
+  await win.fill('input[type="password"]', 'demo-password');
+  await win.click('button:has-text("Login")');
+
+  await delay(500);
+
+  await win.fill('#note-patient-field', 'PX1');
+  await win.fill('#note-encounter-field', '42');
+
+  await delay(500);
+
+  await win.evaluate(() => {
+    const [transcription, compliance, codes, collaboration] = window.__mockSockets;
+    transcription.emit('message', {
+      data: JSON.stringify({ event: 'connected', sessionId: 'ws-trans' }),
+    });
+    transcription.emit('message', {
+      data: JSON.stringify({
+        eventId: 1,
+        transcript: 'final patient note',
+        isInterim: false,
+        speakerLabel: 'patient',
+      }),
+    });
+    compliance.emit('message', {
+      data: JSON.stringify({
+        eventId: 2,
+        issues: [{ message: 'Live compliance alert', severity: 'warning' }],
+      }),
+    });
+    codes.emit('message', {
+      data: JSON.stringify({ eventId: 3, code: 'Z1234', rationale: 'Streaming code' }),
+    });
+    collaboration.emit('message', {
+      data: JSON.stringify({
+        eventId: 4,
+        participants: [{ userId: 'abc', name: 'Dr Demo' }],
+      }),
+    });
+    collaboration.emit('message', {
+      data: JSON.stringify({
+        eventId: 5,
+        conflicts: ['Simultaneous edits detected'],
+      }),
+    });
+  });
+
+  await expect(win.locator('text=final patient note')).toBeVisible();
+  await expect(win.locator('text=Live compliance alert')).toBeVisible();
+  await expect(win.locator('text=Z1234')).toBeVisible();
+  await expect(win.locator('text=Collaborators')).toBeVisible();
+  await expect(win.locator('text=Simultaneous edits detected')).toBeVisible();
+
+  await app.close();
+});

--- a/src/api.js
+++ b/src/api.js
@@ -1789,25 +1789,34 @@ export async function markAllNotificationsRead() {
   return { unreadCount: normaliseCount(data.unreadCount) };
 }
 
-export function connectNotificationsStream({
+function mergeParams(...sources) {
+  const combined = {};
+  for (const source of sources) {
+    if (!source || typeof source !== 'object') continue;
+    for (const [key, value] of Object.entries(source)) {
+      if (value === undefined || value === null || value === '') continue;
+      combined[key] = value;
+    }
+  }
+  return combined;
+}
+
+function connectWebsocketStream(path, {
   onEvent,
-  onCount,
   onError,
   onOpen,
   onClose,
   reconnectDelayMs = 2000,
   maxRetries = Infinity,
   websocketFactory,
+  params = {},
+  getParams,
 } = {}) {
   if (typeof window === 'undefined') {
     return { close() {} };
   }
-  const url = resolveWebsocketUrl('/ws/notifications');
+  const baseUrl = resolveWebsocketUrl(path);
   const token = localStorage.getItem('token');
-  const target = new URL(url);
-  if (token) {
-    target.searchParams.set('token', token);
-  }
   const factory =
     typeof websocketFactory === 'function'
       ? websocketFactory
@@ -1817,29 +1826,22 @@ export function connectNotificationsStream({
   let closed = false;
   let attempts = 0;
 
+  const computeTargetUrl = () => {
+    const target = new URL(baseUrl);
+    if (token) target.searchParams.set('token', token);
+    const dynamicParams = typeof getParams === 'function' ? getParams() : {};
+    const merged = mergeParams(params, dynamicParams);
+    for (const [key, value] of Object.entries(merged)) {
+      target.searchParams.set(key, String(value));
+    }
+    return target.toString();
+  };
+
   const clearTimer = () => {
     if (reconnectTimer) {
       clearTimeout(reconnectTimer);
       reconnectTimer = null;
     }
-  };
-
-  const emitCount = (data) => {
-    if (!data || typeof onCount !== 'function') return;
-    const notifications =
-      typeof data.notifications === 'number'
-        ? data.notifications
-        : typeof data.unreadCount === 'number'
-          ? data.unreadCount
-          : undefined;
-    const drafts =
-      typeof data.drafts === 'number' ? data.drafts : undefined;
-    if (notifications === undefined && drafts === undefined) return;
-    onCount({
-      notifications: notifications !== undefined ? normaliseCount(notifications) : undefined,
-      drafts: drafts !== undefined ? normaliseCount(drafts) : undefined,
-      raw: data,
-    });
   };
 
   const scheduleReconnect = () => {
@@ -1859,8 +1861,9 @@ export function connectNotificationsStream({
   };
 
   const connect = () => {
+    const targetUrl = computeTargetUrl();
     try {
-      socket = factory(target.toString());
+      socket = factory(targetUrl);
     } catch (err) {
       onError?.(err);
       scheduleReconnect();
@@ -1874,9 +1877,8 @@ export function connectNotificationsStream({
     socket.addEventListener?.('message', (event) => {
       try {
         const payload =
-          typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
+          typeof event?.data === 'string' ? JSON.parse(event.data) : event?.data;
         onEvent?.(payload);
-        emitCount(payload);
       } catch (err) {
         onError?.(err);
       }
@@ -1907,6 +1909,108 @@ export function connectNotificationsStream({
       }
     },
   };
+}
+
+export function connectNotificationsStream(options = {}) {
+  const { onCount, onEvent: userOnEvent, ...rest } = options;
+  const emitCount = (data) => {
+    if (!data || typeof onCount !== 'function') return;
+    const notifications =
+      typeof data.notifications === 'number'
+        ? data.notifications
+        : typeof data.unreadCount === 'number'
+          ? data.unreadCount
+          : undefined;
+    const drafts =
+      typeof data.drafts === 'number' ? data.drafts : undefined;
+    if (notifications === undefined && drafts === undefined) return;
+    onCount({
+      notifications: notifications !== undefined ? normaliseCount(notifications) : undefined,
+      drafts: drafts !== undefined ? normaliseCount(drafts) : undefined,
+      raw: data,
+    });
+  };
+  return connectWebsocketStream('/ws/notifications', {
+    ...rest,
+    onEvent: (payload) => {
+      userOnEvent?.(payload);
+      emitCount(payload);
+    },
+  });
+}
+
+export function connectTranscriptionStream({
+  visitSessionId,
+  encounterId,
+  patientId,
+  params,
+  ...rest
+} = {}) {
+  const staticParams = mergeParams(
+    { visit_session_id: visitSessionId, encounter_id: encounterId, patient_id: patientId },
+    params,
+  );
+  return connectWebsocketStream('/ws/transcription', {
+    ...rest,
+    params: staticParams,
+  });
+}
+
+export function connectComplianceStream({
+  visitSessionId,
+  encounterId,
+  patientId,
+  params,
+  ...rest
+} = {}) {
+  const staticParams = mergeParams(
+    { visit_session_id: visitSessionId, encounter_id: encounterId, patient_id: patientId },
+    params,
+  );
+  return connectWebsocketStream('/ws/compliance', {
+    ...rest,
+    params: staticParams,
+  });
+}
+
+export function connectCodesStream({
+  visitSessionId,
+  encounterId,
+  patientId,
+  params,
+  ...rest
+} = {}) {
+  const staticParams = mergeParams(
+    { visit_session_id: visitSessionId, encounter_id: encounterId, patient_id: patientId },
+    params,
+  );
+  return connectWebsocketStream('/ws/codes', {
+    ...rest,
+    params: staticParams,
+  });
+}
+
+export function connectCollaborationStream({
+  visitSessionId,
+  encounterId,
+  patientId,
+  noteId,
+  params,
+  ...rest
+} = {}) {
+  const staticParams = mergeParams(
+    {
+      visit_session_id: visitSessionId,
+      encounter_id: encounterId,
+      patient_id: patientId,
+      note_id: noteId,
+    },
+    params,
+  );
+  return connectWebsocketStream('/ws/collaboration', {
+    ...rest,
+    params: staticParams,
+  });
 }
 
 export async function getUserSession() {

--- a/src/components/SuggestionPanel.jsx
+++ b/src/components/SuggestionPanel.jsx
@@ -137,6 +137,7 @@ function SuggestionPanel({
     }
     return items.map((item, idx) => {
       if (type === 'codes' && typeof item === 'object' && item !== null) {
+        const isLive = Boolean(item.live || item.streaming);
         const text = item.rationale
           ? `${item.code} — ${item.rationale}`
           : item.code;
@@ -155,6 +156,18 @@ function SuggestionPanel({
             >
               {item.code}
             </strong>
+            {isLive ? (
+              <span
+                style={{
+                  marginLeft: '0.5em',
+                  fontSize: '0.75em',
+                  color: '#2563eb',
+                  textTransform: 'uppercase',
+                }}
+              >
+                {t('suggestion.liveBadge', 'Live')}
+              </span>
+            ) : null}
             {item.rationale ? ` — ${item.rationale}` : ''}
             {item.upgrade_to && (
               <span
@@ -268,14 +281,49 @@ function SuggestionPanel({
           </li>
         );
       }
+      const isObject = typeof item === 'object' && item !== null;
+      const textValue = isObject
+        ? item.text || item.message || item.description || item.code || item.summary
+        : item;
+      const isLive = isObject && Boolean(item.live || item.streaming);
+      const severity = isObject && (item.severity || item.level);
       return (
         <li
           key={idx}
-          title={item}
+          title={typeof textValue === 'string' ? textValue : undefined}
           style={{ cursor: 'pointer' }}
-          onClick={() => onInsert && onInsert(item)}
+          onClick={() => {
+            if (!onInsert) return;
+            if (typeof textValue === 'string' && textValue.trim()) {
+              onInsert(textValue);
+            }
+          }}
         >
-          {item}
+          {typeof textValue === 'string' ? textValue : ''}
+          {isLive ? (
+            <span
+              style={{
+                marginLeft: '0.5em',
+                fontSize: '0.75em',
+                color: '#2563eb',
+                textTransform: 'uppercase',
+              }}
+            >
+              {t('suggestion.liveBadge', 'Live')}
+            </span>
+          ) : null}
+          {severity ? (
+            <span
+              style={{
+                marginLeft: '0.5em',
+                fontSize: '0.75em',
+                color: '#b45309',
+                textTransform: 'uppercase',
+              }}
+            >
+              {severity}
+            </span>
+          ) : null}
         </li>
       );
     });

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -197,14 +197,19 @@
     "encounterError": "Unable to validate encounter.",
     "specialtyPlaceholder": "e.g. Family medicine",
     "payerPlaceholder": "e.g. Blue Shield PPO",
-    "payerHint": "Adjust specialty and payer to tailor templates and suggestions."
+    "payerHint": "Adjust specialty and payer to tailor templates and suggestions.",
     "patientIdLabel": "Patient ID",
     "encounterIdLabel": "Encounter ID",
     "visitDuration": "Visit Duration",
     "visitSessionError": "Unable to start visit session",
     "visitSessionActive": "Visit active",
     "visitSessionPaused": "Visit paused",
-    "visitSessionComplete": "Visit complete"
+    "visitSessionComplete": "Visit complete",
+    "liveInterim": "Live (interim)",
+    "collaborators": "Collaborators",
+    "collaborationStatus": "Status: {{status}}",
+    "collaborationConflict": "Collaboration conflict",
+    "collaborationUnknown": "A collaborator encountered an issue"
   },
   "settings": {
     "title": "Settings",
@@ -312,6 +317,7 @@
     "differentials": "Differentials",
     "loading": "Loading suggestions...",
     "none": "No suggestions yet",
+    "liveBadge": "Live",
     "followUp": "Follow-Up",
     "addToCalendar": "Add to calendar",
     "followUpAppointment": "Follow-up appointment",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -197,14 +197,19 @@
     "encounterError": "No se pudo validar el encuentro.",
     "specialtyPlaceholder": "p. ej. Medicina familiar",
     "payerPlaceholder": "p. ej. Blue Shield PPO",
-    "payerHint": "Ajusta especialidad y pagador para adaptar plantillas y sugerencias."
+    "payerHint": "Ajusta especialidad y pagador para adaptar plantillas y sugerencias.",
     "patientIdLabel": "ID de paciente",
     "encounterIdLabel": "ID de encuentro",
     "visitDuration": "Duración de la visita",
     "visitSessionError": "No se pudo iniciar la sesión de visita",
     "visitSessionActive": "Visita en curso",
     "visitSessionPaused": "Visita en pausa",
-    "visitSessionComplete": "Visita finalizada"
+    "visitSessionComplete": "Visita finalizada",
+    "liveInterim": "En vivo (interino)",
+    "collaborators": "Colaboradores",
+    "collaborationStatus": "Estado: {{status}}",
+    "collaborationConflict": "Conflicto de colaboración",
+    "collaborationUnknown": "Un colaborador tuvo un problema"
   },
   "settings": {
     "title": "Configuración",
@@ -312,6 +317,7 @@
     "differentials": "Diagnósticos diferenciales",
     "loading": "Cargando sugerencias...",
     "none": "Sin sugerencias aún",
+    "liveBadge": "En vivo",
     "followUp": "Seguimiento",
     "addToCalendar": "Agregar al calendario",
     "followUpAppointment": "Cita de seguimiento",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -197,14 +197,19 @@
     "encounterError": "Impossible de valider la rencontre.",
     "specialtyPlaceholder": "ex. Médecine générale",
     "payerPlaceholder": "ex. Blue Shield PPO",
-    "payerHint": "Ajustez spécialité et payeur pour adapter modèles et suggestions."
+    "payerHint": "Ajustez spécialité et payeur pour adapter modèles et suggestions.",
     "patientIdLabel": "ID patient",
     "encounterIdLabel": "ID de consultation",
     "visitDuration": "Durée de la visite",
     "visitSessionError": "Impossible de démarrer la session de visite",
     "visitSessionActive": "Visite en cours",
     "visitSessionPaused": "Visite en pause",
-    "visitSessionComplete": "Visite terminée"
+    "visitSessionComplete": "Visite terminée",
+    "liveInterim": "En direct (intermédiaire)",
+    "collaborators": "Collaborateurs",
+    "collaborationStatus": "Statut : {{status}}",
+    "collaborationConflict": "Conflit de collaboration",
+    "collaborationUnknown": "Un collaborateur a rencontré un problème"
   },
   "settings": {
     "title": "Settings",
@@ -312,6 +317,7 @@
     "differentials": "Differentials",
     "loading": "Loading suggestions...",
     "none": "No suggestions yet",
+    "liveBadge": "Live",
     "followUp": "Follow-Up",
     "addToCalendar": "Add to calendar",
     "followUpAppointment": "Follow-up appointment",


### PR DESCRIPTION
## Summary
- add websocket helpers for transcription, compliance, codes, and collaboration streams with resilient reconnection logic in `src/api.js`
- wire NoteEditor to visit-session websocket events, surface collaborator presence/conflicts, and highlight live code/compliance suggestions
- expand locale strings, documentation, unit tests, and add a Playwright spec covering live visit session streams

## Testing
- `npx vitest run --config vitest.config.js src/components/__tests__/NoteEditor.test.jsx src/__tests__/api.notifications.test.js`
- `npm run test:e2e` *(fails: Playwright browsers not installed in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68d04f39d778832486550bb36887fcf2