### PR TITLE
Refactor secrets management for production readiness

### DIFF
--- a/backend/key_manager.py
+++ b/backend/key_manager.py
@@ -1,9 +1,10 @@
 import os
 import stat
 import json
-from datetime import datetime, timezone
+import uuid
+from datetime import datetime, timezone, timedelta
 from pathlib import Path
-from typing import Optional, Dict, Any, List, Tuple
+from typing import Optional, Dict, Any, List, Tuple, Callable
 
 try:
     import keyring
@@ -23,6 +24,333 @@ APP_NAME = "RevenuePilot"
 SERVICE_NAME = "revenuepilot-openai"
 
 DEFAULT_STATUS = "active"
+
+# Mapping of known secret identifiers to their environment variable names.
+SECRET_ENV_MAPPING: Dict[str, str] = {
+    "openai": "OPENAI_API_KEY",
+    "jwt": "JWT_SECRET",
+}
+
+_METADATA_FILENAME = "secrets_metadata.json"
+_ENV_DEV_VALUES = {"development", "dev", "local"}
+_DEFAULT_SECRET_MAX_AGE_DAYS = 90
+
+
+class SecretError(Exception):
+    """Base error for secret management failures."""
+
+
+class SecretNotFoundError(SecretError):
+    """Raised when a required secret is not available."""
+
+
+class SecretReadOnlyError(SecretError):
+    """Raised when attempting to modify a read-only secrets backend."""
+
+
+class SecretRotationError(SecretError):
+    """Raised when rotation metadata is missing or indicates staleness."""
+
+
+_MISSING = object()
+
+
+def _metadata_file() -> Path:
+    return _base_dir() / _METADATA_FILENAME
+
+
+def _load_metadata() -> Dict[str, Dict[str, Any]]:
+    path = _metadata_file()
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def _save_metadata(data: Dict[str, Dict[str, Any]]) -> None:  # pragma: no cover - simple IO
+    _metadata_file().write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def _record_metadata(
+    name: str,
+    *,
+    source: Optional[str] = None,
+    rotated_at: Optional[str] = None,
+    version: Optional[str] = None,
+    expires_at: Optional[str] = None,
+    last_used: Any = _MISSING,
+) -> Dict[str, Any]:
+    data = _load_metadata()
+    record = data.get(name, {}).copy()
+    if source:
+        record["source"] = source
+    if rotated_at is not None:
+        record["rotatedAt"] = rotated_at
+    if version is not None:
+        record["version"] = version
+    if expires_at is not None:
+        record["expiresAt"] = expires_at
+    if last_used is not _MISSING:
+        record["lastUsed"] = last_used
+    record["updatedAt"] = _now_iso()
+    data[name] = record
+    _save_metadata(data)
+    return record
+
+
+def _get_metadata(name: str) -> Dict[str, Any]:
+    return _load_metadata().get(name, {}).copy()
+
+
+def _parse_iso(value: str) -> Optional[datetime]:
+    try:
+        cleaned = value.strip()
+        if cleaned.endswith("Z"):
+            cleaned = cleaned[:-1] + "+00:00"
+        parsed = datetime.fromisoformat(cleaned)
+    except Exception:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _is_dev_env() -> bool:
+    return os.getenv("ENVIRONMENT", "development").lower() in _ENV_DEV_VALUES
+
+
+def _allow_fallback() -> bool:
+    fallback_env = os.getenv("SECRETS_FALLBACK", "auto").lower()
+    if fallback_env == "always":
+        return True
+    if fallback_env == "never":
+        return False
+    return _is_dev_env()
+
+
+def _max_age_days(default: int) -> Optional[int]:
+    value = os.getenv("SECRET_MAX_AGE_DAYS")
+    if value:
+        try:
+            return int(value)
+        except ValueError:
+            pass
+    return default
+
+
+def _validate_rotation(
+    name: str,
+    metadata: Dict[str, Any],
+    *,
+    max_age_days: Optional[int],
+    allow_missing: bool,
+) -> None:
+    if not max_age_days:
+        return
+    rotated_at = metadata.get("rotatedAt") or metadata.get("rotated_at")
+    if not rotated_at:
+        if allow_missing:
+            return
+        raise SecretRotationError(
+            f"Rotation timestamp for '{name}' is missing. Provide {name.upper()}_ROTATED_AT or update the secrets metadata."
+        )
+    parsed = _parse_iso(str(rotated_at))
+    if not parsed:
+        if allow_missing:
+            return
+        raise SecretRotationError(
+            f"Rotation timestamp for '{name}' is not a valid ISO-8601 datetime: {rotated_at}"
+        )
+    if parsed < datetime.now(timezone.utc) - timedelta(days=max_age_days):
+        raise SecretRotationError(
+            f"Secret '{name}' appears stale (rotated {rotated_at}). Rotate at least every {max_age_days} days."
+        )
+
+
+def _env_metadata(env_var: str) -> Dict[str, Any]:
+    metadata: Dict[str, Any] = {}
+    rotated = os.getenv(f"{env_var}_ROTATED_AT")
+    version = os.getenv(f"{env_var}_VERSION")
+    expires = os.getenv(f"{env_var}_EXPIRES_AT")
+    source = os.getenv(f"{env_var}_SOURCE") or "environment"
+    if rotated:
+        metadata["rotatedAt"] = rotated
+    if version:
+        metadata["version"] = version
+    if expires:
+        metadata["expiresAt"] = expires
+    metadata["source"] = source
+    return metadata
+
+
+def load_secret(
+    name: str,
+    env_var: str,
+    *,
+    required: bool = False,
+    allow_fallback: Optional[bool] = None,
+    max_age_days: Optional[int] = None,
+    allow_missing_rotation: Optional[bool] = None,
+) -> Tuple[Optional[str], Dict[str, Any]]:
+    """Load a secret via environment-backed manager with optional fallback."""
+
+    allow_fallback = _allow_fallback() if allow_fallback is None else allow_fallback
+    allow_missing_rotation = (
+        _is_dev_env() if allow_missing_rotation is None else allow_missing_rotation
+    )
+    max_age_days = max_age_days or _max_age_days(_DEFAULT_SECRET_MAX_AGE_DAYS)
+
+    env_value = os.getenv(env_var)
+    if env_value:
+        metadata = _env_metadata(env_var)
+        record = _record_metadata(
+            name,
+            source=metadata.get("source", "environment"),
+            rotated_at=metadata.get("rotatedAt"),
+            version=metadata.get("version"),
+            expires_at=metadata.get("expiresAt"),
+        )
+        metadata = {**record}
+        _validate_rotation(
+            name,
+            metadata,
+            max_age_days=max_age_days,
+            allow_missing=allow_missing_rotation,
+        )
+        return env_value, metadata
+
+    entries = _load_all_keys()
+    entry = entries.get(name)
+    decrypted: Optional[str] = None
+    if entry and isinstance(entry.get("ciphertext"), str):
+        try:
+            decrypted = _decrypt_value(entry["ciphertext"])
+        except Exception:
+            decrypted = None
+    if decrypted:
+        os.environ[env_var] = decrypted
+        metadata = _get_metadata(name)
+        if not metadata or metadata.get("source") != "local-file":
+            metadata = _record_metadata(name, source="local-file")
+        _validate_rotation(
+            name,
+            metadata,
+            max_age_days=max_age_days,
+            allow_missing=allow_missing_rotation,
+        )
+        return decrypted, metadata
+
+    legacy_path = _legacy_file()
+    if legacy_path.exists():
+        try:
+            legacy_value = legacy_path.read_text(encoding="utf-8").strip()
+        except OSError:
+            legacy_value = ""
+        if legacy_value:
+            os.environ[env_var] = legacy_value
+            metadata = _record_metadata(name, source="legacy-file")
+            _validate_rotation(
+                name,
+                metadata,
+                max_age_days=max_age_days,
+                allow_missing=allow_missing_rotation,
+            )
+            return legacy_value, metadata
+
+    if required:
+        raise SecretNotFoundError(
+            f"Secret '{name}' is not configured. Provide {env_var} via the secrets backend or enable the local development fallback."
+        )
+    return None, {}
+
+
+def store_secret(
+    name: str,
+    env_var: str,
+    value: str,
+    *,
+    allow_fallback: Optional[bool] = None,
+    source: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Persist a secret via the writable backend or local fallback."""
+
+    allow_fallback = _allow_fallback() if allow_fallback is None else allow_fallback
+    backend = os.getenv("SECRETS_BACKEND", "auto").lower()
+    if backend in {"env", "environment"} and not allow_fallback:
+        raise SecretReadOnlyError(
+            "The configured secrets backend is environment-managed; rotate the secret in the external store."
+        )
+
+    rotated = _now_iso()
+    version = str(uuid.uuid4())
+    store_key(
+        name,
+        value,
+        rotated_at=rotated,
+        version=version,
+        source=source or "local-file",
+    )
+    os.environ[env_var] = value
+    return _get_metadata(name)
+
+
+def require_secret(
+    name: str,
+    env_var: str,
+    *,
+    description: Optional[str] = None,
+    max_age_days: Optional[int] = None,
+    allow_fallback: Optional[bool] = None,
+    allow_missing_rotation: Optional[bool] = None,
+) -> str:
+    """Return a configured secret or raise with a helpful error."""
+
+    effective_fallback = _allow_fallback() if allow_fallback is None else allow_fallback
+    try:
+        value, metadata = load_secret(
+            name,
+            env_var,
+            required=True,
+            allow_fallback=effective_fallback,
+            max_age_days=max_age_days,
+            allow_missing_rotation=allow_missing_rotation,
+        )
+    except SecretNotFoundError as exc:
+        label = description or f"secret '{name}'"
+        raise SecretNotFoundError(
+            f"{label} is not configured. Provide {env_var} via the configured secrets backend."
+        ) from exc
+    source = metadata.get("source") if isinstance(metadata, dict) else None
+    if not effective_fallback and source and source != "environment":
+        label = description or f"secret '{name}'"
+        raise SecretNotFoundError(
+            f"{label} is configured via a local fallback. Provide {env_var} from the external secrets manager."
+        )
+    return value  # type: ignore[return-value]
+
+
+def ensure_local_secret(
+    name: str,
+    env_var: str,
+    generator: Callable[[], str],
+    *,
+    allow_fallback: Optional[bool] = None,
+) -> str:
+    """Ensure a development secret exists and return it."""
+
+    allow_fallback = _allow_fallback() if allow_fallback is None else allow_fallback
+    value, _ = load_secret(name, env_var, allow_fallback=allow_fallback, required=False)
+    if value:
+        return value
+    if not allow_fallback:
+        raise SecretReadOnlyError(
+            f"Cannot provision '{name}' locally because the fallback store is disabled."
+        )
+    new_value = generator()
+    store_secret(name, env_var, new_value, allow_fallback=True, source="local-file")
+    return new_value
 
 
 def _base_dir() -> Path:
@@ -161,7 +489,12 @@ def list_key_metadata() -> List[Dict[str, Any]]:
     """Return key summaries for API responses."""
 
     records: List[Dict[str, Any]] = []
-    for service, entry in _load_all_keys().items():
+    entries = _load_all_keys()
+    metadata_map = _load_metadata()
+    all_services = sorted(set(entries.keys()) | set(metadata_map.keys()))
+    for service in all_services:
+        entry = entries.get(service, {})
+        metadata = metadata_map.get(service, {})
         ciphertext = entry.get("ciphertext")
         encrypted = isinstance(ciphertext, str) and bool(ciphertext)
         masked = ""
@@ -170,19 +503,39 @@ def list_key_metadata() -> List[Dict[str, Any]]:
                 masked = _mask_key(_decrypt_value(ciphertext))
             except Exception:
                 masked = ""
-        records.append(
-            {
-                "service": service,
-                "keyMasked": masked,
-                "status": entry.get("status", DEFAULT_STATUS),
-                "lastUsed": entry.get("lastUsed"),
-                "encrypted": encrypted,
-            }
-        )
+        else:
+            env_var = SECRET_ENV_MAPPING.get(service)
+            if env_var:
+                env_value = os.getenv(env_var)
+                if env_value:
+                    masked = _mask_key(env_value)
+        source = metadata.get("source")
+        if not source and encrypted:
+            source = "local-file"
+        record = {
+            "service": service,
+            "keyMasked": masked,
+            "status": entry.get("status", DEFAULT_STATUS),
+            "lastUsed": metadata.get("lastUsed") or entry.get("lastUsed"),
+            "encrypted": encrypted,
+            "rotatedAt": metadata.get("rotatedAt"),
+            "version": metadata.get("version"),
+            "source": source,
+            "expiresAt": metadata.get("expiresAt"),
+        }
+        records.append(record)
     return records
 
 
-def store_key(name: str, key: str, status: str = DEFAULT_STATUS) -> None:  # pragma: no cover - thin wrapper
+def store_key(
+    name: str,
+    key: str,
+    status: str = DEFAULT_STATUS,
+    *,
+    rotated_at: Optional[str] = None,
+    version: Optional[str] = None,
+    source: Optional[str] = None,
+) -> None:  # pragma: no cover - thin wrapper
     """Store a named API key in encrypted storage with metadata."""
 
     data = _load_all_keys()
@@ -197,6 +550,13 @@ def store_key(name: str, key: str, status: str = DEFAULT_STATUS) -> None:  # pra
         "lastUsed": None,
     }
     _save_all_keys(data)
+    _record_metadata(
+        name,
+        source=source or "local-file",
+        rotated_at=rotated_at or _now_iso(),
+        version=version or str(uuid.uuid4()),
+        last_used=None,
+    )
 
 
 def mark_key_used(name: str) -> None:
@@ -204,64 +564,52 @@ def mark_key_used(name: str) -> None:
 
     data = _load_all_keys()
     entry = data.get(name)
+    timestamp = _now_iso()
     if not entry:
+        _record_metadata(name, last_used=timestamp)
         return
-    entry["lastUsed"] = _now_iso()
+    entry["lastUsed"] = timestamp
     data[name] = entry
     _save_all_keys(data)
+    _record_metadata(name, last_used=timestamp)
 
 
 def get_api_key() -> Optional[str]:
-    """Load the OpenAI API key from env, keyring, or encrypted file."""
-    key = os.getenv("OPENAI_API_KEY")
+    """Load the OpenAI API key from the configured secrets backend."""
+
+    try:
+        key, _ = load_secret("openai", "OPENAI_API_KEY")
+    except SecretRotationError:
+        raise
     if key:
         mark_key_used("openai")
         return key
+
     if keyring:
         try:
             key = keyring.get_password(SERVICE_NAME, "api_key")
         except KeyringError:
             key = None
         if key:
-            os.environ["OPENAI_API_KEY"] = key
+            try:
+                store_secret("openai", "OPENAI_API_KEY", key)
+            except SecretReadOnlyError:
+                os.environ["OPENAI_API_KEY"] = key
+                _record_metadata("openai", source="keyring")
             mark_key_used("openai")
             return key
-    entries = _load_all_keys()
-    entry = entries.get("openai")
-    if entry and isinstance(entry.get("ciphertext"), str):
-        try:
-            key = _decrypt_value(entry["ciphertext"])
-        except Exception:
-            key = None
-        if key:
-            entry["lastUsed"] = _now_iso()
-            entries["openai"] = entry
-            _save_all_keys(entries)
-            os.environ["OPENAI_API_KEY"] = key
-            return key
-    legacy = _legacy_file()
-    if legacy.exists():
-        try:
-            key = legacy.read_text(encoding="utf-8").strip()
-            if key:
-                os.environ["OPENAI_API_KEY"] = key
-                return key
-        except OSError:
-            pass
+
     return None
 
 
 def save_api_key(key: str) -> None:
     """Persist the API key to keyring or encrypted file."""
+    store_secret("openai", "OPENAI_API_KEY", key)
     if keyring:
         try:
             keyring.set_password(SERVICE_NAME, "api_key", key)
-            store_key("openai", key)
-            os.environ["OPENAI_API_KEY"] = key
-            return
         except KeyringError:
             pass
-    store_key("openai", key)
     legacy = _legacy_file()
     try:
         legacy.write_text(key, encoding="utf-8")
@@ -271,4 +619,3 @@ def save_api_key(key: str) -> None:
             os.chmod(legacy, stat.S_IRUSR | stat.S_IWUSR)
     except OSError:
         pass
-    os.environ["OPENAI_API_KEY"] = key

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,9 +69,11 @@ Use the helper script to launch FastAPI and the Vite frontend together.
 ./start.ps1           # Windows PowerShell
 ```
 
-The script runs `backend/venv/bin/uvicorn backend.main:app --reload` on
-port 8000, exports `VITE_API_URL` and starts the frontend dev server.
-Stopping the frontend terminates the backend process automatically.【F:start.sh†L1-L32】
+The script provisions local JWT and mock OpenAI secrets via the backend
+secrets manager, runs `backend/venv/bin/uvicorn backend.main:app
+--reload` on port 8000, exports `VITE_API_URL` and starts the frontend
+dev server. Stopping the frontend terminates the backend process
+automatically.【F:start.sh†L1-L48】
 
 For manual startup, activate the virtualenv and run the servers
 separately:
@@ -169,14 +171,20 @@ Key environment variables can be supplied via `.env` or exported before
 runtime:
 
 - `VITE_API_URL` – Frontend API base URL (set automatically by `start.sh`).
-- `OPENAI_API_KEY` – Backend OpenAI key, alternatively stored via
-  `/apikey` and `backend/openai_key.txt`.
+- `OPENAI_API_KEY` and `OPENAI_API_KEY_ROTATED_AT` – Backend OpenAI key
+  plus ISO-8601 rotation timestamp supplied by the external secrets
+  manager. `/apikey` persists development overrides through the secrets
+  repository.
 - `USE_OFFLINE_MODEL`, `USE_LOCAL_MODELS`, `LOCAL_*_MODEL` – Offline/local
   AI behaviour toggles.【F:backend/openai_client.py†L1-L117】
 - `FHIR_SERVER_URL` and related auth variables – Configure FHIR export
   destinations.【F:backend/ehr_integration.py†L30-L180】
-- `REVENUEPILOT_DB_PATH`, `JWT_SECRET`, `METRICS_LOOKBACK_DAYS` – Database
-  location, token signing secret and analytics retention window.【F:backend/main.py†L600-L760】
+- `REVENUEPILOT_DB_PATH`, `JWT_SECRET`, `JWT_SECRET_ROTATED_AT`,
+  `METRICS_LOOKBACK_DAYS` – Database location, token signing secret with
+  rotation metadata, and analytics retention window.【F:backend/main.py†L600-L760】
+- `SECRETS_BACKEND`, `SECRETS_FALLBACK`, `SECRET_MAX_AGE_DAYS` – Control
+  whether secrets are loaded from environment managers only or allow the
+  encrypted local fallback, and configure stale-secret enforcement.【F:backend/key_manager.py†L85-L230】
 
 See `docs/LOCAL_MODELS.md` for detailed offline model guidance and
 `docs/DESKTOP_BUILD.md` for packaging environment variables.
@@ -194,6 +202,13 @@ npm run update-server   # optional local auto-update feed
 The generated artifacts live in `dist/` and can be distributed per
 platform. Refer to [Desktop Build and Auto-Update Guide](DESKTOP_BUILD.md)
 for certificate management and smoke tests.【F:docs/DESKTOP_BUILD.md†L1-L80】
+
+Production deployments should source `OPENAI_API_KEY`, `JWT_SECRET` and
+other credentials from an external secrets manager (Vault, SSM, etc.)
+and provide the corresponding `*_ROTATED_AT` metadata so the backend can
+enforce rotation policies. Set `SECRETS_BACKEND=env` and leave
+`SECRETS_FALLBACK=never` in hosted environments; the development scripts
+only provision local fallbacks when `ENVIRONMENT` is a development value.【F:backend/key_manager.py†L85-L230】【F:start.sh†L1-L48】
 
 ## Additional references
 

--- a/docs/SOP.md
+++ b/docs/SOP.md
@@ -21,8 +21,10 @@ codebase. Follow them for every change, regardless of size.
   `source backend/venv/bin/activate` (macOS/Linux) or
   `backend\venv\Scripts\activate` (Windows) when running Python
   commands manually.
-- Store secrets locally. OpenAI keys can be injected via `/apikey` in the
-  settings view; never commit `.env` files.
+- Secrets are sourced from the secrets manager. `install`/`start` scripts
+  provision mock JWT and OpenAI values for development, but production
+  deployments must inject real secrets (and `*_ROTATED_AT` metadata)
+  through the external store; never commit `.env` files.【F:install.sh†L1-L70】【F:start.sh†L1-L48】
 
 ## 3. Local CI checklist
 

--- a/install.ps1
+++ b/install.ps1
@@ -27,8 +27,26 @@ python -m venv venv
 pip install -r requirements.txt
 deactivate
 
+Set-Location $scriptDir
+
+Write-Host "Provisioning development secrets..."
+$pythonExe = Join-Path $scriptDir 'backend\venv\Scripts\python.exe'
+if (-not (Test-Path $pythonExe)) {
+    $pythonExe = 'python'
+}
+$provisionScript = @'
+import os
+import secrets
+
+from backend import key_manager
+
+os.environ.setdefault("ENVIRONMENT", "development")
+key_manager.ensure_local_secret("jwt", "JWT_SECRET", lambda: secrets.token_urlsafe(48))
+key_manager.ensure_local_secret(
+    "openai", "OPENAI_API_KEY", lambda: "sk-local-" + secrets.token_hex(16)
+)
+'@
+& $pythonExe -c $provisionScript
+
 Write-Host "Installation complete."
-Write-Host "To start the backend server, run:"
-Write-Host "  cd backend; .\\venv\\Scripts\\Activate.ps1; uvicorn main:app --reload --port 8000"
-Write-Host "To run the front-end, open a new terminal and run:"
-Write-Host "  npm run dev"
+Write-Host "Run ./start.ps1 (or ./start.sh on macOS/Linux) to launch the full stack with development secrets provisioned."

--- a/install.sh
+++ b/install.sh
@@ -54,8 +54,21 @@ pip install -r requirements.txt
 python -m spacy download en_core_web_sm
 deactivate
 
+cd "$SCRIPT_DIR"
+
+echo "Provisioning development secrets..."
+backend/venv/bin/python - <<'PY'
+import os
+import secrets
+
+from backend import key_manager
+
+os.environ.setdefault("ENVIRONMENT", "development")
+key_manager.ensure_local_secret("jwt", "JWT_SECRET", lambda: secrets.token_urlsafe(48))
+key_manager.ensure_local_secret(
+    "openai", "OPENAI_API_KEY", lambda: "sk-local-" + secrets.token_hex(16)
+)
+PY
+
 echo "Installation complete."
-echo "To start the backend server, run:"
-echo "  cd $(pwd) && source venv/bin/activate && uvicorn main:app --reload --port 8000"
-echo "To run the front-end, open a new terminal, navigate to the project root and run:"
-echo "  npm run dev"
+echo "Run ./start.sh (or ./start.ps1 on Windows) to launch the full stack with development secrets provisioned."

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,15 @@
 import os
 import sys
+from datetime import datetime, timezone
 
 # Ensure the repository root is on sys.path so tests can import the backend package
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
+
+_now_iso = datetime.now(timezone.utc).isoformat()
+os.environ.setdefault('ENVIRONMENT', 'development')
+os.environ.setdefault('JWT_SECRET', 'test-jwt-secret')
+os.environ.setdefault('JWT_SECRET_ROTATED_AT', _now_iso)
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+os.environ.setdefault('OPENAI_API_KEY_ROTATED_AT', _now_iso)

--- a/tests/test_key_manager.py
+++ b/tests/test_key_manager.py
@@ -1,4 +1,8 @@
+import json
 import os
+from datetime import datetime, timezone, timedelta
+
+import pytest
 
 import backend.key_manager as km
 
@@ -8,6 +12,7 @@ def test_save_and_load_key(tmp_path, monkeypatch):
     monkeypatch.setattr(km, "keyring", None)
     monkeypatch.setattr(km, "user_data_dir", lambda *a, **k: str(tmp_path))
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY_ROTATED_AT", raising=False)
 
     # No key exists initially
     assert km.get_api_key() is None
@@ -17,6 +22,11 @@ def test_save_and_load_key(tmp_path, monkeypatch):
     key_file = tmp_path / "openai_key.txt"
     assert key_file.read_text() == "secret"
     assert os.environ["OPENAI_API_KEY"] == "secret"
+
+    metadata_path = tmp_path / "secrets_metadata.json"
+    metadata = json.loads(metadata_path.read_text())
+    assert metadata["openai"]["source"] == "local-file"
+    assert metadata["openai"]["rotatedAt"]
 
     stored = km.get_all_keys()
     assert "openai" in stored
@@ -33,6 +43,10 @@ def test_save_and_load_key(tmp_path, monkeypatch):
             "status": "active",
             "lastUsed": None,
             "encrypted": True,
+            "rotatedAt": metadata["openai"]["rotatedAt"],
+            "version": metadata["openai"]["version"],
+            "source": "local-file",
+            "expiresAt": metadata["openai"].get("expiresAt"),
         }
     ]
 
@@ -44,3 +58,33 @@ def test_save_and_load_key(tmp_path, monkeypatch):
     assert updated_summary["service"] == "openai"
     assert updated_summary["keyMasked"] == "**cret"
     assert updated_summary["lastUsed"] is not None
+    refreshed_metadata = json.loads(metadata_path.read_text())
+    assert refreshed_metadata["openai"]["lastUsed"] == updated_summary["lastUsed"]
+
+
+def test_require_secret_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(km, "user_data_dir", lambda *a, **k: str(tmp_path))
+    monkeypatch.delenv("JWT_SECRET", raising=False)
+    monkeypatch.delenv("JWT_SECRET_ROTATED_AT", raising=False)
+    with pytest.raises(km.SecretNotFoundError):
+        km.require_secret("jwt", "JWT_SECRET", allow_fallback=False)
+
+
+def test_secret_rotation_stale(tmp_path, monkeypatch):
+    monkeypatch.setattr(km, "keyring", None)
+    monkeypatch.setattr(km, "user_data_dir", lambda *a, **k: str(tmp_path))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY_ROTATED_AT", raising=False)
+    monkeypatch.setenv("ENVIRONMENT", "production")
+
+    km.store_secret("openai", "OPENAI_API_KEY", "secret")
+    metadata_path = tmp_path / "secrets_metadata.json"
+    data = json.loads(metadata_path.read_text())
+    data["openai"]["rotatedAt"] = (
+        datetime.now(timezone.utc) - timedelta(days=200)
+    ).isoformat()
+    metadata_path.write_text(json.dumps(data))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(km.SecretRotationError):
+        km.get_api_key()


### PR DESCRIPTION
## Summary
- integrate a configurable secrets backend for JWT and OpenAI credentials with rotation metadata and stricter error handling
- provision development secrets via install/start scripts and document production requirements for external secret stores
- expand tests to cover missing or stale secrets and seed defaults for the test environment

## Testing
- pytest --no-cov

------
https://chatgpt.com/codex/tasks/task_e_68d04f4f1f4c832485801c4912cdc4fc