### PR TITLE
Integrate external secrets backends

### DIFF
--- a/docs/SOP.md
+++ b/docs/SOP.md
@@ -24,7 +24,13 @@ codebase. Follow them for every change, regardless of size.
 - Secrets are sourced from the secrets manager. `install`/`start` scripts
   provision mock JWT and OpenAI values for development, but production
   deployments must inject real secrets (and `*_ROTATED_AT` metadata)
-  through the external store; never commit `.env` files.【F:install.sh†L1-L70】【F:start.sh†L1-L48】
+  through the external store; never commit `.env` files.【F:install.sh†L1-L70】【F:start.sh†L1-L64】
+- When `ENVIRONMENT` is not development, `start` scripts validate that the
+  configured backend (AWS Secrets Manager, Vault or environment
+  injection) already contains the required credentials plus rotation
+  metadata (`rotatedAt`, `version`, optionally `expiresAt`). Missing or
+  stale secrets cause an immediate failure so remediation happens before
+  deployment.【F:start.sh†L1-L64】【F:start.ps1†L1-L64】
 
 ## 3. Local CI checklist
 

--- a/start.ps1
+++ b/start.ps1
@@ -27,6 +27,26 @@ if env in {"development", "dev", "local"}:
     key_manager.ensure_local_secret(
         "openai", "OPENAI_API_KEY", lambda: "sk-local-" + secrets.token_hex(16)
     )
+else:
+    failures = []
+    for name, env_var in key_manager.SECRET_ENV_MAPPING.items():
+        try:
+            key_manager.require_secret(
+                name,
+                env_var,
+                allow_fallback=False,
+                allow_missing_rotation=False,
+            )
+        except key_manager.SecretRotationError as exc:
+            failures.append(f"{env_var}: {exc}")
+        except key_manager.SecretError as exc:
+            failures.append(f"{env_var}: {exc}")
+    if failures:
+        details = "\n - ".join(failures)
+        raise SystemExit(
+            "Required secrets are missing or invalid. Provision them in the configured secrets backend before starting the stack:\n - "
+            + details
+        )
 '@
 & $pythonExe -c $provisionScript
 


### PR DESCRIPTION
## Summary
- add AWS Secrets Manager and HashiCorp Vault integrations to the secret manager and gate local fallbacks to development
- require production environments to present required secrets before start-up
- document the provisioning and rotation metadata expected by the new secrets workflow

## Testing
- python3 -m pytest *(fails: missing optional backend dependencies such as prometheus_client in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d05ce28a588324bf170648dbd321d6