### PR TITLE
Update docs for finalization and TypeScript references

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -141,10 +141,11 @@ interfaces. `backend/main.py` ties together the modules listed below.
    from `/api/user/*` endpoints.【F:backend/main.py†L4239-L4473】
 2. **Drafting** – `NoteEditor` tracks patient and encounter IDs, performs
    client-side caching and posts to `/api/notes/*` for auto-save and
-   versioning.【F:src/components/NoteEditor.jsx†L80-L160】【F:backend/main.py†L7970-L8046】
+   versioning.【F:revenuepilot-frontend/src/components/NoteEditor.tsx†L1000-L1058】【F:revenuepilot-frontend/src/components/NoteEditor.tsx†L1166-L1245】【F:backend/main.py†L7970-L8046】
 3. **AI interactions** – Beautify/suggest/summarise requests travel
-   through `api.js`, hit FastAPI where text is de-identified, prompts are
-   assembled and responses logged for analytics.【F:src/api.js†L520-L760】【F:backend/main.py†L9755-L12084】
+   through the TypeScript API helpers, hit FastAPI where text is
+   de-identified, prompts are assembled and responses logged for
+   analytics.【F:revenuepilot-frontend/src/lib/api.ts†L425-L590】【F:backend/main.py†L9755-L12084】
  4. **Compliance & workflow** – Compliance issues and selected codes feed
    into the workflow APIs, culminating in finalisation and optional FHIR
    export.【F:backend/main.py†L10374-L11270】
@@ -154,11 +155,10 @@ interfaces. `backend/main.py` ties together the modules listed below.
    alerts.【F:backend/main.py†L7536-L8912】
   6. **Live visit telemetry** – Active visit sessions open websocket
      channels for `/ws/transcription`, `/ws/compliance`, `/ws/codes` and
-     `/ws/collaboration`. `api.js` tracks the reconnection state and
-     resumes from the last `eventId`, while `NoteEditor` merges interim
-     transcripts, streaming compliance alerts, code suggestions and
-     collaborator presence into the existing UI without interrupting the
-     draft.【F:src/api.js†L1804-L2015】【F:src/components/NoteEditor.jsx†L860-L1110】
+     `/ws/collaboration`. The API utilities build authenticated websocket
+     URLs while `NoteEditor` resumes streaming transcripts, compliance
+     alerts, code suggestions and collaborator presence without
+     interrupting the draft.【F:revenuepilot-frontend/src/lib/api.ts†L425-L479】【F:revenuepilot-frontend/src/components/NoteEditor.tsx†L1000-L1058】【F:revenuepilot-frontend/src/components/NoteEditor.tsx†L2117-L2124】
 
 ## External services & configuration
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -135,7 +135,7 @@ and Prettier for the frontend plus Ruff/pytest on the backend.【F:package.json�
   their previous view after finishing finalisation.【F:revenuepilot-frontend/src/ProtectedApp.tsx†L785-L820】【F:revenuepilot-frontend/src/ProtectedApp.tsx†L1661-L1670】
 - **Validation & attestation panels** – Trigger note validation, review
   reimbursement details, record attestation metadata and monitor dispatch
-  results without leaving the workspace.【F:src/components/WorkflowView.jsx†L130-L370】
+  results without leaving the workspace.【F:revenuepilot-frontend/src/components/FinalizationWizardAdapter.tsx†L1320-L1556】【F:revenuepilot-frontend/src/features/finalization/WorkflowWizard.tsx†L540-L624】
 - **Live coding stream awareness** – The finalization wizard surfaces
   websocket status badges, reuses streaming suggestions when available
   and only hits REST fallbacks when streams are offline.【F:revenuepilot-frontend/src/components/FinalizationWizardAdapter.tsx†L69-L118】【F:revenuepilot-frontend/src/components/FinalizationWizardAdapter.tsx†L832-L1140】【F:revenuepilot-frontend/src/components/FinalizationWizardAdapter.tsx†L1600-L1652】


### PR DESCRIPTION
## Summary
- update the handbook’s finalisation workflow section to cite the current FinalizationWizard components
- refresh the architecture data-flow references to the TypeScript NoteEditor and API helper modules
- ensure terminology matches the TypeScript implementation and add citations for quick navigation

## Testing
- no tests were run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d0770469148324ba1fa0a31bd05ddf