### PR TITLE
Pin database dependencies and document connection env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,24 @@
 OPENAI_API_KEY=
 VITE_API_URL=http://localhost:8000
 BACKEND_URL=http://localhost:8000
+# Database configuration for the FastAPI backend.
+# Leave DATABASE_URL empty to use the SQLite DSN below. Provide
+# POSTGRES_* variables to build a PostgreSQL DSN automatically or set
+# DATABASE_URL explicitly to override everything.
+SQLITE_DSN=sqlite+aiosqlite:///./revenuepilot.db
+DATABASE_URL=
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5432
+POSTGRES_DB=revenuepilot
+POSTGRES_USER=revenuepilot
+POSTGRES_PASSWORD=
+PGSSLMODE=prefer
+# Optional CA bundle (e.g., AWS RDS combined bundle path)
+PGSSLROOTCERT=
+PGCONNECT_TIMEOUT=10
+DB_POOL_SIZE=5
+DB_MAX_OVERFLOW=10
+STATEMENT_TIMEOUT_MS=30000
 DEID_ENGINE=regex
 DEID_HASH_TOKENS=true
 ICON_PNG_URL=

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,5 +23,7 @@ llama-cpp-python
 requests-mock
 cryptography
 bleach
-SQLAlchemy
+SQLAlchemy>=2.0
+alembic>=1.13
+psycopg[binary]>=3.2
 

--- a/backend/requirements_audio.txt
+++ b/backend/requirements_audio.txt
@@ -1,4 +1,7 @@
 # Optional heavy audio dependencies for advanced diarisation/noise reduction.
-# Install these only if you need multi-speaker diarisation.
+# Install these only if you need multi-speaker diarisation. Include the base
+# runtime stack (SQLAlchemy>=2.0, alembic>=1.13, psycopg[binary]>=3.2,
+# python-dotenv, etc.) before the audio extras.
+-r requirements.txt
 pyannote.audio
 torchaudio

--- a/backend/requirements_dev.txt
+++ b/backend/requirements_dev.txt
@@ -1,3 +1,5 @@
+# Include the runtime stack (SQLAlchemy>=2.0, alembic>=1.13, psycopg[binary]>=3.2,
+# python-dotenv, etc.) and add development-time tooling.
 -r requirements.txt
 pytest
 pytest-cov

--- a/docs/README.md
+++ b/docs/README.md
@@ -201,15 +201,40 @@ runtime:
   AI behaviour toggles.【F:backend/openai_client.py†L1-L117】
 - `FHIR_SERVER_URL` and related auth variables – Configure FHIR export
   destinations.【F:backend/ehr_integration.py†L30-L180】
-- `REVENUEPILOT_DB_PATH`, `JWT_SECRET`, `JWT_SECRET_ROTATED_AT`,
-  `METRICS_LOOKBACK_DAYS` – Database location, token signing secret with
-  rotation metadata, and analytics retention window.【F:backend/main.py†L600-L760】
+- `DATABASE_URL`, `SQLITE_DSN`, `POSTGRES_*`, `PGSSLMODE`, `PGCONNECT_TIMEOUT`,
+  `PGSSLROOTCERT`, `DB_POOL_SIZE`, `DB_MAX_OVERFLOW`, `STATEMENT_TIMEOUT_MS`,
+  `JWT_SECRET`, `JWT_SECRET_ROTATED_AT`, `METRICS_LOOKBACK_DAYS` – Backend
+  database configuration, token signing secret with rotation metadata, and
+  analytics retention window.【F:backend/main.py†L600-L760】
 - `SECRETS_BACKEND`, `SECRETS_FALLBACK`, `SECRET_MAX_AGE_DAYS` – Control
   whether secrets are loaded from environment managers only or allow the
   encrypted local fallback, and configure stale-secret enforcement.
 - `SECRETS_PREFIX`, `AWS_REGION`, `VAULT_ADDR`, `VAULT_TOKEN`,
   `VAULT_NAMESPACE`, `VAULT_MOUNT`, `VAULT_BASE_PATH` – Configure the
   external secrets backend described below.【F:backend/key_manager.py†L85-L380】
+
+#### Database connection precedence
+
+The backend resolves its SQLAlchemy engine configuration in the following
+order:
+
+1. **Explicit DSN** – When `DATABASE_URL` is provided, it is used exactly
+   as supplied.
+2. **Component variables** – If `POSTGRES_HOST` (and related
+   `POSTGRES_*` settings) are present, the backend assembles a PostgreSQL
+   DSN using those values plus optional TLS overrides such as
+   `PGSSLMODE`, `PGSSLROOTCERT` and connection timeouts from
+   `PGCONNECT_TIMEOUT`.
+3. **SQLite fallback** – In the absence of the above, the application
+   falls back to `SQLITE_DSN`, which defaults to the local development
+   SQLite file.
+
+`DB_POOL_SIZE`, `DB_MAX_OVERFLOW` and `STATEMENT_TIMEOUT_MS` tune the
+connection pool while `PGSSLROOTCERT` can point at an AWS RDS combined CA
+bundle when TLS verification is required. Treat `POSTGRES_PASSWORD` and
+other secrets as production credentials that must be injected at runtime
+via a secrets manager (AWS Secrets Manager, SSM Parameter Store, Vault,
+etc.) rather than committed to `.env` files or source control.
 
 ### Secrets management
 


### PR DESCRIPTION
## Summary
- pin SQLAlchemy 2.x, Alembic 1.13+, and psycopg[binary] 3.2+ across backend requirement sets while ensuring python-dotenv is bundled
- extend the sample .env with dual-mode SQLite/Postgres configuration, connection pool tuning, SSL, and timeout options
- document database variable precedence and reiterate that production secrets belong in a managed vault or parameter store

## Testing
- not run (configuration and documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68d0868fb4148324888d764dd3fe61de