### PR TITLE
test: use in-memory sqlalchemy fixtures for backend tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,18 @@
 import asyncio
 import inspect
 import os
+import sqlite3
 import sys
+from collections import defaultdict, deque
+from dataclasses import dataclass
 from datetime import datetime, timezone
+from typing import Iterator
 
 import pytest
+import sqlalchemy as sa
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
 
 # Ensure the repository root is on sys.path so tests can import the backend package
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
@@ -34,4 +42,110 @@ os.environ.setdefault('JWT_SECRET', 'test-jwt-secret')
 os.environ.setdefault('JWT_SECRET_ROTATED_AT', _now_iso)
 os.environ.setdefault('OPENAI_API_KEY', 'sk-test-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
 os.environ.setdefault('OPENAI_API_KEY_ROTATED_AT', _now_iso)
+
+
+@dataclass
+class DatabaseContext:
+    """Holds state for the ephemeral in-memory SQLite database."""
+
+    engine: sa.engine.Engine
+    connection: sa.engine.Connection
+    raw_connection: sqlite3.Connection
+    session_factory: sessionmaker
+
+    def make_session(self) -> Session:
+        """Return a new SQLAlchemy session bound to the in-memory engine."""
+
+        return self.session_factory()
+
+
+@pytest.fixture(scope='function')
+def in_memory_db() -> Iterator[DatabaseContext]:
+    """Provide an isolated in-memory SQLite database for each test."""
+
+    from backend import main
+
+    engine = sa.create_engine(
+        'sqlite+pysqlite:///:memory:',
+        future=True,
+        connect_args={'check_same_thread': False},
+        poolclass=StaticPool,
+    )
+    connection = engine.connect()
+    raw_connection = connection.connection
+    assert isinstance(raw_connection, sqlite3.Connection)
+    raw_connection.row_factory = sqlite3.Row
+
+    previous = getattr(main, 'db_conn', None)
+    if isinstance(previous, sqlite3.Connection):
+        try:
+            previous.close()
+        except Exception:
+            pass
+
+    main.db_conn = raw_connection
+    main.configure_auth_session_factory(raw_connection)
+    main._init_core_tables(raw_connection)
+    main.notification_counts = main.NotificationStore()
+    main.events = []
+    main.transcript_history = defaultdict(lambda: deque(maxlen=main.TRANSCRIPT_HISTORY_LIMIT))
+    main.app.dependency_overrides[main.get_db] = lambda: raw_connection
+
+    session_factory = sessionmaker(
+        bind=engine,
+        autoflush=False,
+        expire_on_commit=False,
+        future=True,
+    )
+
+    context = DatabaseContext(
+        engine=engine,
+        connection=connection,
+        raw_connection=raw_connection,
+        session_factory=session_factory,
+    )
+
+    try:
+        yield context
+    finally:
+        session_factory.close_all()
+        main.app.dependency_overrides.pop(main.get_db, None)
+        try:
+            raw_connection.close()
+        except Exception:
+            pass
+        connection.close()
+        engine.dispose()
+
+
+@pytest.fixture(scope='function')
+def db_session(in_memory_db: DatabaseContext) -> Iterator[Session]:
+    """Yield a SQLAlchemy session tied to the in-memory database."""
+
+    session = in_memory_db.make_session()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture(scope='function')
+def api_client(in_memory_db: DatabaseContext) -> Iterator[TestClient]:
+    """Yield a FastAPI test client bound to the in-memory database."""
+
+    from backend import main
+
+    with TestClient(main.app) as client:
+        yield client
+
+
+@pytest.fixture(scope='function')
+def admin_user(db_session) -> str:
+    """Create a default administrator account for tests."""
+
+    from backend import auth, main
+
+    with main.auth_session_scope() as session:
+        auth.register_user(session, 'admin', 'secret', 'admin')
+    return 'admin'
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,45 +1,32 @@
-import sqlite3
+"""Authentication endpoint regression tests."""
+
 import importlib
 
 import pytest
-from fastapi.testclient import TestClient
 
 import backend.main as main
 from backend import auth
 
 
-def setup_module(module):
-    """Use an in-memory database for isolation during authentication tests."""
-    main.db_conn = sqlite3.connect(':memory:', check_same_thread=False)
-    main.db_conn.row_factory = sqlite3.Row
-    main.db_conn.execute(
-        'CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT, eventType TEXT, timestamp REAL, details TEXT, revenue REAL, codes TEXT, compliance_flags TEXT, public_health INTEGER, satisfaction INTEGER)'
-    )
-    main.db_conn.execute(
-        'CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password_hash TEXT, role TEXT)'
-    )
-    main.db_conn.execute(
-        'CREATE TABLE audit_log (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp REAL, username TEXT, action TEXT, details TEXT)'
-    )
-    main.ensure_settings_table(main.db_conn)
-    main.configure_auth_session_factory(main.db_conn)
-    with main.auth_session_scope() as session:
-        auth.register_user(session, 'admin', 'secret', 'admin')
+@pytest.fixture()
+def client(api_client):
+    """Return a FastAPI test client bound to the isolated database."""
+
+    return api_client
 
 
-def test_register_and_login():
-    client = TestClient(main.app)
-    # Register a new regular user
+def test_register_and_login(client, admin_user):
+    """Users can register, log in and receive JWT tokens with their role."""
+
     resp = client.post('/register', json={'username': 'alice', 'password': 'pw'})
     assert resp.status_code == 200
-    # New user can log in and receives token with correct role
+
     resp = client.post('/login', json={'username': 'alice', 'password': 'pw'})
     assert resp.status_code == 200
     token = resp.json()['access_token']
     payload = main.jwt.decode(token, main.JWT_SECRET, algorithms=[main.JWT_ALGORITHM])
     assert payload['role'] == 'user'
 
-    # Password stored in DB should be a bcrypt hash and verify correctly
     row = main.db_conn.execute(
         'SELECT password_hash FROM users WHERE username=?',
         ('alice',),
@@ -49,68 +36,83 @@ def test_register_and_login():
     assert auth.verify_password('pw', row['password_hash'])
 
 
-def test_role_enforcement():
-    client = TestClient(main.app)
-    # Login as non-admin user
+def test_role_enforcement(client, admin_user):
+    """Regular users cannot access administrator endpoints."""
+
+    client.post('/register', json={'username': 'alice', 'password': 'pw'})
     resp = client.post('/login', json={'username': 'alice', 'password': 'pw'})
     token = resp.json()['access_token']
-    # Non-admin should be forbidden from accessing metrics
+
     resp = client.get('/metrics', headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 403
 
 
-def test_login_failure():
-    client = TestClient(main.app)
+def test_login_failure(client, admin_user):
+    """Invalid credentials should not authenticate a user."""
+
+    client.post('/register', json={'username': 'alice', 'password': 'pw'})
     resp = client.post('/login', json={'username': 'alice', 'password': 'wrong'})
     assert resp.status_code == 401
 
 
-def test_invalid_token_rejected():
-    client = TestClient(main.app)
-    # An obviously invalid token should return 401 rather than 403
+def test_invalid_token_rejected(client, admin_user):
+    """Malformed JWT tokens are rejected with a 401."""
+
     resp = client.get('/settings', headers={'Authorization': 'Bearer badtoken'})
     assert resp.status_code == 401
 
 
-def test_login_lockout():
-    client = TestClient(main.app)
+def test_login_lockout(client, admin_user):
+    """Accounts lock after repeated failed logins."""
+
     client.post('/register', json={'username': 'charlie', 'password': 'pw'})
     for _ in range(5):
         resp = client.post('/login', json={'username': 'charlie', 'password': 'bad'})
         assert resp.status_code == 401
+
     resp = client.post('/login', json={'username': 'charlie', 'password': 'pw'})
     assert resp.status_code == 423
 
 
-def test_audit_endpoint():
-    client = TestClient(main.app)
+def test_audit_endpoint(client, admin_user):
+    """Audit log requires admin access and records failed logins."""
+
     client.post('/login', json={'username': 'nosuch', 'password': 'bad'})
     admin_token = client.post('/login', json={'username': 'admin', 'password': 'secret'}).json()['access_token']
     resp = client.get('/audit', headers={'Authorization': f'Bearer {admin_token}'})
     assert resp.status_code == 200
     data = resp.json()
     assert any(entry['action'] == 'failed_login' for entry in data)
+
     client.post('/register', json={'username': 'bob', 'password': 'pw'})
     user_token = client.post('/login', json={'username': 'bob', 'password': 'pw'}).json()['access_token']
-    assert client.get('/audit', headers={'Authorization': f'Bearer {user_token}'}).status_code == 403
+    forbidden = client.get('/audit', headers={'Authorization': f'Bearer {user_token}'})
+    assert forbidden.status_code == 403
 
 
-def test_refresh_token_flow():
-    client = TestClient(main.app)
+def test_refresh_token_flow(client, admin_user):
+    """Refresh tokens issue new access tokens and invalid ones fail."""
+
     resp = client.post('/login', json={'username': 'admin', 'password': 'secret'})
     refresh_token = resp.json()['refresh_token']
+
     resp2 = client.post('/refresh', json={'refresh_token': refresh_token})
     assert resp2.status_code == 200
     new_token = resp2.json()['access_token']
-    assert client.get('/metrics', headers={'Authorization': f'Bearer {new_token}'}).status_code == 200
+    metrics = client.get('/metrics', headers={'Authorization': f'Bearer {new_token}'})
+    assert metrics.status_code == 200
+
     bad = client.post('/refresh', json={'refresh_token': 'bad'})
     assert bad.status_code == 401
 
 
-def test_requires_jwt_secret(monkeypatch):
+def test_requires_jwt_secret(monkeypatch, db_session):
+    """Production deployments require a configured JWT secret."""
+
     monkeypatch.delenv('JWT_SECRET', raising=False)
     monkeypatch.setenv('ENVIRONMENT', 'production')
     with pytest.raises(RuntimeError):
         importlib.reload(main)
+
     monkeypatch.setenv('ENVIRONMENT', 'development')
     importlib.reload(main)

--- a/tests/test_auth_api_namespace.py
+++ b/tests/test_auth_api_namespace.py
@@ -1,105 +1,108 @@
-import sqlite3
+"""Tests for the namespaced authentication API endpoints."""
+
 from typing import Dict
 
 import pytest
-from fastapi.testclient import TestClient
 
 import backend.main as main
 from backend import auth
-from backend.main import _init_core_tables
 
 
 @pytest.fixture()
-def client(monkeypatch):
-    conn = sqlite3.connect(":memory:", check_same_thread=False)
-    conn.row_factory = sqlite3.Row
-    _init_core_tables(conn)
-    main.db_conn = conn
-    main.configure_auth_session_factory(conn)
-    monkeypatch.setattr(main, "db_conn", conn)
+def bootstrap_admin(db_session):
+    """Provision an administrator used for bootstrap authentication calls."""
+
     with main.auth_session_scope() as session:
         auth.register_user(
             session,
-            "bootstrap-admin",
-            "admin-pass",
-            role="admin",
-            email="bootstrap-admin@example.test",
-            name="Bootstrap Admin",
+            'bootstrap-admin',
+            'admin-pass',
+            role='admin',
+            email='bootstrap-admin@example.test',
+            name='Bootstrap Admin',
         )
-    return TestClient(main.app)
+    return 'bootstrap-admin'
+
+
+@pytest.fixture()
+def client(api_client, bootstrap_admin):
+    """Return a FastAPI test client with an admin account pre-provisioned."""
+
+    return api_client
 
 
 def auth_header(token: str) -> Dict[str, str]:
-    return {"Authorization": f"Bearer {token}"}
+    return {'Authorization': f'Bearer {token}'}
 
 
 def test_namespaced_register_allows_idempotent_calls(client):
-    payload = {"username": "clinician", "password": "pw123"}
+    payload = {'username': 'clinician', 'password': 'pw123'}
 
-    response = client.post("/auth/register", json=payload)
+    response = client.post('/auth/register', json=payload)
     assert response.status_code == 200
     data = response.json()
-    assert data["access_token"], "Expected access token in register response"
-    assert data["refresh_token"], "Expected refresh token in register response"
-    assert data["settings"]["theme"] == "modern"
-    assert data["session"]["selectedCodes"]["codes"] == 0
+    assert data['access_token'], 'Expected access token in register response'
+    assert data['refresh_token'], 'Expected refresh token in register response'
+    assert data['settings']['theme'] == 'modern'
+    assert data['session']['selectedCodes']['codes'] == 0
 
-    repeat = client.post("/auth/register", json=payload)
+    repeat = client.post('/auth/register', json=payload)
     assert repeat.status_code == 200, repeat.json()
     repeat_data = repeat.json()
-    assert repeat_data["access_token"], "Idempotent register should still issue token"
-    assert repeat_data["session"]["selectedCodes"]["codes"] == 0
+    assert repeat_data['access_token'], 'Idempotent register should still issue token'
+    assert repeat_data['session']['selectedCodes']['codes'] == 0
 
 
 def test_namespaced_login_returns_session_payload(client):
     with main.auth_session_scope() as session:
         auth.register_user(
             session,
-            "workflow-user",
-            "complex-pass",
-            role="analyst",
-            email="workflow@example.test",
-            name="Workflow Analyst",
+            'workflow-user',
+            'complex-pass',
+            role='analyst',
+            email='workflow@example.test',
+            name='Workflow Analyst',
         )
 
     response = client.post(
-        "/api/auth/login",
-        json={"username": "workflow-user", "password": "complex-pass"},
+        '/api/auth/login',
+        json={'username': 'workflow-user', 'password': 'complex-pass'},
     )
     assert response.status_code == 200, response.json()
     data = response.json()
-    assert data["access_token"]
-    assert data["refresh_token"]
-    assert data["settings"]["specialty"] is None
-    session = data["session"]
-    assert isinstance(session["selectedCodes"], dict)
-    assert session["selectedCodes"]["codes"] == 0
-    assert isinstance(session["finalizationSessions"], dict)
+    assert data['access_token']
+    assert data['refresh_token']
+    assert data['settings']['specialty'] is None
+    session_payload = data['session']
+    assert isinstance(session_payload['selectedCodes'], dict)
+    assert session_payload['selectedCodes']['codes'] == 0
+    assert isinstance(session_payload['finalizationSessions'], dict)
 
 
 def test_logout_revokes_status(client):
     with main.auth_session_scope() as session:
-        auth.register_user(session, "temp-user", "pw")
+        auth.register_user(session, 'temp-user', 'pw')
+
     login = client.post(
-        "/api/auth/login",
-        json={"username": "temp-user", "password": "pw"},
+        '/api/auth/login',
+        json={'username': 'temp-user', 'password': 'pw'},
     )
-    token = login.json()["access_token"]
-    refresh = login.json()["refresh_token"]
-    status_before = client.get("/api/auth/status", headers=auth_header(token))
-    assert status_before.json()["authenticated"] is True
+    token = login.json()['access_token']
+    refresh = login.json()['refresh_token']
+    status_before = client.get('/api/auth/status', headers=auth_header(token))
+    assert status_before.json()['authenticated'] is True
 
     logout = client.post(
-        "/api/auth/logout",
-        json={"token": refresh},
+        '/api/auth/logout',
+        json={'token': refresh},
         headers=auth_header(token),
     )
     assert logout.status_code == 200
-    assert logout.json()["success"] is True
+    assert logout.json()['success'] is True
 
     refresh_attempt = client.post(
-        "/refresh",
-        json={"refresh_token": refresh},
+        '/refresh',
+        json={'refresh_token': refresh},
         headers=auth_header(token),
     )
     assert refresh_attempt.status_code == 401

--- a/tests/test_auth_flow.py
+++ b/tests/test_auth_flow.py
@@ -1,79 +1,44 @@
-import sqlite3
-from fastapi.testclient import TestClient
-
-from backend import main
-from backend import auth
+"""End-to-end authentication flow tests."""
 
 
-def setup_module(module):
-    db = sqlite3.connect(":memory:", check_same_thread=False)
-    db.row_factory = sqlite3.Row
-    main.db_conn = db
-    # Required tables
-    db.execute(
-        "CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password_hash TEXT, role TEXT)"
-    )
-    db.execute(
-        "CREATE TABLE audit_log (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp REAL, username TEXT, action TEXT, details TEXT)"
-    )
-    db.execute(
-        "CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT, eventType TEXT, timestamp REAL, details TEXT, revenue REAL, codes TEXT, compliance_flags TEXT, public_health INTEGER, satisfaction INTEGER)"
-    )
-    main.ensure_settings_table(db)
-    main.configure_auth_session_factory(db)
-    with main.auth_session_scope() as session:
-        auth.register_user(session, "admin", "secret", "admin")
+def test_registration_login_refresh_and_roles(api_client, admin_user):
+    client = api_client
 
-
-def test_registration_login_refresh_and_roles():
-    client = TestClient(main.app)
-    # Admin login
-    resp = client.post("/login", json={"username": "admin", "password": "secret"})
+    resp = client.post('/login', json={'username': 'admin', 'password': 'secret'})
     assert resp.status_code == 200
     admin_tokens = resp.json()
-    admin_token = admin_tokens["access_token"]
+    admin_token = admin_tokens['access_token']
 
-    # Register regular user
-    resp = client.post(
-        "/register",
-        json={"username": "alice", "password": "pw"},
-    )
+    resp = client.post('/register', json={'username': 'alice', 'password': 'pw'})
     assert resp.status_code == 200
 
-    # User login
-    resp = client.post("/login", json={"username": "alice", "password": "pw"})
+    resp = client.post('/login', json={'username': 'alice', 'password': 'pw'})
     assert resp.status_code == 200
     tokens = resp.json()
-    access = tokens["access_token"]
-    refresh = tokens["refresh_token"]
+    access = tokens['access_token']
+    refresh = tokens['refresh_token']
 
-    # Access admin endpoint should fail for regular user
-    resp = client.get("/metrics", headers={"Authorization": f"Bearer {access}"})
+    resp = client.get('/metrics', headers={'Authorization': f'Bearer {access}'})
     assert resp.status_code == 403
 
-    # Refresh token to obtain new access token
-    resp = client.post("/refresh", json={"refresh_token": refresh})
+    resp = client.post('/refresh', json={'refresh_token': refresh})
     assert resp.status_code == 200
-    new_access = resp.json()["access_token"]
+    new_access = resp.json()['access_token']
 
-    # New token works on user endpoint
     resp = client.post(
-        "/event",
-        json={"eventType": "test", "details": {}},
-        headers={"Authorization": f"Bearer {new_access}"},
+        '/event',
+        json={'eventType': 'test', 'details': {}},
+        headers={'Authorization': f'Bearer {new_access}'},
     )
     assert resp.status_code == 200
 
-    # Admin token can access admin endpoint
-    resp = client.get("/metrics", headers={"Authorization": f"Bearer {admin_token}"})
+    resp = client.get('/metrics', headers={'Authorization': f'Bearer {admin_token}'})
     assert resp.status_code == 200
 
-    # Regular user cannot view audit log
-    resp = client.get("/audit", headers={"Authorization": f"Bearer {new_access}"})
+    resp = client.get('/audit', headers={'Authorization': f'Bearer {access}'})
     assert resp.status_code == 403
 
-    # Admin can view audit log and see metrics entry
-    resp = client.get("/audit", headers={"Authorization": f"Bearer {admin_token}"})
+    resp = client.get('/audit', headers={'Authorization': f'Bearer {admin_token}'})
     assert resp.status_code == 200
     logs = resp.json()
-    assert any(log["details"] == "/metrics" for log in logs)
+    assert any(log['details'] == '/metrics' for log in logs)


### PR DESCRIPTION
## Summary
- add reusable fixtures in `tests/conftest.py` to spin up an in-memory SQLAlchemy engine, session, and FastAPI test client
- update authentication- and patient-related tests to consume the new fixtures instead of manual sqlite setup

## Testing
- pytest -o addopts='' tests/test_auth.py tests/test_auth_api_namespace.py tests/test_auth_flow.py tests/test_patient_endpoints.py *(fails: repository currently has merge-conflict markers in `backend/migrations.py`, triggering an `IndentationError` during import)*

------
https://chatgpt.com/codex/tasks/task_e_68d08d3d41bc8324845be25aec1eed7d