### PR TITLE
Add Postgres-aware testing and CI enhancements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,26 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REVENUEPILOT_SKIP_PACKAGED: 1
+      DB_POOL_SIZE: 5
+      DB_MAX_OVERFLOW: 10
+      STATEMENT_TIMEOUT_MS: 30000
+      PGCONNECT_TIMEOUT: 10
+      REVENUEPILOT_DB_PATH: ${{ github.workspace }}/.tmp/ci.db
+      RUN_PG_TESTS: ${{ vars.RUN_PG_TESTS || '0' }}
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: revenuepilot
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
 
@@ -46,8 +66,22 @@ jobs:
       - name: "Python lint & test with coverage"
         if: hashFiles('requirements.txt') != ''
         run: |
+          mkdir -p .tmp
+          python -m alembic -c backend/alembic/alembic.ini upgrade head
+          python -m alembic -c backend/alembic/alembic.ini check
           pytest --maxfail=1 --disable-warnings -q --cov=backend --cov-report=term --cov-report=json:coverage/python-coverage-raw.json
           if command -v flake8; then flake8 backend; fi
+      - name: "PostgreSQL migrations & smoke tests"
+        if: env.RUN_PG_TESTS == '1'
+        env:
+          TEST_DATABASE_URL: postgresql+psycopg://postgres:postgres@localhost:5432/revenuepilot
+          DATABASE_URL: postgresql+psycopg://postgres:postgres@localhost:5432/revenuepilot
+          REVENUEPILOT_DATABASE_URL: postgresql+psycopg://postgres:postgres@localhost:5432/revenuepilot
+          RUN_PG_TESTS: 1
+        run: |
+          python -m alembic -c backend/alembic/alembic.ini upgrade head
+          python -m alembic -c backend/alembic/alembic.ini check
+          pytest -m postgres --maxfail=1 --disable-warnings -q
       - name: "Build Python coverage badge + enforce threshold"
         if: hashFiles('requirements.txt') != ''
         run: |

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -14,10 +14,11 @@ from sqlalchemy.orm import declarative_base
 
 
 Base = declarative_base()
+legacy_metadata = sa.MetaData()
 
 clinics = sa.Table(
     "clinics",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("id", sa.Text, primary_key=True),
     sa.Column("code", sa.Text, nullable=False, unique=True),
     sa.Column("name", sa.Text),
@@ -28,7 +29,7 @@ clinics = sa.Table(
 
 users = sa.Table(
     "users",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
     sa.Column("username", sa.Text, unique=True),
     sa.Column("email", sa.Text, unique=True),
@@ -49,7 +50,7 @@ sa.Index("idx_users_clinic", users.c.clinic_id)
 
 settings = sa.Table(
     "settings",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id"), primary_key=True),
     sa.Column("theme", sa.Text, nullable=False),
     sa.Column("categories", sa.Text, nullable=False, server_default=sa.text("'{}'")),
@@ -68,7 +69,7 @@ settings = sa.Table(
 
 user_profile = sa.Table(
     "user_profile",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id"), primary_key=True),
     sa.Column("current_view", sa.Text),
     sa.Column("clinic", sa.Text),
@@ -78,7 +79,7 @@ user_profile = sa.Table(
 
 templates = sa.Table(
     "templates",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
     sa.Column("user", sa.Text),
     sa.Column("clinic", sa.Text),
@@ -91,7 +92,7 @@ templates = sa.Table(
 
 events = sa.Table(
     "events",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
     sa.Column("eventType", sa.Text, nullable=False),
     sa.Column("timestamp", sa.Float, nullable=False),
@@ -109,7 +110,7 @@ sa.Index("idx_events_type", events.c.eventType)
 
 event_aggregates = sa.Table(
     "event_aggregates",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("day", sa.Text, primary_key=True),
     sa.Column("start_ts", sa.Float, nullable=False),
     sa.Column("end_ts", sa.Float, nullable=False),
@@ -120,7 +121,7 @@ event_aggregates = sa.Table(
 
 confidence_scores = sa.Table(
     "confidence_scores",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
     sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id"), nullable=False),
     sa.Column("note_id", sa.Text),
@@ -133,7 +134,7 @@ confidence_scores = sa.Table(
 
 compliance_rules = sa.Table(
     "compliance_rules",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("id", sa.Text, primary_key=True),
     sa.Column("name", sa.Text, nullable=False),
     sa.Column("description", sa.Text, nullable=False),
@@ -148,7 +149,7 @@ compliance_rules = sa.Table(
 
 compliance_issues = sa.Table(
     "compliance_issues",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
     sa.Column("issue_id", sa.Text, nullable=False, unique=True),
     sa.Column("rule_id", sa.Text),
@@ -167,7 +168,7 @@ compliance_issues = sa.Table(
 
 compliance_issue_history = sa.Table(
     "compliance_issue_history",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
     sa.Column("issue_id", sa.Text, nullable=False),
     sa.Column("code", sa.Text),
@@ -183,7 +184,7 @@ sa.Index("idx_compliance_history_created_at", compliance_issue_history.c.created
 
 billing_audits = sa.Table(
     "billing_audits",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
     sa.Column("audit_id", sa.Text, nullable=False, server_default=sa.text("''")),
     sa.Column("code", sa.Text),
@@ -199,7 +200,7 @@ sa.Index("idx_billing_audits_created_at", billing_audits.c.created_at)
 
 refresh_tokens = sa.Table(
     "refresh_tokens",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
     sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id"), nullable=False),
     sa.Column("token_hash", sa.Text, nullable=False),
@@ -210,7 +211,7 @@ sa.Index("idx_refresh_user", refresh_tokens.c.user_id)
 
 sessions = sa.Table(
     "sessions",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("id", sa.Text, primary_key=True),
     sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id"), nullable=False),
     sa.Column("token_hash", sa.Text),
@@ -227,7 +228,7 @@ sa.Index("idx_sessions_user", sessions.c.user_id)
 
 password_reset_tokens = sa.Table(
     "password_reset_tokens",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("id", sa.Text, primary_key=True),
     sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id"), nullable=False),
     sa.Column("token_hash", sa.Text, nullable=False),
@@ -240,7 +241,7 @@ sa.Index("idx_password_reset_expiry", password_reset_tokens.c.expires_at)
 
 mfa_challenges = sa.Table(
     "mfa_challenges",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("session_token", sa.Text, primary_key=True),
     sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id"), nullable=False),
     sa.Column("code_hash", sa.Text, nullable=False),
@@ -253,7 +254,7 @@ mfa_challenges = sa.Table(
 
 audit_log = sa.Table(
     "audit_log",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
     sa.Column("timestamp", sa.Float, nullable=False),
     sa.Column("username", sa.Text),
@@ -271,7 +272,7 @@ sa.Index("idx_audit_log_action", audit_log.c.action)
 
 note_auto_saves = sa.Table(
     "note_auto_saves",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
     sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id")),
     sa.Column("note_id", sa.Integer),
@@ -282,7 +283,7 @@ note_auto_saves = sa.Table(
 
 note_versions = sa.Table(
     "note_versions",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
     sa.Column("note_id", sa.Text, nullable=False),
     sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id")),
@@ -293,7 +294,7 @@ note_versions = sa.Table(
 
 notes = sa.Table(
     "notes",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
     sa.Column("content", sa.Text),
     sa.Column("status", sa.Text, nullable=False, server_default=sa.text("'draft'")),
@@ -304,7 +305,7 @@ notes = sa.Table(
 
 error_log = sa.Table(
     "error_log",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
     sa.Column("timestamp", sa.Float, nullable=False),
     sa.Column("username", sa.Text),
@@ -315,7 +316,7 @@ error_log = sa.Table(
 
 exports = sa.Table(
     "exports",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
     sa.Column("timestamp", sa.Float, nullable=False),
     sa.Column("ehr", sa.Text),
@@ -327,7 +328,7 @@ exports = sa.Table(
 
 patients = sa.Table(
     "patients",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
     sa.Column("first_name", sa.Text),
     sa.Column("last_name", sa.Text),
@@ -346,7 +347,7 @@ sa.Index("idx_patients_dob", patients.c.dob)
 
 encounters = sa.Table(
     "encounters",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
     sa.Column("patient_id", sa.Integer, sa.ForeignKey("patients.id"), nullable=False),
     sa.Column("date", sa.Text),
@@ -360,7 +361,7 @@ sa.Index("idx_encounters_date", encounters.c.date)
 
 visit_sessions = sa.Table(
     "visit_sessions",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
     sa.Column("encounter_id", sa.Integer, sa.ForeignKey("encounters.id"), nullable=False),
     sa.Column("status", sa.Text, nullable=False),
@@ -373,7 +374,7 @@ visit_sessions = sa.Table(
 
 notification_counters = sa.Table(
     "notification_counters",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id"), primary_key=True),
     sa.Column("count", sa.Integer, nullable=False, server_default=sa.text("0")),
     sa.Column("updated_at", sa.Float, nullable=False),
@@ -381,7 +382,7 @@ notification_counters = sa.Table(
 
 notification_events = sa.Table(
     "notification_events",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
     sa.Column("event_id", sa.Text, nullable=False, unique=True),
     sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id"), nullable=False),
@@ -399,7 +400,7 @@ sa.Index("idx_notification_events_unread", notification_events.c.user_id, notifi
 
 notifications = sa.Table(
     "notifications",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("username", sa.Text, primary_key=True),
     sa.Column("count", sa.Integer, nullable=False, server_default=sa.text("0")),
     sa.Column("updated_at", sa.Float),
@@ -407,7 +408,7 @@ notifications = sa.Table(
 
 session_state = sa.Table(
     "session_state",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id"), primary_key=True),
     sa.Column("data", sa.Text),
     sa.Column("updated_at", sa.Float),
@@ -415,7 +416,7 @@ session_state = sa.Table(
 
 shared_workflow_sessions = sa.Table(
     "shared_workflow_sessions",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("session_id", sa.Text, primary_key=True),
     sa.Column("owner_username", sa.Text),
     sa.Column("data", sa.Text, nullable=False),
@@ -428,7 +429,7 @@ sa.Index(
 
 compliance_rule_catalog = sa.Table(
     "compliance_rule_catalog",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("id", sa.Text, primary_key=True),
     sa.Column("name", sa.Text, nullable=False),
     sa.Column("category", sa.Text),
@@ -439,7 +440,7 @@ compliance_rule_catalog = sa.Table(
 
 cpt_codes = sa.Table(
     "cpt_codes",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("code", sa.Text, primary_key=True),
     sa.Column("description", sa.Text),
     sa.Column("rvu", sa.Float),
@@ -454,7 +455,7 @@ cpt_codes = sa.Table(
 
 icd10_codes = sa.Table(
     "icd10_codes",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("code", sa.Text, primary_key=True),
     sa.Column("description", sa.Text),
     sa.Column("clinical_context", sa.Text),
@@ -468,7 +469,7 @@ icd10_codes = sa.Table(
 
 hcpcs_codes = sa.Table(
     "hcpcs_codes",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("code", sa.Text, primary_key=True),
     sa.Column("description", sa.Text),
     sa.Column("rvu", sa.Float),
@@ -483,7 +484,7 @@ hcpcs_codes = sa.Table(
 
 cpt_reference = sa.Table(
     "cpt_reference",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("code", sa.Text, primary_key=True),
     sa.Column("description", sa.Text),
     sa.Column("base_rvu", sa.Float),
@@ -492,7 +493,7 @@ cpt_reference = sa.Table(
 
 payer_schedules = sa.Table(
     "payer_schedules",
-    Base.metadata,
+    legacy_metadata,
     sa.Column("payer_type", sa.Text, primary_key=True),
     sa.Column("location", sa.Text, primary_key=True, server_default=sa.text("''")),
     sa.Column("code", sa.Text, primary_key=True),

--- a/backend/requirements_dev.txt
+++ b/backend/requirements_dev.txt
@@ -4,6 +4,7 @@
 pytest
 pytest-cov
 pytest-asyncio
+pytest-postgresql
 httpx
 ruff
 flake8

--- a/ci.sh
+++ b/ci.sh
@@ -1,10 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export DB_POOL_SIZE="${DB_POOL_SIZE:-5}"
+export DB_MAX_OVERFLOW="${DB_MAX_OVERFLOW:-10}"
+export STATEMENT_TIMEOUT_MS="${STATEMENT_TIMEOUT_MS:-30000}"
+export PGCONNECT_TIMEOUT="${PGCONNECT_TIMEOUT:-10}"
+export REVENUEPILOT_DB_PATH="${REVENUEPILOT_DB_PATH:-$(pwd)/.tmp/ci.db}"
+mkdir -p "$(dirname "$REVENUEPILOT_DB_PATH")"
+
 backend/venv/bin/python -m alembic -c backend/alembic/alembic.ini upgrade head
+backend/venv/bin/python -m alembic -c backend/alembic/alembic.ini check
 
 ruff check backend
 pytest --cov=backend --cov-report=term
+
+if [[ "${RUN_PG_TESTS:-0}" == "1" ]]; then
+  : "${TEST_DATABASE_URL:?TEST_DATABASE_URL must be set when RUN_PG_TESTS=1}"
+  export DATABASE_URL="$TEST_DATABASE_URL"
+  export REVENUEPILOT_DATABASE_URL="$TEST_DATABASE_URL"
+  export RUN_PG_TESTS=1
+  backend/venv/bin/python -m alembic -c backend/alembic/alembic.ini upgrade head
+  backend/venv/bin/python -m alembic -c backend/alembic/alembic.ini check
+  pytest -m postgres --maxfail=1 --disable-warnings -q
+fi
+
 npm run lint
 npm run test:coverage
 npx playwright install --with-deps chromium

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 addopts = --cov=backend --cov-report=term-missing --cov-report=xml --cov-fail-under=35
+markers =
+    postgres: Tests requiring PostgreSQL and explicit opt-in via RUN_PG_TESTS=1 or --run-postgres.

--- a/tests/test_alembic_consistency.py
+++ b/tests/test_alembic_consistency.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+
+
+def test_alembic_heads_match_metadata(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    cfg = Config(str(repo_root / 'backend' / 'alembic' / 'alembic.ini'))
+    cfg.set_main_option('script_location', str(repo_root / 'backend' / 'alembic'))
+    db_path = tmp_path / 'alembic-check.db'
+    cfg.set_main_option('sqlalchemy.url', f'sqlite+pysqlite:///{db_path}')
+
+    command.upgrade(cfg, 'head')
+    command.check(cfg)

--- a/tests/test_db_config.py
+++ b/tests/test_db_config.py
@@ -1,0 +1,41 @@
+import pytest
+
+from backend.db.config import get_database_settings
+
+
+def test_engine_options_reflect_env(monkeypatch):
+    monkeypatch.setenv('REVENUEPILOT_DATABASE_URL', 'postgresql+psycopg://user:pass@localhost/testdb')
+    monkeypatch.setenv('DB_POOL_SIZE', '7')
+    monkeypatch.setenv('DB_MAX_OVERFLOW', '2')
+    monkeypatch.setenv('PGCONNECT_TIMEOUT', '15')
+    monkeypatch.setenv('STATEMENT_TIMEOUT_MS', '45000')
+    monkeypatch.delenv('DB_POOL_TIMEOUT', raising=False)
+
+    get_database_settings.cache_clear()
+    settings = get_database_settings()
+    options = settings.engine_options()
+    assert options['pool_size'] == 7
+    assert options['max_overflow'] == 2
+    connect_args = options['connect_args']
+    assert connect_args['connect_timeout'] == 15
+    assert '-c timezone=UTC' in connect_args['options']
+    assert '-c statement_timeout=45000' in connect_args['options']
+
+    monkeypatch.delenv('REVENUEPILOT_DATABASE_URL', raising=False)
+    monkeypatch.delenv('DB_POOL_SIZE', raising=False)
+    monkeypatch.delenv('DB_MAX_OVERFLOW', raising=False)
+    monkeypatch.delenv('PGCONNECT_TIMEOUT', raising=False)
+    monkeypatch.delenv('STATEMENT_TIMEOUT_MS', raising=False)
+    get_database_settings.cache_clear()
+
+
+def test_invalid_integer_env_raises(monkeypatch):
+    monkeypatch.setenv('REVENUEPILOT_DATABASE_URL', 'postgresql+psycopg://user:pass@localhost/testdb')
+    monkeypatch.setenv('DB_POOL_SIZE', 'not-a-number')
+    get_database_settings.cache_clear()
+    settings = get_database_settings()
+    with pytest.raises(ValueError):
+        settings.engine_options()
+    monkeypatch.delenv('REVENUEPILOT_DATABASE_URL', raising=False)
+    monkeypatch.delenv('DB_POOL_SIZE', raising=False)
+    get_database_settings.cache_clear()

--- a/tests/test_db_postgres_smoke.py
+++ b/tests/test_db_postgres_smoke.py
@@ -1,0 +1,58 @@
+import sqlalchemy as sa
+
+import pytest
+
+from backend.db import models
+
+
+@pytest.mark.postgres
+def test_postgres_crud_smoke(orm_session):
+    clinic = models.Clinic(id='clinic-1', code='CL1', name='Clinic One')
+    orm_session.add(clinic)
+
+    user = models.User(
+        username='pg-user',
+        email='pg-user@example.test',
+        password_hash='$2b$12$abcdefghijklmnopqrstuv',
+        role='admin',
+        clinic_id=clinic.id,
+        name='PG User',
+    )
+    orm_session.add(user)
+    orm_session.flush()
+
+    fetched_user = orm_session.execute(
+        sa.select(models.User).where(models.User.username == 'pg-user')
+    ).scalar_one()
+    assert fetched_user.created_at.tzinfo is not None
+    fetched_user.name = 'Updated User'
+    orm_session.flush()
+    refreshed_user = orm_session.get(models.User, fetched_user.id)
+    assert refreshed_user.name == 'Updated User'
+
+    issue = models.ComplianceIssue(
+        issue_id='issue-1',
+        title='Missing documentation',
+        severity=models.ComplianceSeverity.HIGH,
+        status=models.ComplianceStatus.OPEN,
+        category='testing',
+    )
+    orm_session.add(issue)
+
+    notification = models.Notification(username='pg-user', count=3)
+    orm_session.add(notification)
+    orm_session.flush()
+
+    fetched_issue = orm_session.execute(
+        sa.select(models.ComplianceIssue).where(models.ComplianceIssue.issue_id == 'issue-1')
+    ).scalar_one()
+    assert fetched_issue.created_at.tzinfo is not None
+    fetched_issue.status = models.ComplianceStatus.RESOLVED
+
+    orm_session.delete(notification)
+    orm_session.flush()
+
+    remaining_notifications = orm_session.execute(
+        sa.select(sa.func.count()).select_from(models.Notification)
+    ).scalar_one()
+    assert remaining_notifications == 0

--- a/tests/test_db_timezone.py
+++ b/tests/test_db_timezone.py
@@ -1,0 +1,15 @@
+import sqlalchemy as sa
+
+from backend.db import models
+
+
+def test_all_datetime_columns_are_timezone_aware():
+    tz_columns = []
+    for table in models.Base.metadata.sorted_tables:
+        for column in table.columns:
+            if isinstance(column.type, sa.DateTime):
+                tz_columns.append((table.name, column.name))
+                assert (
+                    getattr(column.type, 'timezone', False)
+                ), f"{table.name}.{column.name} must be timezone-aware"
+    assert tz_columns, "Expected at least one timezone-aware column in metadata"


### PR DESCRIPTION
## Summary
- expose database pool and timeout settings via DatabaseSettings.engine_options and ensure Postgres connections set timezone/statement timeout defaults
- extend pytest fixtures to optionally provision PostgreSQL sessions, add Alembic/ORM regression tests, and add Postgres CRUD smoke tests
- wire optional PostgreSQL smoke tests and Alembic checks into ci.sh and the GitHub workflow with configurable RUN_PG_TESTS gating

## Testing
- `ruff check backend/db/config.py tests/conftest.py tests/test_alembic_consistency.py tests/test_db_config.py tests/test_db_postgres_smoke.py tests/test_db_timezone.py`
- `pytest tests/test_db_timezone.py tests/test_alembic_consistency.py tests/test_db_config.py --cov-fail-under=0`

------
https://chatgpt.com/codex/tasks/task_e_68d0909b8a9083249081d5074e7574e3