### PR TITLE
Refactor legacy database helpers into dedicated module

### DIFF
--- a/backend/compliance.py
+++ b/backend/compliance.py
@@ -23,7 +23,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
-from backend import db
+import backend.database_legacy as db
 from backend.compliance_models import Base, ComplianceRule
 
 # ---------------------------------------------------------------------------

--- a/backend/database_legacy.py
+++ b/backend/database_legacy.py
@@ -84,8 +84,6 @@ from backend import code_tables
 from backend import patients
 from backend import visits
 from backend import scheduling
-from backend import compliance as compliance_engine
-from backend.compliance import configure_engine as configure_compliance_engine
 from backend.codes_data import load_code_metadata
 
 logger = logging.getLogger(__name__)
@@ -157,6 +155,8 @@ def _seed_reference_data(conn: sqlite3.Connection) -> None:
 
     try:
         if existing_rules == 0:
+            from backend import compliance as compliance_engine
+
             seed_compliance_rules(conn, compliance_engine.get_rules())
 
         metadata = load_code_metadata()
@@ -261,6 +261,8 @@ def _initialise_schema(conn: sqlite3.Connection) -> None:
 
     patients.configure_database(conn)
     scheduling.configure_database(conn)
+    from backend.compliance import configure_engine as configure_compliance_engine
+
     configure_compliance_engine(conn)
     _seed_reference_data(conn)
     conn.commit()

--- a/backend/db/__init__.py
+++ b/backend/db/__init__.py
@@ -1,6 +1,49 @@
 """Database helpers for RevenuePilot."""
 
+from backend.database_legacy import (
+    DATA_DIR,
+    DATABASE_PATH,
+    DATABASE_URL,
+    SQLITE_FILENAME,
+    SQLITE_PATH,
+    SessionLocal,
+    connection_scope,
+    engine,
+    get_connection,
+    get_db,
+    get_session,
+    get_sync_connection,
+    initialise_for_tests,
+    initialise_schema,
+    reset_global_connection,
+    resolve_session_connection,
+    set_sync_connection,
+    use_connection,
+)
+
 from .config import DatabaseSettings, get_database_settings
 from .models import Base
 
-__all__ = ["Base", "DatabaseSettings", "get_database_settings"]
+__all__ = [
+    "Base",
+    "DATA_DIR",
+    "DATABASE_PATH",
+    "DATABASE_URL",
+    "DatabaseSettings",
+    "SessionLocal",
+    "SQLITE_FILENAME",
+    "SQLITE_PATH",
+    "connection_scope",
+    "engine",
+    "get_connection",
+    "get_database_settings",
+    "get_db",
+    "get_session",
+    "get_sync_connection",
+    "initialise_for_tests",
+    "initialise_schema",
+    "reset_global_connection",
+    "resolve_session_connection",
+    "set_sync_connection",
+    "use_connection",
+]

--- a/backend/main.py
+++ b/backend/main.py
@@ -149,7 +149,7 @@ from backend.db.models import (
 from backend.audio_processing import simple_transcribe, diarize_and_transcribe  # type: ignore
 from backend import public_health as public_health_api  # type: ignore
 import backend.scheduling as scheduling_module  # type: ignore
-from backend.db import (
+from backend.database_legacy import (
     DATABASE_PATH,
     get_connection,
     get_session,
@@ -210,7 +210,7 @@ from backend.templates import (
     update_user_template,
     delete_user_template,
 )  # type: ignore
-from backend import db
+import backend.database_legacy as db
 from backend.scheduling import DEFAULT_EVENT_SUMMARY, export_ics, recommend_follow_up  # type: ignore
 from backend.scheduling import (  # type: ignore
     create_appointment,
@@ -1386,7 +1386,7 @@ async def _broadcast_notification_count(username: str) -> None:
 
 
 # Set up a SQLite database for persistent analytics storage.  Connection
-# creation and schema initialisation live in ``backend.db`` so the dependency
+# creation and schema initialisation live in ``backend.database_legacy`` so the dependency
 # can be shared across the application and tests.
 data_dir = DATABASE_PATH.parent
 data_dir.mkdir(parents=True, exist_ok=True)
@@ -1395,7 +1395,7 @@ UPLOAD_DIR = Path(os.getenv("CHART_UPLOAD_DIR", str(data_dir / "uploaded_charts"
 db_conn = get_connection()
 
 # Set up a SQLite database for persistent analytics storage.  The database
-# location and connection management are centralised in ``backend.db`` so the
+# location and connection management are centralised in ``backend.database_legacy`` so the
 # same configuration is reused across modules.
 data_dir = str(db.DATA_DIR)
 DB_PATH = str(db.SQLITE_PATH)
@@ -1577,7 +1577,7 @@ _prune_analytics_if_needed()
 # Helper to (re)initialise core tables when db_conn is swapped in tests.
 def _init_core_tables(conn):  # pragma: no cover - invoked in tests indirectly
     initialise_schema(conn)
-    from backend import db as db_helpers
+    import backend.database_legacy as db_helpers
 
     db_helpers.use_connection(conn)
     conn.row_factory = sqlite3.Row

--- a/backend/scheduling.py
+++ b/backend/scheduling.py
@@ -27,7 +27,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
-from backend import db
+import backend.database_legacy as db
 
 
 # Default intervals for broad condition categories.  These are defined as
@@ -980,24 +980,6 @@ def _apply_db_bulk_operation(
                 _VISIT_SESSIONS_TABLE.c.id.desc(),
             )
             .limit(1)
-
-    now_ts = to_epoch_seconds(utc_now())
-    session_row = conn.execute(
-        """
-        SELECT id
-        FROM visit_sessions
-        WHERE encounter_id=?
-        ORDER BY updated_at DESC, id DESC
-        LIMIT 1
-        """,
-        (encounter_id,),
-    ).fetchone()
-    if session_row:
-        session_id = (
-            session_row["id"]
-            if hasattr(session_row, "keys")
-            else session_row[0]  # type: ignore[index]
-
         )
         .mappings()
         .first()
@@ -1058,13 +1040,6 @@ def apply_bulk_operations(
             try:
                 appt_id = int(update["id"])
             except Exception:
-
-        time_value = update.get("time")
-        if time_value is None:
-            new_start = None
-        else:
-            new_start = _parse_datetime(time_value)
-            if new_start is None:
                 failed += 1
                 continue
 

--- a/tests/test_db_postgres_smoke.py
+++ b/tests/test_db_postgres_smoke.py
@@ -2,15 +2,15 @@ import sqlalchemy as sa
 
 import pytest
 
-from backend.db import models
+from backend.db import models as db_models
 
 
 @pytest.mark.postgres
 def test_postgres_crud_smoke(orm_session):
-    clinic = models.Clinic(id='clinic-1', code='CL1', name='Clinic One')
+    clinic = db_models.Clinic(id='clinic-1', code='CL1', name='Clinic One')
     orm_session.add(clinic)
 
-    user = models.User(
+    user = db_models.User(
         username='pg-user',
         email='pg-user@example.test',
         password_hash='$2b$12$abcdefghijklmnopqrstuv',
@@ -22,37 +22,37 @@ def test_postgres_crud_smoke(orm_session):
     orm_session.flush()
 
     fetched_user = orm_session.execute(
-        sa.select(models.User).where(models.User.username == 'pg-user')
+        sa.select(db_models.User).where(db_models.User.username == 'pg-user')
     ).scalar_one()
     assert fetched_user.created_at.tzinfo is not None
     fetched_user.name = 'Updated User'
     orm_session.flush()
-    refreshed_user = orm_session.get(models.User, fetched_user.id)
+    refreshed_user = orm_session.get(db_models.User, fetched_user.id)
     assert refreshed_user.name == 'Updated User'
 
-    issue = models.ComplianceIssue(
+    issue = db_models.ComplianceIssue(
         issue_id='issue-1',
         title='Missing documentation',
-        severity=models.ComplianceSeverity.HIGH,
-        status=models.ComplianceStatus.OPEN,
+        severity=db_models.ComplianceSeverity.HIGH,
+        status=db_models.ComplianceStatus.OPEN,
         category='testing',
     )
     orm_session.add(issue)
 
-    notification = models.Notification(username='pg-user', count=3)
+    notification = db_models.Notification(username='pg-user', count=3)
     orm_session.add(notification)
     orm_session.flush()
 
     fetched_issue = orm_session.execute(
-        sa.select(models.ComplianceIssue).where(models.ComplianceIssue.issue_id == 'issue-1')
+        sa.select(db_models.ComplianceIssue).where(db_models.ComplianceIssue.issue_id == 'issue-1')
     ).scalar_one()
     assert fetched_issue.created_at.tzinfo is not None
-    fetched_issue.status = models.ComplianceStatus.RESOLVED
+    fetched_issue.status = db_models.ComplianceStatus.RESOLVED
 
     orm_session.delete(notification)
     orm_session.flush()
 
     remaining_notifications = orm_session.execute(
-        sa.select(sa.func.count()).select_from(models.Notification)
+        sa.select(sa.func.count()).select_from(db_models.Notification)
     ).scalar_one()
     assert remaining_notifications == 0

--- a/tests/test_db_timezone.py
+++ b/tests/test_db_timezone.py
@@ -1,11 +1,11 @@
 import sqlalchemy as sa
 
-from backend.db import models
+from backend.db import models as db_models
 
 
 def test_all_datetime_columns_are_timezone_aware():
     tz_columns = []
-    for table in models.Base.metadata.sorted_tables:
+    for table in db_models.Base.metadata.sorted_tables:
         for column in table.columns:
             if isinstance(column.type, sa.DateTime):
                 tz_columns.append((table.name, column.name))


### PR DESCRIPTION
## Summary
- move the legacy SQL helpers out of `backend/db.py` into the new `backend/database_legacy.py` module and adjust callers
- expand `backend/db/__init__.py` so FastAPI code can import session factories from the package instead of the legacy module
- tidy dependent helpers and tests (main/compliance/scheduling/migrations) to use the new module and remove redundant compatibility logic

## Testing
- `pytest tests/test_db_timezone.py tests/test_db_postgres_smoke.py` *(fails: coverage threshold 35% not met with limited scope)*
- `pytest` *(fails: backend.patients missing configure_database in wider suite)*

------
https://chatgpt.com/codex/tasks/task_e_68d09aa1beec8324a4b6f70b8738a553