### PR TITLE
Refactor settings endpoints to use ORM sessions

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -87,7 +87,7 @@ import json, sqlite3
 from uuid import uuid4
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.orm import Session as SQLAlchemySession, sessionmaker
 from sqlalchemy.pool import StaticPool
 try:  # prefer appdirs
@@ -145,6 +145,9 @@ from backend.db.models import (
     HCPCSCode,
     ICD10Code,
     PayerSchedule,
+    Setting,
+    User,
+    UserProfile as UserProfileRecord,
 )
 from backend.audio_processing import simple_transcribe, diarize_and_transcribe  # type: ignore
 from backend import public_health as public_health_api  # type: ignore
@@ -2938,42 +2941,67 @@ def _persist_refresh_token(user_id: int, refresh_token: str, days: int) -> None:
         logger.exception("refresh_token_persist_failed", error=str(exc))
 
 
-def _load_user_preferences(user_id: int) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-    settings_row = db_conn.execute(
-        "SELECT theme, categories, rules, lang, summary_lang, specialty, payer, region, use_local_models, use_offline_mode, agencies, template, beautify_model, suggest_model, summarize_model, deid_engine FROM settings WHERE user_id=?",
-        (user_id,),
-    ).fetchone()
-    if settings_row:
-        sr = dict(settings_row)
+def _as_dict(value: Any, default: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+            if isinstance(parsed, dict):
+                return parsed
+        except json.JSONDecodeError:
+            pass
+    return dict(default or {})
+
+
+def _as_list(value: Any, default: Optional[Iterable[Any]] = None) -> List[Any]:
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+            if isinstance(parsed, list):
+                return parsed
+        except json.JSONDecodeError:
+            pass
+    return list(default or [])
+
+
+def _load_user_preferences(session: Session, user_id: int) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    setting = session.get(Setting, user_id)
+    if setting is not None:
+        categories_default = CategorySettings().model_dump()
         settings = {
-            "theme": sr["theme"],
-            "categories": json.loads(sr["categories"]),
-            "rules": json.loads(sr["rules"]),
-            "lang": sr["lang"],
-            "summaryLang": sr["summary_lang"] or sr["lang"],
-            "specialty": sr["specialty"],
-            "payer": sr["payer"],
-            "region": sr["region"] or "",
-            "template": sr["template"],
-            "useLocalModels": bool(sr["use_local_models"]),
-            "useOfflineMode": bool(sr.get("use_offline_mode", 0)),
-            "agencies": json.loads(sr["agencies"]) if sr["agencies"] else ["CDC", "WHO"],
-            "beautifyModel": sr["beautify_model"],
-            "suggestModel": sr["suggest_model"],
-            "summarizeModel": sr["summarize_model"],
-            "deidEngine": sr["deid_engine"] or os.getenv("DEID_ENGINE", "regex"),
+            "theme": setting.theme,
+            "categories": _as_dict(setting.categories, categories_default) or categories_default,
+            "rules": _as_list(setting.rules, []),
+            "lang": setting.lang,
+            "summaryLang": setting.summary_lang or setting.lang,
+            "specialty": setting.specialty,
+            "payer": setting.payer,
+            "region": setting.region or "",
+            "template": setting.template,
+            "useLocalModels": bool(setting.use_local_models),
+            "useOfflineMode": bool(getattr(setting, "use_offline_mode", False)),
+            "agencies": _as_list(setting.agencies, ["CDC", "WHO"]) or ["CDC", "WHO"],
+            "beautifyModel": setting.beautify_model,
+            "suggestModel": setting.suggest_model,
+            "summarizeModel": setting.summarize_model,
+            "deidEngine": setting.deid_engine or os.getenv("DEID_ENGINE", "regex"),
         }
     else:
         settings = UserSettings().model_dump()
 
     try:
-        session_row = db_conn.execute(
-            "SELECT data FROM session_state WHERE user_id=?",
-            (user_id,),
-        ).fetchone()
-    except sqlite3.OperationalError:
+        session_row = session.execute(
+            sa.text("SELECT data FROM session_state WHERE user_id=:user_id"),
+            {"user_id": user_id},
+        ).mappings().first()
+    except OperationalError:
         session_row = None
-    if session_row and session_row["data"]:
+    if session_row and session_row.get("data"):
         session_state = _normalize_session_state(session_row["data"])
     else:
         session_state = _normalize_session_state(SessionStateModel())
@@ -3869,7 +3897,8 @@ async def login(model: LoginModel, request: Request) -> Dict[str, Any]:
     db_conn.commit()
     LOGIN_RATE_LIMITER.reset(limiter_key)
 
-    settings, session_state = _load_user_preferences(user_row["id"])
+    with auth_session_scope() as orm_session:
+        settings, session_state = _load_user_preferences(orm_session, user_row["id"])
     user_agent = _user_agent(request)
 
     if _row_get(user_row, "mfa_enabled"):
@@ -3967,7 +3996,8 @@ async def verify_mfa(model: VerifyMFAModel, request: Request) -> Dict[str, Any]:
             detail={"error": "Invalid or expired MFA code", "code": "INVALID_MFA"},
         )
 
-    settings, session_state = _load_user_preferences(user_row["id"])
+    with auth_session_scope() as orm_session:
+        settings, session_state = _load_user_preferences(orm_session, user_row["id"])
     ip_address = _client_ip(request)
     user_agent = _user_agent(request)
     remember_me = bool(_row_get(challenge, "remember_me"))
@@ -4297,7 +4327,8 @@ async def auth_validate(
             detail="Invalid or expired token",
         )
 
-    settings, _session_state = _load_user_preferences(row["id"])
+    with auth_session_scope() as orm_session:
+        settings, _session_state = _load_user_preferences(orm_session, row["id"])
     user_payload = _build_user_payload(row)
     user_payload.update(
         {
@@ -4629,77 +4660,68 @@ async def get_audit_logs(user=Depends(require_role("admin"))) -> List[Dict[str, 
 
 
 @app.get("/settings")
-async def get_user_settings(user=Depends(require_role("user"))) -> Dict[str, Any]:
+async def get_user_settings(
+    user=Depends(require_role("user")),
+    session: Session = Depends(get_session),
+) -> Dict[str, Any]:
     """Return the current user's saved settings or defaults if none exist."""
-    row = db_conn.execute(
-        "SELECT s.theme, s.categories, s.rules, s.lang, s.summary_lang, s.specialty, s.payer, s.region, s.use_local_models, s.use_offline_mode, s.agencies, s.template, s.beautify_model, s.suggest_model, s.summarize_model, s.deid_engine FROM settings s JOIN users u ON s.user_id = u.id WHERE u.username=?",
-        (user["sub"],),
-    ).fetchone()
 
-    if row:
-        rd = dict(row)
-        settings = UserSettings(
-            theme=rd["theme"],
-            categories=json.loads(rd["categories"]),
-            rules=json.loads(rd["rules"]),
-            lang=rd["lang"],
-            summaryLang=rd["summary_lang"] or rd["lang"],
-            specialty=rd["specialty"],
-            payer=rd["payer"],
-            region=rd["region"] or "",
-            template=rd["template"],
-            useLocalModels=bool(rd["use_local_models"]),
-            useOfflineMode=bool(rd.get("use_offline_mode", 0)),
-            agencies=json.loads(rd["agencies"]) if rd["agencies"] else ["CDC", "WHO"],
-            beautifyModel=rd["beautify_model"],
-            suggestModel=rd["suggest_model"],
-            summarizeModel=rd["summarize_model"],
-            deidEngine=rd["deid_engine"] or os.getenv("DEID_ENGINE", "regex"),
-        )
-        return settings.model_dump()
-    return UserSettings(deidEngine=os.getenv("DEID_ENGINE", "regex")).model_dump()
+    user_record = session.execute(
+        sa.select(User).where(User.username == user["sub"])
+    ).scalar_one_or_none()
+    if not user_record:
+        return UserSettings(deidEngine=os.getenv("DEID_ENGINE", "regex")).model_dump()
+
+    settings_dict, _ = _load_user_preferences(session, user_record.id)
+    try:
+        validated = UserSettings.model_validate(settings_dict)
+    except ValidationError:
+        merged = UserSettings().model_dump()
+        merged.update(settings_dict)
+        validated = UserSettings.model_validate(merged)
+    return validated.model_dump()
 
 
 @app.post("/settings")
 @app.put("/api/user/preferences")
 async def save_user_settings(
-    model: UserSettings, user=Depends(require_role("user"))
+    model: UserSettings,
+    user=Depends(require_role("user")),
+    session: Session = Depends(get_session),
 ) -> Dict[str, Any]:
     """Persist settings for the authenticated user."""
-    # Explicit validation of deidEngine (pydantic may be bypassed if missing fields in test payload)
+
     if model.deidEngine not in {"regex", "presidio", "philter", "scrubadub"}:
         raise HTTPException(status_code=422, detail="invalid deid engine")
-    row = db_conn.execute(
-        "SELECT id FROM users WHERE username=?",
-        (user["sub"],),
-    ).fetchone()
-    if not row:
-        raise HTTPException(status_code=400, detail="User not found")
-    db_conn.execute(
-        # Added deid_engine column
-        "INSERT OR REPLACE INTO settings (user_id, theme, categories, rules, lang, summary_lang, specialty, payer, region, template, use_local_models, agencies, beautify_model, suggest_model, summarize_model, deid_engine, use_offline_mode) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        (
-            row["id"],
-            model.theme,
-            json.dumps(model.categories.model_dump()),
-            json.dumps(model.rules),
-            model.lang,
-            model.summaryLang,
-            model.specialty,
-            model.payer,
-            model.region,
-            model.template,
-            int(model.useLocalModels),
-            json.dumps(model.agencies),
-            model.beautifyModel,
-            model.suggestModel,
-            model.summarizeModel,
-            model.deidEngine,
-            int(model.useOfflineMode),
-        ),
-    )
 
-    db_conn.commit()
+    user_record = session.execute(
+        sa.select(User).where(User.username == user["sub"])
+    ).scalar_one_or_none()
+    if not user_record:
+        raise HTTPException(status_code=400, detail="User not found")
+
+    setting = session.get(Setting, user_record.id)
+    if setting is None:
+        setting = Setting(user_id=user_record.id)
+        session.add(setting)
+
+    setting.theme = model.theme
+    setting.categories = model.categories.model_dump()
+    setting.rules = list(model.rules)
+    setting.lang = model.lang
+    setting.summary_lang = model.summaryLang
+    setting.specialty = model.specialty
+    setting.payer = model.payer
+    setting.region = model.region
+    setting.template = model.template
+    setting.use_local_models = bool(model.useLocalModels)
+    setting.agencies = list(model.agencies)
+    setting.beautify_model = model.beautifyModel
+    setting.suggest_model = model.suggestModel
+    setting.summarize_model = model.summarizeModel
+    setting.deid_engine = model.deidEngine
+    setting.use_offline_mode = bool(model.useOfflineMode)
+
     return model.model_dump()
 
 
@@ -4718,15 +4740,20 @@ async def list_available_themes() -> Dict[str, Any]:
 
 
 @app.get("/api/user/preferences")
-async def api_get_user_preferences(user=Depends(require_role("user"))):
-    return await get_user_settings(user)
+async def api_get_user_preferences(
+    user=Depends(require_role("user")),
+    session: Session = Depends(get_session),
+):
+    return await get_user_settings(user=user, session=session)
 
 
 @app.put("/api/user/preferences")
 async def api_put_user_preferences(
-    model: UserSettings, user=Depends(require_role("user"))
+    model: UserSettings,
+    user=Depends(require_role("user")),
+    session: Session = Depends(get_session),
 ) -> Dict[str, Any]:
-    return await save_user_settings(model, user)
+    return await save_user_settings(model, user=user, session=session)
 
 
 @app.get("/api/integrations/ehr/config")
@@ -4797,76 +4824,61 @@ async def post_keys_endpoint(
 
 
 @app.get("/api/user/layout-preferences")
-async def get_layout_preferences(user=Depends(require_role("user"))) -> Dict[str, Any]:
-    row = db_conn.execute(
-        "SELECT layout_prefs FROM settings WHERE user_id=(SELECT id FROM users WHERE username=?)",
-        (user["sub"],),
-    ).fetchone()
+async def get_layout_preferences(
+    user=Depends(require_role("user")),
+    session: Session = Depends(get_session),
+) -> Dict[str, Any]:
+    user_id = session.execute(
+        sa.select(User.id).where(User.username == user["sub"])
+    ).scalar_one_or_none()
 
     data: Dict[str, Any] = {}
-    if row and row["layout_prefs"]:
-        try:
-            loaded = json.loads(row["layout_prefs"])
-            if isinstance(loaded, dict):
-                data = loaded
-        except Exception as exc:
-            logger.warning(
-                "layout_preferences_deserialize_failed",
-                user=user.get("sub"),
-                error=str(exc),
-            )
+    if user_id is not None:
+        setting = session.get(Setting, user_id)
+        if setting and setting.layout_prefs:
+            try:
+                loaded = _as_dict(setting.layout_prefs, {})
+                if isinstance(loaded, dict):
+                    data = loaded
+            except Exception as exc:
+                logger.warning(
+                    "layout_preferences_deserialize_failed",
+                    user=user.get("sub"),
+                    error=str(exc),
+                )
     response_payload: Dict[str, Any] = {"success": True, "data": data}
     if isinstance(data, dict):
         response_payload.update(data)
     return response_payload
 
 
-
 @app.put("/api/user/layout-preferences")
 async def put_layout_preferences(
-    prefs: Dict[str, Any], user=Depends(require_role("user"))
+    prefs: Dict[str, Any],
+    user=Depends(require_role("user")),
+    session: Session = Depends(get_session),
 ) -> Response:
-    core: Dict[str, Any]
     if "data" in prefs and isinstance(prefs["data"], dict):
         core = dict(prefs["data"])
     else:
         core = {key: value for key, value in prefs.items() if key not in {"success", "data"}}
-    data = json.dumps(core)
-    row = db_conn.execute(
-        "SELECT id FROM users WHERE username= ?",
-        (user["sub"],),
-    ).fetchone()
-    if not row:
+
+    user_record = session.execute(
+        sa.select(User).where(User.username == user["sub"])
+    ).scalar_one_or_none()
+    if not user_record:
         raise HTTPException(status_code=400, detail="User not found")
 
-    uid = row["id"]
-    db_conn.execute(
-        """
-        INSERT INTO settings (user_id, theme, layout_prefs)
-        VALUES (?, 'light', ?)
-        ON CONFLICT(user_id) DO UPDATE SET layout_prefs=excluded.layout_prefs
-        """,
-        (uid, data),
-    )
-    db_conn.commit()
+    setting = session.get(Setting, user_record.id)
+    if setting is None:
+        setting = Setting(user_id=user_record.id)
+        session.add(setting)
+        if not setting.theme:
+            setting.theme = "light"
 
-    stored = db_conn.execute(
-        "SELECT layout_prefs FROM settings WHERE user_id=?",
-        (uid,),
-    ).fetchone()
+    setting.layout_prefs = dict(core)
 
-    data_payload: Dict[str, Any] = {}
-    if stored and stored["layout_prefs"]:
-        try:
-            loaded = json.loads(stored["layout_prefs"])
-            if isinstance(loaded, dict):
-                data_payload = loaded
-        except Exception as exc:
-            logger.warning(
-                "layout_preferences_deserialize_failed",
-                user=uid,
-                error=str(exc),
-            )
+    data_payload = _as_dict(setting.layout_prefs, {})
     if not data_payload and isinstance(prefs, dict):
         data_payload = {key: value for key, value in prefs.items() if key not in {"success", "data"}}
     response_payload: Dict[str, Any] = {"success": True, "data": data_payload}
@@ -4970,7 +4982,8 @@ def _build_user_profile_payload(username: str) -> Dict[str, Any]:
             if isinstance(parsed_ui, dict):
                 ui_preferences = parsed_ui
 
-    settings, _ = _load_user_preferences(user_id)
+    with auth_session_scope() as orm_session:
+        settings, _ = _load_user_preferences(orm_session, user_id)
     combined_preferences = copy.deepcopy(settings)
     if stored_preferences:
         combined_preferences.update(stored_preferences)
@@ -6624,92 +6637,46 @@ def _register_session_activity(
     session["activeEditors"] = active_entries
 
 
-def _load_user_settings_preferences(user_id: int) -> Dict[str, Any]:
+def _load_user_settings_preferences(session: Session, user_id: int) -> Dict[str, Any]:
     """Load legacy user settings preferences for compatibility."""
 
     defaults = UserSettings().model_dump()
     preferences = copy.deepcopy(defaults)
-    try:
-        row = db_conn.execute(
-            """
-            SELECT
-                theme,
-                categories,
-                rules,
-                lang,
-                summary_lang,
-                specialty,
-                payer,
-                region,
-                use_local_models,
-                use_offline_mode,
-                agencies,
-                template,
-                beautify_model,
-                suggest_model,
-                summarize_model,
-                deid_engine
-            FROM settings
-            WHERE user_id=?
-            """,
-            (user_id,),
-        ).fetchone()
-    except sqlite3.Error:
-        row = None
-    if not row:
+    setting = session.get(Setting, user_id)
+    if setting is None:
         return preferences
-    record = dict(row)
+
     categories_default = copy.deepcopy(preferences.get("categories") or {})
     categories_value = categories_default
-    categories_raw = record.get("categories")
+    categories_raw = _as_dict(setting.categories, categories_default)
     if categories_raw:
-        try:
-            parsed = json.loads(categories_raw)
-            if isinstance(parsed, dict):
-                categories_value.update({key: bool(value) for key, value in parsed.items()})
-        except json.JSONDecodeError:
-            pass
+        categories_value.update({key: bool(value) for key, value in categories_raw.items()})
     preferences["categories"] = categories_value
-    rules_raw = record.get("rules")
-    rules_value: List[str] = []
-    if rules_raw:
-        try:
-            parsed_rules = json.loads(rules_raw)
-            if isinstance(parsed_rules, list):
-                rules_value = [str(item) for item in parsed_rules if isinstance(item, str)]
-        except json.JSONDecodeError:
-            rules_value = []
+
+    rules_value = [str(item) for item in _as_list(setting.rules, []) if isinstance(item, str)]
     preferences["rules"] = rules_value or preferences.get("rules", [])
-    lang_value = record.get("lang") or preferences.get("lang")
+
+    lang_value = setting.lang or preferences.get("lang")
     preferences["lang"] = lang_value
-    summary_lang = record.get("summary_lang") or lang_value
+    summary_lang = setting.summary_lang or lang_value
     preferences["summaryLang"] = summary_lang
-    preferences["specialty"] = record.get("specialty") or preferences.get("specialty")
-    preferences["payer"] = record.get("payer") or preferences.get("payer")
-    region = record.get("region")
+    preferences["specialty"] = setting.specialty or preferences.get("specialty")
+    preferences["payer"] = setting.payer or preferences.get("payer")
+    region = setting.region
     preferences["region"] = region if isinstance(region, str) else preferences.get("region")
-    template = record.get("template")
+    template = setting.template
     preferences["template"] = template if template is not None else preferences.get("template")
-    preferences["useLocalModels"] = bool(record.get("use_local_models", preferences.get("useLocalModels", False)))
-    preferences["useOfflineMode"] = bool(record.get("use_offline_mode", preferences.get("useOfflineMode", False)))
-    agencies_raw = record.get("agencies")
-    agencies_value = preferences.get("agencies") or []
-    if agencies_raw:
-        try:
-            parsed_agencies = json.loads(agencies_raw)
-            if isinstance(parsed_agencies, list):
-                agencies_value = [str(item) for item in parsed_agencies if item]
-        except json.JSONDecodeError:
-            agencies_value = preferences.get("agencies") or []
+    preferences["useLocalModels"] = bool(setting.use_local_models)
+    preferences["useOfflineMode"] = bool(getattr(setting, "use_offline_mode", False))
+    agencies_value = [str(item) for item in _as_list(setting.agencies, preferences.get("agencies") or []) if item]
     preferences["agencies"] = agencies_value or ["CDC", "WHO"]
-    preferences["beautifyModel"] = record.get("beautify_model") or preferences.get("beautifyModel")
-    preferences["suggestModel"] = record.get("suggest_model") or preferences.get("suggestModel")
-    preferences["summarizeModel"] = record.get("summarize_model") or preferences.get("summarizeModel")
-    deid_engine = record.get("deid_engine") or os.getenv("DEID_ENGINE")
+    preferences["beautifyModel"] = setting.beautify_model or preferences.get("beautifyModel")
+    preferences["suggestModel"] = setting.suggest_model or preferences.get("suggestModel")
+    preferences["summarizeModel"] = setting.summarize_model or preferences.get("summarizeModel")
+    deid_engine = setting.deid_engine or os.getenv("DEID_ENGINE")
     preferences["deidEngine"] = deid_engine or preferences.get("deidEngine")
-    theme = record.get("theme")
-    if isinstance(theme, str) and theme:
-        preferences["theme"] = theme
+    if isinstance(setting.theme, str) and setting.theme:
+        preferences["theme"] = setting.theme
     return preferences
 
 
@@ -6737,7 +6704,10 @@ def _sync_selected_codes_to_session_state(
 
 
 @app.get("/api/user/profile")
-async def get_user_profile(user=Depends(require_role("user"))) -> Dict[str, Any]:
+async def get_user_profile(
+    user=Depends(require_role("user")),
+    session: Session = Depends(get_session),
+) -> Dict[str, Any]:
 
     base_profile = UserProfile().model_dump()
     defaults = UserSettings().model_dump()
@@ -6752,49 +6722,20 @@ async def get_user_profile(user=Depends(require_role("user"))) -> Dict[str, Any]
         "preferences": defaults,
         "uiPreferences": normalized_defaults,
     }
-    row = db_conn.execute(
-        """
-        SELECT
-            u.id AS user_id,
-            u.username,
-            u.name,
-            u.role,
-            u.clinic_id,
-            up.current_view,
-            up.clinic,
-            up.preferences,
-            up.ui_preferences
-        FROM users u
-        LEFT JOIN user_profile up ON up.user_id = u.id
-        WHERE u.username=?
-        """,
-        (user["sub"],),
-    ).fetchone()
-    if not row:
+    user_record = session.execute(
+        sa.select(User).where(User.username == user["sub"])
+    ).scalar_one_or_none()
+    if not user_record:
         return result
-    preferences_raw = row["preferences"] if row["preferences"] else {}
-    if isinstance(preferences_raw, str):
-        try:
-            profile_preferences = json.loads(preferences_raw)
-        except json.JSONDecodeError:
-            profile_preferences = {}
-    elif isinstance(preferences_raw, dict):
-        profile_preferences = preferences_raw
-    else:
-        profile_preferences = {}
-    ui_raw = row["ui_preferences"] if row["ui_preferences"] else {}
-    if isinstance(ui_raw, str):
-        try:
-            ui_dict = json.loads(ui_raw)
-        except json.JSONDecodeError:
-            ui_dict = {}
-    elif isinstance(ui_raw, dict):
-        ui_dict = ui_raw
-    else:
-        ui_dict = {}
+    profile_record = session.get(UserProfileRecord, user_record.id)
+    profile_preferences = _as_dict(
+        getattr(profile_record, "preferences", {}) or {},
+        {},
+    )
+    ui_dict = _as_dict(getattr(profile_record, "ui_preferences", {}) or {}, {})
     normalized_ui = _normalize_ui_preferences_payload(ui_dict)
-    user_id = row["user_id"]
-    settings_preferences = _load_user_settings_preferences(user_id)
+    user_id = user_record.id
+    settings_preferences = _load_user_settings_preferences(session, user_id)
     merged_preferences = copy.deepcopy(settings_preferences)
     if isinstance(profile_preferences, dict):
         for key, value in profile_preferences.items():
@@ -6807,18 +6748,25 @@ async def get_user_profile(user=Depends(require_role("user"))) -> Dict[str, Any]
                     merged_preferences["categories"] = value
             else:
                 merged_preferences[key] = value
-    clinic_value = row["clinic"] if row["clinic"] else row["clinic_id"]
+    clinic_value = None
+    if profile_record and profile_record.clinic:
+        clinic_value = profile_record.clinic
+    else:
+        clinic_value = user_record.clinic_id
     if clinic_value is not None and not isinstance(clinic_value, str):
         clinic_value = str(clinic_value)
     result.update(
         {
             "userId": str(user_id) if user_id is not None else None,
-            "username": row["username"],
-            "name": row["name"] or row["username"],
-            "role": row["role"],
-            "permissions": [row["role"]] if row["role"] else [],
+            "username": user_record.username,
+            "name": user_record.name or user_record.username,
+            "role": user_record.role,
+            "permissions": [user_record.role] if user_record.role else [],
             "clinic": clinic_value,
-            "currentView": row["current_view"] or base_profile.get("currentView"),
+            "currentView": (
+                getattr(profile_record, "current_view", None)
+                or base_profile.get("currentView")
+            ),
             "preferences": merged_preferences,
             "uiPreferences": normalized_ui,
             "specialty": merged_preferences.get("specialty"),
@@ -6830,72 +6778,76 @@ async def get_user_profile(user=Depends(require_role("user"))) -> Dict[str, Any]
 
 @app.put("/api/user/profile")
 async def update_user_profile(
-    profile: UserProfile, user=Depends(require_role("user"))
+    profile: UserProfile,
+    user=Depends(require_role("user")),
+    session: Session = Depends(get_session),
 ) -> Dict[str, Any]:
-    row = db_conn.execute(
-        "SELECT id FROM users WHERE username=?", (user["sub"],)
-    ).fetchone()
-    if not row:
+    user_record = session.execute(
+        sa.select(User).where(User.username == user["sub"])
+    ).scalar_one_or_none()
+    if not user_record:
         raise HTTPException(status_code=400, detail="User not found")
     preferences = profile.preferences if isinstance(profile.preferences, dict) else {}
     ui_preferences = _normalize_ui_preferences_payload(profile.uiPreferences)
-    db_conn.execute(
-        "INSERT OR REPLACE INTO user_profile (user_id, current_view, clinic, preferences, ui_preferences) "
-        "VALUES (?, ?, ?, ?, ?)",
-        (
-            row["id"],
-            profile.currentView,
-            profile.clinic,
-            json.dumps(preferences),
-            json.dumps(ui_preferences),
-        ),
-    )
-    db_conn.commit()
-    return await get_user_profile(user=user)
+    record = session.get(UserProfileRecord, user_record.id)
+    if record is None:
+        record = UserProfileRecord(user_id=user_record.id)
+        session.add(record)
+    record.current_view = profile.currentView
+    record.clinic = profile.clinic
+    record.preferences = dict(preferences)
+    record.ui_preferences = dict(ui_preferences)
+    return await get_user_profile(user=user, session=session)
 
 
 
 @app.get("/api/user/current-view")
-async def get_current_view(user=Depends(require_role("user"))) -> Dict[str, Any]:
-    row = db_conn.execute(
-        "SELECT up.current_view FROM user_profile up JOIN users u ON up.user_id = u.id WHERE u.username=?",
-        (user["sub"],),
-    ).fetchone()
-    return {"currentView": row["current_view"] if row else None}
+async def get_current_view(
+    user=Depends(require_role("user")),
+    session: Session = Depends(get_session),
+) -> Dict[str, Any]:
+    user_id = session.execute(
+        sa.select(User.id).where(User.username == user["sub"])
+    ).scalar_one_or_none()
+    if user_id is None:
+        return {"currentView": None}
+    profile = session.get(UserProfileRecord, user_id)
+    return {"currentView": getattr(profile, "current_view", None)}
 
 
 @app.get("/api/user/ui-preferences")
-async def get_ui_preferences(user=Depends(require_role("user"))) -> Dict[str, Any]:
-    row = db_conn.execute(
-        "SELECT up.ui_preferences FROM user_profile up JOIN users u ON up.user_id = u.id WHERE u.username=?",
-        (user["sub"],),
-    ).fetchone()
-    prefs = json.loads(row["ui_preferences"]) if row and row["ui_preferences"] else {}
+async def get_ui_preferences(
+    user=Depends(require_role("user")),
+    session: Session = Depends(get_session),
+) -> Dict[str, Any]:
+    user_id = session.execute(
+        sa.select(User.id).where(User.username == user["sub"])
+    ).scalar_one_or_none()
+    prefs: Dict[str, Any] = {}
+    if user_id is not None:
+        record = session.get(UserProfileRecord, user_id)
+        prefs = _as_dict(getattr(record, "ui_preferences", {}) or {}, {})
     normalized = _normalize_ui_preferences_payload(prefs)
     return {"uiPreferences": normalized}
 
 
 @app.put("/api/user/ui-preferences")
 async def put_ui_preferences(
-    model: UiPreferencesModel, user=Depends(require_role("user"))
+    model: UiPreferencesModel,
+    user=Depends(require_role("user")),
+    session: Session = Depends(get_session),
 ) -> Dict[str, Any]:
-    row = db_conn.execute(
-        "SELECT id FROM users WHERE username=?", (user["sub"],)
-    ).fetchone()
-    if not row:
+    user_record = session.execute(
+        sa.select(User).where(User.username == user["sub"])
+    ).scalar_one_or_none()
+    if not user_record:
         raise HTTPException(status_code=400, detail="User not found")
     normalized = _normalize_ui_preferences_payload(model.uiPreferences)
-    updated = json.dumps(normalized)
-    cur = db_conn.execute(
-        "UPDATE user_profile SET ui_preferences=? WHERE user_id=?",
-        (updated, row["id"]),
-    )
-    if cur.rowcount == 0:
-        db_conn.execute(
-            "INSERT INTO user_profile (user_id, ui_preferences) VALUES (?, ?)",
-            (row["id"], updated),
-        )
-    db_conn.commit()
+    record = session.get(UserProfileRecord, user_record.id)
+    if record is None:
+        record = UserProfileRecord(user_id=user_record.id)
+        session.add(record)
+    record.ui_preferences = dict(normalized)
     return {"uiPreferences": normalized}
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import sys
 from collections import defaultdict, deque
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Iterator, List
+from typing import Generator, Iterator, List
 
 import pytest
 import sqlalchemy as sa
@@ -18,6 +18,61 @@ from sqlalchemy.pool import StaticPool
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
+
+import types
+import importlib.util
+from pathlib import Path
+
+if 'backend.scheduling' not in sys.modules:
+    scheduling_stub = types.SimpleNamespace(
+        DEFAULT_EVENT_SUMMARY="",
+        export_ics=lambda *args, **kwargs: None,
+        recommend_follow_up=lambda *args, **kwargs: [],
+        create_appointment=lambda *args, **kwargs: None,
+        list_appointments=lambda *args, **kwargs: [],
+        export_appointment_ics=lambda *args, **kwargs: None,
+        get_appointment=lambda *args, **kwargs: None,
+        apply_bulk_operations=lambda *args, **kwargs: (0, 0),
+        reset_state=lambda: None,
+    )
+    sys.modules['backend.scheduling'] = scheduling_stub
+
+if 'backend.db' not in sys.modules:
+    import sqlite3
+    db_module = types.ModuleType('backend.db')
+    db_module.DATABASE_PATH = Path(':memory:')
+
+    def _get_connection() -> sqlite3.Connection:
+        conn = sqlite3.connect(':memory:', check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _get_session():  # pragma: no cover - should be overridden in tests
+        raise RuntimeError('get_session dependency must be overridden in tests')
+
+    def _initialise_schema(conn: sqlite3.Connection) -> None:  # pragma: no cover - no-op for tests
+        return None
+
+    def _resolve_session_connection(session):  # pragma: no cover - minimal fallback
+        if hasattr(session, 'connection'):
+            try:
+                return session.connection().connection
+            except Exception:
+                return session
+        return session
+
+    db_module.get_connection = _get_connection
+    db_module.get_session = _get_session
+    db_module.initialise_schema = _initialise_schema
+    db_module.resolve_session_connection = _resolve_session_connection
+    models_path = Path(ROOT) / 'backend' / 'db' / 'models.py'
+    spec = importlib.util.spec_from_file_location('backend.db.models', models_path)
+    assert spec and spec.loader
+    models_module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(models_module)  # type: ignore[union-attr]
+    sys.modules['backend.db.models'] = models_module
+    db_module.models = models_module
+    sys.modules['backend.db'] = db_module
 
 
 def _env_flag(name: str) -> bool:
@@ -122,6 +177,21 @@ def in_memory_db() -> Iterator[DatabaseContext]:
     main.transcript_history = defaultdict(lambda: deque(maxlen=main.TRANSCRIPT_HISTORY_LIMIT))
     main.app.dependency_overrides[main.get_db] = lambda: raw_connection
 
+    from backend import db as db_module
+
+    def _session_dependency() -> Generator[Session, None, None]:
+        session = session_factory()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    main.app.dependency_overrides[db_module.get_session] = _session_dependency
+
     session_factory = sessionmaker(
         bind=engine,
         autoflush=False,
@@ -140,7 +210,10 @@ def in_memory_db() -> Iterator[DatabaseContext]:
         yield context
     finally:
         session_factory.close_all()
+        from backend import db as db_module
+
         main.app.dependency_overrides.pop(main.get_db, None)
+        main.app.dependency_overrides.pop(db_module.get_session, None)
         try:
             raw_connection.close()
         except Exception:

--- a/tests/test_layout_preferences.py
+++ b/tests/test_layout_preferences.py
@@ -1,57 +1,45 @@
-import sqlite3
+import pytest
 
-from fastapi.testclient import TestClient
-
-import backend.main as main
-from backend import auth
+from backend import main
+from backend.db.models import User
 
 
-def setup_module(module):
-    # Set up in-memory database and required tables
-    main.db_conn = sqlite3.connect(":memory:", check_same_thread=False)
-    main.db_conn.row_factory = sqlite3.Row
-    main.db_conn.execute(
-        "CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT, eventType TEXT, timestamp REAL, details TEXT, revenue REAL, time_to_close REAL, codes TEXT, compliance_flags TEXT, public_health INTEGER, satisfaction INTEGER)"
-    )
-    main.db_conn.execute(
-        "CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password_hash TEXT, role TEXT)"
-    )
-    main.db_conn.execute(
-        "CREATE TABLE audit_log (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp REAL, username TEXT, action TEXT, details TEXT)"
-    )
-    main.ensure_settings_table(main.db_conn)
-    main.ensure_error_log_table(main.db_conn)
-    main.ensure_refresh_table(main.db_conn)
-    main.ensure_session_state_table(main.db_conn)
-    main.configure_auth_session_factory(main.db_conn)
-    with main.auth_session_scope() as session:
-        auth.register_user(session, "alice", "pw")
+@pytest.fixture
+def user_credentials(db_session):
+    username = "alice"
+    password = "pw"
+    user = User(username=username, password_hash=main.hash_password(password), role="user")
+    db_session.add(user)
+    db_session.commit()
+    return username, password
 
 
-def _token():
-    client = TestClient(main.app)
-    return client.post("/login", json={"username": "alice", "password": "pw"}).json()["access_token"]
+@pytest.fixture
+def auth_token(api_client, user_credentials):
+    username, password = user_credentials
+    response = api_client.post("/login", json={"username": username, "password": password})
+    assert response.status_code == 200
+    return response.json()["access_token"]
 
 
-def test_layout_preferences_roundtrip():
-    client = TestClient(main.app)
-    token = _token()
-    headers = {"Authorization": f"Bearer {token}"}
-    # Initially empty
-    resp = client.get("/api/user/layout-preferences", headers=headers)
+def test_layout_preferences_roundtrip(api_client, auth_token):
+    headers = {"Authorization": f"Bearer {auth_token}"}
+    resp = api_client.get("/api/user/layout-preferences", headers=headers)
     assert resp.status_code == 200
     body = resp.json()
     assert body["success"] is True
     assert body["data"] == {}
+
     payload = {"noteEditor": 65, "suggestionPanel": 35, "sidebarCollapsed": True}
-    resp = client.put("/api/user/layout-preferences", json=payload, headers=headers)
+    resp = api_client.put("/api/user/layout-preferences", json=payload, headers=headers)
     assert resp.status_code == 200
     body = resp.json()
     assert body["success"] is True
     assert body["data"] == payload
     assert body["noteEditor"] == 65
     assert body["suggestionPanel"] == 35
-    resp = client.get("/api/user/layout-preferences", headers=headers)
+
+    resp = api_client.get("/api/user/layout-preferences", headers=headers)
     assert resp.status_code == 200
     body = resp.json()
     assert body["success"] is True

--- a/tests/test_settings_login_cycle.py
+++ b/tests/test_settings_login_cycle.py
@@ -1,35 +1,33 @@
-import sqlite3
-from fastapi.testclient import TestClient
-from backend import main, migrations
+import pytest
+
+import pytest
+
+from backend import main
+from backend.db.models import User
 
 
-def setup_db(monkeypatch):
-    db = sqlite3.connect(':memory:', check_same_thread=False)
-    db.row_factory = sqlite3.Row
-    db.execute('CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password_hash TEXT, role TEXT)')
-    db.execute('CREATE TABLE audit_log (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp REAL, username TEXT, action TEXT, details TEXT)')
-    migrations.ensure_settings_table(db)
-    pwd = main.hash_password('pw')
-    db.execute('INSERT INTO users (username, password_hash, role) VALUES (?,?,?)', ('alice', pwd, 'user'))
-    db.commit()
-    monkeypatch.setattr(main, 'db_conn', db)
-    return db
+@pytest.fixture
+def user_credentials(db_session):
+    username = 'alice'
+    password = 'pw'
+    user = User(username=username, password_hash=main.hash_password(password), role='user')
+    db_session.add(user)
+    db_session.commit()
+    return username, password
 
 
-def auth(token):
+def auth(token: str) -> dict[str, str]:
     return {'Authorization': f'Bearer {token}'}
 
 
-def test_settings_persist_across_login_cycle(monkeypatch):
-    setup_db(monkeypatch)
-    client = TestClient(main.app)
-    # first login to get tokens
-    resp = client.post('/login', json={'username': 'alice', 'password': 'pw'})
+def test_settings_persist_across_login_cycle(api_client, user_credentials):
+    username, password = user_credentials
+
+    resp = api_client.post('/login', json={'username': username, 'password': password})
     assert resp.status_code == 200
     tokens = resp.json()
     token = tokens['access_token']
 
-    # Save custom settings
     custom = {
         'theme': 'dark',
         'categories': {'codes': False, 'compliance': True, 'publicHealth': True, 'differentials': True},
@@ -48,16 +46,14 @@ def test_settings_persist_across_login_cycle(monkeypatch):
         'summarizeModel': 'gpt-z',
         'deidEngine': 'regex',
     }
-    resp = client.post('/settings', json=custom, headers=auth(token))
+    resp = api_client.post('/settings', json=custom, headers=auth(token))
     assert resp.status_code == 200, resp.text
 
-    # simulate logout by discarding token and re-login
-    resp2 = client.post('/login', json={'username': 'alice', 'password': 'pw'})
+    resp2 = api_client.post('/login', json={'username': username, 'password': password})
     assert resp2.status_code == 200
     token2 = resp2.json()['access_token']
 
-    # Fetch settings after re-login
-    resp3 = client.get('/settings', headers=auth(token2))
+    resp3 = api_client.get('/settings', headers=auth(token2))
     assert resp3.status_code == 200
     data = resp3.json()
     for k, v in [
@@ -79,9 +75,8 @@ def test_settings_persist_across_login_cycle(monkeypatch):
     assert data['summarizeModel'] == 'gpt-z'
     assert data['deidEngine'] == 'regex'
 
-    # unknown key should be ignored silently
     bad = dict(custom)
     bad['unknownKey'] = 'value'
-    resp4 = client.post('/settings', json=bad, headers=auth(token2))
+    resp4 = api_client.post('/settings', json=bad, headers=auth(token2))
     assert resp4.status_code == 200
     assert 'unknownKey' not in resp4.json()

--- a/tests/test_user_profile_api.py
+++ b/tests/test_user_profile_api.py
@@ -1,37 +1,22 @@
-import sqlite3
-from fastapi.testclient import TestClient
+import pytest
+import pytest
 
-from backend import main, migrations
-
-
-def _setup_db(monkeypatch):
-    db = sqlite3.connect(":memory:", check_same_thread=False)
-    db.row_factory = sqlite3.Row
-    db.execute(
-        "CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password_hash TEXT, role TEXT)"
-    )
-    migrations.ensure_settings_table(db)
-    migrations.ensure_user_profile_table(db)
-    pwd = main.hash_password("pw")
-    db.execute(
-        "INSERT INTO users (username, password_hash, role) VALUES (?,?,?)",
-        ("alice", pwd, "user"),
-    )
-    db.commit()
-    migrations.ensure_notification_counters_table(db)
-    migrations.ensure_notification_events_table(db)
-    monkeypatch.setattr(main, "db_conn", db)
-    main.notification_counts = main.NotificationStore()
-    return db
+from backend import main
+from backend.db.models import User
 
 
-def test_profile_and_notifications(monkeypatch):
-    _setup_db(monkeypatch)
-    client = TestClient(main.app)
-    token = main.create_token("alice", "user")
+@pytest.fixture
+def user_token(db_session):
+    user = User(username="alice", password_hash=main.hash_password("pw"), role="user")
+    db_session.add(user)
+    db_session.commit()
+    return main.create_token("alice", "user")
 
-    # initial profile fetch
-    resp = client.get("/api/user/profile", headers={"Authorization": f"Bearer {token}"})
+
+def test_profile_and_notifications(api_client, user_token):
+    token = user_token
+
+    resp = api_client.get("/api/user/profile", headers={"Authorization": f"Bearer {token}"})
     assert resp.status_code == 200
     profile_payload = resp.json()
     if isinstance(profile_payload, dict) and "data" in profile_payload:
@@ -53,36 +38,35 @@ def test_profile_and_notifications(monkeypatch):
         "preferences": {"p": 1},
         "uiPreferences": {"theme": "dark"},
     }
-    resp = client.put(
+    resp = api_client.put(
         "/api/user/profile",
         json=payload,
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 200
 
-    resp = client.get("/api/user/current-view", headers={"Authorization": f"Bearer {token}"})
+    resp = api_client.get("/api/user/current-view", headers={"Authorization": f"Bearer {token}"})
     assert resp.json()["currentView"] == "dashboard"
 
-    resp = client.get("/api/user/ui-preferences", headers={"Authorization": f"Bearer {token}"})
+    resp = api_client.get("/api/user/ui-preferences", headers={"Authorization": f"Bearer {token}"})
     prefs_payload = resp.json()["uiPreferences"]
     assert prefs_payload["theme"] == "dark"
     assert prefs_payload["navigation"]["collapsed"] is False
 
-    resp = client.put(
+    resp = api_client.put(
         "/api/user/ui-preferences",
         json={"uiPreferences": {"theme": "light"}},
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 200
-    resp = client.get("/api/user/ui-preferences", headers={"Authorization": f"Bearer {token}"})
+    resp = api_client.get("/api/user/ui-preferences", headers={"Authorization": f"Bearer {token}"})
     updated_prefs = resp.json()["uiPreferences"]
     assert updated_prefs["theme"] == "light"
     assert "navigation" in updated_prefs
 
-    resp = client.get("/api/notifications/count", headers={"Authorization": f"Bearer {token}"})
+    resp = api_client.get("/api/notifications/count", headers={"Authorization": f"Bearer {token}"})
     assert resp.json()["notifications"] == 0
 
-    # Persist a few unread notification records which should update counters.
     for idx in range(5):
         payload = {
             "notificationId": f"test-{idx}",
@@ -94,10 +78,10 @@ def test_profile_and_notifications(monkeypatch):
         assert stored["id"] == payload["notificationId"]
         assert count == idx + 1
 
-    resp = client.get("/api/notifications/count", headers={"Authorization": f"Bearer {token}"})
+    resp = api_client.get("/api/notifications/count", headers={"Authorization": f"Bearer {token}"})
     assert resp.json()["notifications"] == 5
 
-    with client.websocket_connect(
+    with api_client.websocket_connect(
         "/ws/notifications", headers={"Authorization": f"Bearer {token}"}
     ) as ws:
         data = ws.receive_json()


### PR DESCRIPTION
## Summary
- refactor settings, layout, and profile endpoints to rely on SQLAlchemy sessions and typed helpers
- update preference normalization utilities to work with ORM records
- modernize the related unit tests to use shared in-memory fixtures and ORM seeding

## Testing
- `pytest -o addopts= tests/test_settings_roundtrip.py tests/test_settings_persistence.py tests/test_settings_edge.py tests/test_layout_preferences.py tests/test_user_profile_api.py tests/test_settings_login_cycle.py` *(fails: backend.migrations contains syntax errors upstream)*

------
https://chatgpt.com/codex/tasks/task_e_68d09e078ae4832492cd8988f007448f