### PR TITLE
Refactor scheduling to share SQLAlchemy sessions

### DIFF
--- a/backend/database_legacy.py
+++ b/backend/database_legacy.py
@@ -20,6 +20,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Dict, Generator, Optional
 
+import sqlalchemy as sa
 from sqlalchemy import event, create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
@@ -80,11 +81,13 @@ from backend.migrations import (
     seed_compliance_rules,
     seed_payer_schedules,
 )
+import backend.db.models as db_models
 from backend import code_tables
 from backend import patients
 from backend import visits
 from backend import scheduling
 from backend.codes_data import load_code_metadata
+from backend.migrations import session_scope
 
 logger = logging.getLogger(__name__)
 
@@ -148,72 +151,78 @@ def get_engine() -> Engine:
 
 def _seed_reference_data(conn: sqlite3.Connection) -> None:
     try:
-        existing_rules = conn.execute("SELECT COUNT(*) FROM compliance_rule_catalog").fetchone()[0]
-    except sqlite3.Error as exc:  # pragma: no cover - defensive
-        logger.warning("compliance_rules_table_inspect_failed", error=str(exc))
-        return
+        with session_scope(conn) as session:
+            existing_rules = session.scalar(
+                sa.select(sa.func.count()).select_from(db_models.ComplianceRuleCatalogEntry)
+            )
+            if not existing_rules:
+                from backend import compliance as compliance_engine
 
-    try:
-        if existing_rules == 0:
-            from backend import compliance as compliance_engine
+                seed_compliance_rules(session, compliance_engine.get_rules())
 
-            seed_compliance_rules(conn, compliance_engine.get_rules())
+            metadata = load_code_metadata()
+            cpt_metadata = {
+                code: info
+                for code, info in metadata.items()
+                if (info.get("type") or "").upper() == "CPT"
+            }
 
-        metadata = load_code_metadata()
-        cpt_metadata = {
-            code: info
-            for code, info in metadata.items()
-            if (info.get("type") or "").upper() == "CPT"
-        }
+            existing_cpt_codes = session.scalar(
+                sa.select(sa.func.count()).select_from(db_models.CPTCode)
+            )
+            if not existing_cpt_codes:
+                seed_cpt_codes(session, code_tables.DEFAULT_CPT_CODES.items())
 
-        existing_cpt_codes = conn.execute("SELECT COUNT(*) FROM cpt_codes").fetchone()[0]
-        if existing_cpt_codes == 0:
-            seed_cpt_codes(conn, code_tables.DEFAULT_CPT_CODES.items())
+            existing_icd_codes = session.scalar(
+                sa.select(sa.func.count()).select_from(db_models.ICD10Code)
+            )
+            if not existing_icd_codes:
+                seed_icd10_codes(session, code_tables.DEFAULT_ICD10_CODES.items())
 
-        existing_icd_codes = conn.execute("SELECT COUNT(*) FROM icd10_codes").fetchone()[0]
-        if existing_icd_codes == 0:
-            seed_icd10_codes(conn, code_tables.DEFAULT_ICD10_CODES.items())
+            existing_hcpcs_codes = session.scalar(
+                sa.select(sa.func.count()).select_from(db_models.HCPCSCode)
+            )
+            if not existing_hcpcs_codes:
+                seed_hcpcs_codes(session, code_tables.DEFAULT_HCPCS_CODES.items())
 
-        existing_hcpcs_codes = conn.execute("SELECT COUNT(*) FROM hcpcs_codes").fetchone()[0]
-        if existing_hcpcs_codes == 0:
-            seed_hcpcs_codes(conn, code_tables.DEFAULT_HCPCS_CODES.items())
+            existing_cpt = session.scalar(
+                sa.select(sa.func.count()).select_from(db_models.CPTReference)
+            )
+            if not existing_cpt:
+                seed_cpt_reference(session, cpt_metadata.items())
 
-        existing_cpt = conn.execute("SELECT COUNT(*) FROM cpt_reference").fetchone()[0]
-        if existing_cpt == 0:
-            seed_cpt_reference(conn, cpt_metadata.items())
-
-        existing_schedules = conn.execute("SELECT COUNT(*) FROM payer_schedules").fetchone()[0]
-        if existing_schedules == 0:
-            schedules = []
-            for code, info in cpt_metadata.items():
-                reimbursement = info.get("reimbursement")
-                if reimbursement in (None, ""):
-                    continue
-                rvu_value = info.get("rvu")
-                base_amount = float(reimbursement)
-                schedules.append(
-                    {
-                        "payer_type": "commercial",
-                        "location": "",
-                        "code": code,
-                        "reimbursement": base_amount,
-                        "rvu": rvu_value,
-                    }
-                )
-                schedules.append(
-                    {
-                        "payer_type": "medicare",
-                        "location": "",
-                        "code": code,
-                        "reimbursement": round(base_amount * 0.8, 2),
-                        "rvu": rvu_value,
-                    }
-                )
-            seed_payer_schedules(conn, schedules)
-
-        conn.commit()
+            existing_schedules = session.scalar(
+                sa.select(sa.func.count()).select_from(db_models.PayerSchedule)
+            )
+            if not existing_schedules:
+                schedules = []
+                for code, info in cpt_metadata.items():
+                    reimbursement = info.get("reimbursement")
+                    if reimbursement in (None, ""):
+                        continue
+                    rvu_value = info.get("rvu")
+                    base_amount = float(reimbursement)
+                    schedules.append(
+                        {
+                            "payer_type": "commercial",
+                            "location": "",
+                            "code": code,
+                            "reimbursement": base_amount,
+                            "rvu": rvu_value,
+                        }
+                    )
+                    schedules.append(
+                        {
+                            "payer_type": "medicare",
+                            "location": "",
+                            "code": code,
+                            "reimbursement": round(base_amount * 0.8, 2),
+                            "rvu": rvu_value,
+                        }
+                    )
+                seed_payer_schedules(session, schedules)
     except Exception as exc:  # pragma: no cover - best effort
-        logger.warning("reference_data_seed_failed", error=str(exc))
+        logger.warning("reference_data_seed_failed: %s", exc)
 
 
 def _initialise_schema(conn: sqlite3.Connection) -> None:

--- a/backend/main.py
+++ b/backend/main.py
@@ -138,6 +138,7 @@ from backend.key_manager import (
     store_key,
     store_secret,
 )  # type: ignore
+import backend.db.models as db_models
 from backend.db.models import (
     CPTCode,
     CPTReference,
@@ -211,6 +212,7 @@ from backend.templates import (
     delete_user_template,
 )  # type: ignore
 import backend.database_legacy as db
+get_db = db.get_db
 from backend.scheduling import DEFAULT_EVENT_SUMMARY, export_ics, recommend_follow_up  # type: ignore
 from backend.scheduling import (  # type: ignore
     create_appointment,
@@ -219,7 +221,6 @@ from backend.scheduling import (  # type: ignore
     get_appointment,
     apply_bulk_operations,
     configure_database as configure_schedule_database,
-    schedule_session_scope,
 )
 from backend import code_tables  # type: ignore
 from backend import patients  # type: ignore
@@ -1480,8 +1481,6 @@ def auth_session_scope() -> Iterator[SQLAlchemySession]:
 db_conn = sqlite3.connect(DB_PATH, check_same_thread=False)
 create_all_tables(db_conn)
 
-configure_schedule_database(db_conn)
-
 
 _template_sessionmakers: Dict[int, sessionmaker[Session]] = {}
 
@@ -1527,6 +1526,8 @@ def _template_session(conn: sqlite3.Connection) -> Iterator[Session]:
 compliance_engine.configure_engine(engine=db.engine)
 
 configure_auth_session_factory(db_conn)
+if _auth_sessionmaker is not None:
+    configure_schedule_database(_auth_sessionmaker)
 
 
 
@@ -1706,64 +1707,56 @@ def _init_core_tables(conn):  # pragma: no cover - invoked in tests indirectly
     create_all_tables(conn)
 
 
-    existing_patients = conn.execute("SELECT COUNT(*) FROM patients").fetchone()[0]
-    if existing_patients == 0:
-        now = datetime.utcnow().replace(microsecond=0)
-        last_visit_date = (now - timedelta(days=45)).date().isoformat()
-        allergies = json.dumps(["Penicillin"])
-        medications = json.dumps(["Lisinopril"])
-        conn.execute(
-            """
-            INSERT INTO patients
-                (first_name, last_name, dob, mrn, gender, insurance, last_visit, allergies, medications)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                "Alice",
-                "Anderson",
-                "1985-04-12",
-                "MRN-1001",
-                "female",
-                "medicare",
-                last_visit_date,
-                allergies,
-                medications,
-            ),
+    with session_scope(conn) as session:
+        existing_patients = session.scalar(
+            sa.select(sa.func.count()).select_from(db_models.patients)
         )
-        patient_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
-        encounter_start = now + timedelta(days=1)
-        encounter_end = encounter_start + timedelta(minutes=30)
-        conn.execute(
-            """
-            INSERT INTO encounters (patient_id, date, type, provider, description)
-            VALUES (?, ?, ?, ?, ?)
-            """,
-            (
-                patient_id,
-                encounter_start.isoformat(),
-                "telehealth",
-                "Dr. Smith",
-                "Telehealth follow-up",
-            ),
-        )
-        encounter_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
-        conn.execute(
-            """
-            INSERT INTO visit_sessions (encounter_id, status, start_time, end_time, updated_at)
-            VALUES (?, ?, ?, ?, ?)
-            """,
-            (
-                encounter_id,
-                "scheduled",
-                encounter_start.isoformat(),
-                encounter_end.isoformat(),
-                time.time(),
-            ),
-        )
+        if not existing_patients:
+            now = datetime.utcnow().replace(microsecond=0)
+            last_visit_date = (now - timedelta(days=45)).date().isoformat()
+            allergies = json.dumps(["Penicillin"])
+            medications = json.dumps(["Lisinopril"])
+            patient_result = session.execute(
+                db_models.patients.insert().values(
+                    first_name="Alice",
+                    last_name="Anderson",
+                    dob="1985-04-12",
+                    mrn="MRN-1001",
+                    gender="female",
+                    insurance="medicare",
+                    last_visit=last_visit_date,
+                    allergies=allergies,
+                    medications=medications,
+                )
+            )
+            patient_id = int(patient_result.inserted_primary_key[0])
+
+            encounter_start = now + timedelta(days=1)
+            encounter_end = encounter_start + timedelta(minutes=30)
+            encounter_result = session.execute(
+                db_models.encounters.insert().values(
+                    patient_id=patient_id,
+                    date=encounter_start.isoformat(),
+                    type="telehealth",
+                    provider="Dr. Smith",
+                    description="Telehealth follow-up",
+                )
+            )
+            encounter_id = int(encounter_result.inserted_primary_key[0])
+
+            session.execute(
+                db_models.visit_sessions.insert().values(
+                    encounter_id=encounter_id,
+                    status="scheduled",
+                    start_time=encounter_start.isoformat(),
+                    end_time=encounter_end.isoformat(),
+                    updated_at=time.time(),
+                )
+            )
 
     _seed_reference_data(conn)
-    conn.commit()
-    configure_schedule_database(conn)
+    if _auth_sessionmaker is not None:
+        configure_schedule_database(_auth_sessionmaker)
     compliance_engine.configure_engine(conn)
 
 
@@ -12795,7 +12788,7 @@ async def create_schedule_appointment(appt: AppointmentCreate, user=Depends(requ
 
 @app.get("/schedule", response_model=AppointmentList)
 async def list_schedule_appointments(user=Depends(require_role("user"))):
-    with schedule_session_scope() as session:
+    with auth_session_scope() as session:
         items = list_appointments(session=session)
     parsed: List[Appointment] = []
     summaries: Dict[str, Any] = {}
@@ -12847,10 +12840,15 @@ async def schedule_bulk_operations(
 ) -> ScheduleBulkSummary:
     if not req.updates:
         return ScheduleBulkSummary(succeeded=0, failed=0)
-    succeeded, failed = apply_bulk_operations(
-        [{"id": item.id, "action": item.action, "time": item.time} for item in req.updates],
-        req.provider,
-    )
+    with auth_session_scope() as session:
+        succeeded, failed = apply_bulk_operations(
+            [
+                {"id": item.id, "action": item.action, "time": item.time}
+                for item in req.updates
+            ],
+            req.provider,
+            session=session,
+        )
     if succeeded:
         _invalidate_dashboard_cache("quick_actions")
 
@@ -12860,7 +12858,7 @@ async def schedule_bulk_operations(
 
 @app.get("/api/schedule/appointments", response_model=AppointmentList)
 async def api_list_appointments(user=Depends(require_role("user"))):
-    with schedule_session_scope() as session:
+    with auth_session_scope() as session:
         items = list_appointments(session=session)
     parsed: List[Appointment] = []
     summaries: Dict[str, Any] = {}
@@ -13609,32 +13607,58 @@ async def validate_encounter_post(
 
 @app.post("/api/visits/session")
 async def start_visit_session(model: VisitSessionCreate, user=Depends(require_role("user"))):
-    now = datetime.utcnow().isoformat()
-    cursor = db_conn.cursor()
-    cursor.execute(
-        "INSERT INTO visit_sessions (encounter_id, status, start_time) VALUES (?, ?, ?)",
-        (model.encounter_id, "started", now),
-    )
-    session_id = cursor.lastrowid
-    db_conn.commit()
+    now = datetime.utcnow().replace(microsecond=0).isoformat()
+    with auth_session_scope() as session:
+        result = session.execute(
+            db_models.visit_sessions.insert().values(
+                encounter_id=model.encounter_id,
+                status="started",
+                start_time=now,
+                end_time=None,
+                updated_at=time.time(),
+            )
+        )
+        session_id = int(result.inserted_primary_key[0])
     return {"sessionId": session_id, "status": "started", "startTime": now}
 
 
 @app.put("/api/visits/session")
 async def update_visit_session(model: VisitSessionUpdate, user=Depends(require_role("user"))):
-    row = db_conn.execute("SELECT * FROM visit_sessions WHERE id=?", (model.session_id,)).fetchone()
-    if not row:
-        raise HTTPException(status_code=404, detail="session not found")
-    end_time = row["end_time"]
-    status = model.action
-    if model.action == "complete":
-        end_time = datetime.utcnow().isoformat()
-    db_conn.execute(
-        "UPDATE visit_sessions SET status=?, end_time=? WHERE id=?",
-        (status, end_time, model.session_id),
-    )
-    db_conn.commit()
-    updated = db_conn.execute("SELECT * FROM visit_sessions WHERE id=?", (model.session_id,)).fetchone()
+    with auth_session_scope() as session:
+        row = (
+            session.execute(
+                sa.select(db_models.visit_sessions).where(
+                    db_models.visit_sessions.c.id == model.session_id
+                )
+            )
+            .mappings()
+            .first()
+        )
+        if not row:
+            raise HTTPException(status_code=404, detail="session not found")
+
+        end_time = row.get("end_time")
+        status = model.action
+        if model.action == "complete":
+            end_time = datetime.utcnow().replace(microsecond=0).isoformat()
+
+        session.execute(
+            db_models.visit_sessions.update()
+            .where(db_models.visit_sessions.c.id == model.session_id)
+            .values(status=status, end_time=end_time, updated_at=time.time())
+        )
+
+        updated = (
+            session.execute(
+                sa.select(db_models.visit_sessions).where(
+                    db_models.visit_sessions.c.id == model.session_id
+                )
+            )
+            .mappings()
+            .first()
+        )
+
+    assert updated is not None
     return {
         "sessionId": updated["id"],
         "status": updated["status"],

--- a/backend/patients.py
+++ b/backend/patients.py
@@ -23,6 +23,12 @@ import requests
 from sqlalchemy import and_, func, literal, or_, select
 from sqlalchemy.orm import Session
 
+
+def configure_database(_conn) -> None:
+    """Compatibility shim retained for legacy database initialisers."""
+
+    return None
+
 from backend import models as sa_models
 
 from backend.time_utils import ensure_utc, from_epoch_seconds

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,6 +104,10 @@ def in_memory_db() -> Iterator[DatabaseContext]:
     )
     connection = engine.connect()
     raw_connection = connection.connection
+    if hasattr(raw_connection, "driver_connection"):
+        raw_connection = raw_connection.driver_connection
+    elif hasattr(raw_connection, "connection"):
+        raw_connection = raw_connection.connection
     assert isinstance(raw_connection, sqlite3.Connection)
     raw_connection.row_factory = sqlite3.Row
 

--- a/tests/test_new_api_endpoints.py
+++ b/tests/test_new_api_endpoints.py
@@ -1,33 +1,21 @@
-import sqlite3
-from collections import defaultdict, deque
-
 import pytest
-from fastapi.testclient import TestClient
+import backend.db.models as db_models
 
-from backend import main, migrations
-from backend.main import _init_core_tables
+from backend import main
 
 
 @pytest.fixture
-def client(monkeypatch):
-    main.db_conn = sqlite3.connect(':memory:', check_same_thread=False)
-    main.db_conn.row_factory = sqlite3.Row
-    _init_core_tables(main.db_conn)
-    migrations.ensure_settings_table(main.db_conn)
-    pwd = main.hash_password("pw")
-    main.db_conn.execute(
-        "INSERT INTO users (username, password_hash, role) VALUES (?, ?, ?)",
-        ("user", pwd, "user"),
+def client(api_client, db_session):
+    password_hash = main.hash_password("pw")
+    db_session.execute(
+        db_models.users.insert().values(
+            username="user",
+            password_hash=password_hash,
+            role="user",
+        )
     )
-    main.db_conn.commit()
-    monkeypatch.setattr(main, "db_conn", main.db_conn)
-    monkeypatch.setattr(main, "events", [])
-    monkeypatch.setattr(
-        main,
-        "transcript_history",
-        defaultdict(lambda: deque(maxlen=main.TRANSCRIPT_HISTORY_LIMIT)),
-    )
-    return TestClient(main.app)
+    db_session.commit()
+    return api_client
 
 
 def auth_header(token):


### PR DESCRIPTION
## Summary
- update scheduling configuration to reuse the shared SQLAlchemy sessionmaker and remove direct configure calls from the API
- persist visit session CRUD paths via SQLAlchemy and seed core tables through ORM sessions
- align scheduling tests and fixtures to build state through ORM helpers

## Testing
- pytest tests/test_new_api_endpoints.py tests/test_workflow_api.py *(fails: coverage plugin enforces fail-under threshold during targeted run)*

------
https://chatgpt.com/codex/tasks/task_e_68d0a0209aec8324b5482ea215b950da