### PR TITLE
Harden chart upload filename handling

### DIFF
--- a/backend/charts.py
+++ b/backend/charts.py
@@ -3,24 +3,68 @@ from __future__ import annotations
 """Helpers for handling uploaded chart files."""
 
 from pathlib import Path
+import logging
 import os
+
+
+logger = logging.getLogger(__name__)
 
 _UPLOAD_DIR = Path(os.getenv("CHART_UPLOAD_DIR", "/tmp/revenuepilot_charts"))
 _UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
 
 
-def process_chart(filename: str, data: bytes) -> None:
+def _path_within(base: Path, candidate: Path) -> bool:
+    try:
+        candidate.relative_to(base)
+    except ValueError:
+        return False
+    return True
+
+
+def _get_upload_dir() -> Path:
+    override = os.getenv("CHART_UPLOAD_DIR")
+    if override:
+        return Path(override)
+    return _UPLOAD_DIR
+
+
+def process_chart(filename: str, data: bytes) -> Path | None:
     """Persist uploaded chart data to a temporary directory.
 
-    This function is intended to be triggered via ``BackgroundTasks`` and
-    simulates the work that would normally be done when processing
-    uploaded chart files.
+    The incoming *filename* is sanitised in the same way as the
+    ``/api/charts/upload`` endpoint to ensure background processing cannot
+    traverse outside of :data:`_UPLOAD_DIR`.
     """
 
-    # Write the file; if anything fails we simply drop the data as this is
-    # a demo.  Exceptions are intentionally swallowed so background tasks
-    # don't crash the server.
+    upload_dir = _get_upload_dir()
+    upload_dir.mkdir(parents=True, exist_ok=True)
+
+    from backend.main import sanitize_chart_filename
+
+    sanitized = sanitize_chart_filename(filename)
+    base_dir = upload_dir.resolve()
+    destination = (base_dir / sanitized).resolve()
+    if not _path_within(base_dir, destination):
+        logger.warning(
+            "chart_upload.rejected sanitized=%s reason=%s",
+            sanitized,
+            "outside_upload_dir",
+        )
+        raise ValueError("Resolved chart path escapes upload directory")
+
     try:
-        (_UPLOAD_DIR / filename).write_bytes(data)
-    except Exception:
-        pass
+        destination.write_bytes(data)
+    except Exception as exc:  # pragma: no cover - filesystem dependent failures
+        logger.warning(
+            "chart_upload.write_failed sanitized=%s error=%s",
+            sanitized,
+            exc,
+        )
+        return None
+
+    logger.info(
+        "chart_upload.persisted sanitized=%s size=%s",
+        sanitized,
+        len(data),
+    )
+    return destination

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,7 @@ if 'backend.scheduling' not in sys.modules:
         get_appointment=lambda *args, **kwargs: None,
         apply_bulk_operations=lambda *args, **kwargs: (0, 0),
         reset_state=lambda: None,
+        configure_database=lambda *args, **kwargs: None,
     )
     sys.modules['backend.scheduling'] = scheduling_stub
 

--- a/tests/test_chart_upload_security.py
+++ b/tests/test_chart_upload_security.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+
+import backend.db.models as db_models
+
+if "backend.scheduling" in sys.modules:
+    setattr(sys.modules["backend.scheduling"], "configure_database", lambda *args, **kwargs: None)
+
+from backend import charts, main
+
+
+def _auth_header(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def authed_client(api_client, db_session):
+    password_hash = main.hash_password("pw")
+    db_session.execute(
+        db_models.users.insert().values(
+            username="user",
+            password_hash=password_hash,
+            role="user",
+        )
+    )
+    db_session.commit()
+
+    resp = api_client.post("/login", json={"username": "user", "password": "pw"})
+    assert resp.status_code == 200
+    token = resp.json()["access_token"]
+    return api_client, token
+
+
+def test_chart_upload_confines_to_directory(tmp_path: Path, authed_client, monkeypatch):
+    client, token = authed_client
+    monkeypatch.setattr(main, "UPLOAD_DIR", tmp_path)
+    monkeypatch.setattr(charts, "_UPLOAD_DIR", tmp_path)
+
+    resp = client.post(
+        "/api/charts/upload",
+        headers=_auth_header(token),
+        files={"file": ("../../../../etc/passwd", b"payload")},
+    )
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["filename"] != "../../../../etc/passwd"
+
+    stored = tmp_path / payload["filename"]
+    assert stored.exists()
+    assert stored.read_bytes() == b"payload"
+
+
+def test_chart_upload_rejects_escape_attempt(tmp_path: Path, authed_client, monkeypatch):
+    client, token = authed_client
+    monkeypatch.setattr(main, "UPLOAD_DIR", tmp_path)
+    monkeypatch.setattr(charts, "_UPLOAD_DIR", tmp_path)
+    monkeypatch.setattr(main, "sanitize_chart_filename", lambda _: "../escape.txt")
+
+    resp = client.post(
+        "/api/charts/upload",
+        headers=_auth_header(token),
+        files={"file": ("chart.txt", b"payload")},
+    )
+    assert resp.status_code == 400
+
+
+def test_process_chart_rejects_escape_attempt(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(charts, "_UPLOAD_DIR", tmp_path)
+    monkeypatch.setattr(main, "sanitize_chart_filename", lambda _: "../escape.txt")
+
+    with pytest.raises(ValueError):
+        charts.process_chart("chart.txt", b"payload")
+
+
+def test_process_chart_persists_with_sanitized_name(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(charts, "_UPLOAD_DIR", tmp_path)
+    sanitized_name = main.sanitize_chart_filename("../report.txt")
+
+    result = charts.process_chart("../report.txt", b"payload")
+    assert result is not None
+    stored = tmp_path / sanitized_name
+    assert stored.exists()
+    assert stored.read_bytes() == b"payload"


### PR DESCRIPTION
## Summary
- add a helper in the chart upload API to derive sanitized filenames and reject paths that escape the upload directory
- update backend chart processing to reuse the sanitizer and log sanitized audit details
- extend the test suite with upload confinement checks and ensure the FastAPI stubs expose configure_database

## Testing
- pytest --no-cov tests/test_chart_upload_security.py tests/test_new_api_endpoints.py::test_charts_upload

------
https://chatgpt.com/codex/tasks/task_e_68d0ad9ba78083248a731a82679b79dc