### PR TITLE
Queue EHR exports and harden TLS defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,8 +15,8 @@ POSTGRES_PORT=5432
 POSTGRES_DB=revenuepilot
 POSTGRES_USER=revenuepilot
 POSTGRES_PASSWORD=
-PGSSLMODE=prefer
-# Optional CA bundle (e.g., AWS RDS combined bundle path)
+PGSSLMODE=verify-full
+# Optional CA bundle (e.g., AWS RDS combined bundle path - required in production)
 PGSSLROOTCERT=
 PGCONNECT_TIMEOUT=10
 DB_POOL_SIZE=5


### PR DESCRIPTION
## Summary
- require verify-full TLS mode in the example Postgres environment configuration
- return richer HTTP metadata from the EHR client to flag retryable failures
- add an asynchronous export queue with exponential backoff, background workers, and progress tracking
- expose a test helper and update API tests to work with the queued export flow

## Testing
- pytest *(fails: missing optional backend.db.config module in upstream test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68d17accd2808324bd7ee3b4150b06cc