### PR TITLE
Harden PHI handling across prompts, storage, and egress

### DIFF
--- a/backend/charts.py
+++ b/backend/charts.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import logging
 import os
 
+from backend.encryption import encrypt_artifact
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +54,8 @@ def process_chart(filename: str, data: bytes) -> Path | None:
         raise ValueError("Resolved chart path escapes upload directory")
 
     try:
-        destination.write_bytes(data)
+        ciphertext = encrypt_artifact(data)
+        destination.write_bytes(ciphertext)
     except Exception as exc:  # pragma: no cover - filesystem dependent failures
         logger.warning(
             "chart_upload.write_failed sanitized=%s error=%s",

--- a/backend/egress.py
+++ b/backend/egress.py
@@ -1,0 +1,88 @@
+"""Hardened HTTP egress helpers enforcing TLS verification and allowlists."""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlparse
+import os
+
+import requests
+from prometheus_client import Counter
+
+
+EGRESS_FAILURES = Counter(
+    "revenuepilot_egress_failures_total",
+    "Outbound HTTP calls blocked or failed security checks",
+    ("reason",),
+)
+
+
+def _allowed_hosts() -> set[str]:
+    raw = os.getenv("ALLOWED_EGRESS_HOSTS")
+    hosts: set[str] = set()
+    if raw:
+        hosts.update(host.strip().lower() for host in raw.split(",") if host.strip())
+    else:
+        hosts.update(
+            {
+                "api.openai.com",
+                "clinicaltables.nlm.nih.gov",
+                "www.cdc.gov",
+                "api.uspreventiveservicestaskforce.org",
+                "www.who.int",
+                "localhost",
+                "127.0.0.1",
+            }
+        )
+    for env_var in (
+        "EHR_PATIENT_API_URL",
+        "EHR_TOKEN_URL",
+        "EHR_FHIR_BASE_URL",
+        "EHR_EXPORT_BASE_URL",
+    ):
+        value = os.getenv(env_var)
+        if not value:
+            continue
+        parsed = urlparse(value)
+        if parsed.hostname:
+            hosts.add(parsed.hostname.lower())
+    return hosts
+
+
+def _verify_host(url: str) -> None:
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+    allowed = _allowed_hosts()
+    if allowed and host not in allowed:
+        EGRESS_FAILURES.labels(reason="disallowed_host").inc()
+        raise RuntimeError(f"Egress to host '{host}' is not permitted")
+
+
+def secure_request(method: str, url: str, **kwargs: Any) -> requests.Response:
+    """Dispatch a HTTP request enforcing TLS verification and allowlists."""
+
+    _verify_host(url)
+    kwargs.setdefault("timeout", 10)
+    kwargs.setdefault("verify", True)
+    try:
+        response = requests.request(method=method, url=url, **kwargs)
+        response.raise_for_status()
+        return response
+    except requests.exceptions.SSLError:
+        EGRESS_FAILURES.labels(reason="tls_failure").inc()
+        raise
+    except requests.exceptions.RequestException:
+        EGRESS_FAILURES.labels(reason="network_failure").inc()
+        raise
+
+
+def secure_get(url: str, **kwargs: Any) -> requests.Response:
+    return secure_request("GET", url, **kwargs)
+
+
+def secure_post(url: str, **kwargs: Any) -> requests.Response:
+    return secure_request("POST", url, **kwargs)
+
+
+__all__ = ["secure_get", "secure_post", "secure_request", "EGRESS_FAILURES"]
+

--- a/backend/ehr_integration.py
+++ b/backend/ehr_integration.py
@@ -15,8 +15,9 @@ import re
 import time
 from typing import Any, Dict, List, Optional, Sequence
 
-import requests
 import logging
+
+from backend.egress import secure_post
 
 FHIR_SERVER_URL = os.getenv("FHIR_SERVER_URL", "https://fhir.example.com")
 TOKEN_URL = os.getenv("EHR_TOKEN_URL")
@@ -51,7 +52,7 @@ def get_ehr_token() -> Optional[str]:
         return _token_cache["token"]
 
     try:
-        resp = requests.post(
+        resp = secure_post(
             TOKEN_URL,
             data={"grant_type": "client_credentials"},
             auth=(CLIENT_ID, CLIENT_SECRET),
@@ -344,7 +345,7 @@ def post_note_and_codes(
     url = f"{FHIR_SERVER_URL.rstrip('/')}/Bundle"
     headers = _auth_headers()
 
-    resp = requests.post(url, json=payload, headers=headers or None, timeout=10)
+    resp = secure_post(url, json=payload, headers=headers or None, timeout=10)
     status_code = resp.status_code
 
     if status_code in {401, 403}:

--- a/backend/encryption.py
+++ b/backend/encryption.py
@@ -1,0 +1,150 @@
+"""Centralised helpers for encrypting sensitive payloads at rest.
+
+The module provides two independent encryption domains:
+
+``artifact``
+    Used for uploaded chart files and any intermediate artifacts written to
+    disk.  The ciphertext is persisted verbatim to the filesystem.
+
+``ai_payload``
+    Used for structured AI inputs/outputs that are stored in relational
+    databases.  Ciphertext is base64 encoded and wrapped in a small JSON
+    envelope so legacy rows can be upgraded transparently.
+
+Keys are resolved through :mod:`backend.key_manager`.  In production the
+secrets backend should be wired to a cloud KMS; during tests or local
+development the fallback store (encrypted via Fernet) is used.  The helpers
+expose simple ``encrypt_*`` / ``decrypt_*`` primitives so callers do not need
+to reason about key management directly.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from functools import lru_cache
+from typing import Any, Dict, Mapping
+
+from cryptography.fernet import Fernet, InvalidToken
+
+from backend import key_manager
+
+_ARTIFACT_SECRET_NAME = "artifact-encryption-key"
+_ARTIFACT_ENV_VAR = "ARTIFACT_ENCRYPTION_KEY"
+
+_AI_SECRET_NAME = "ai-payload-encryption-key"
+_AI_ENV_VAR = "AI_PAYLOAD_ENCRYPTION_KEY"
+
+
+def _ensure_key(name: str, env_var: str) -> bytes:
+    """Return a stable key for *name*, creating one if required."""
+
+    value, _metadata = key_manager.load_secret(
+        name,
+        env_var,
+        required=False,
+        allow_missing_rotation=True,
+    )
+    if value:
+        return value.encode("utf-8")
+
+    generated = Fernet.generate_key().decode("utf-8")
+    key_manager.store_secret(name, env_var, generated, source="generated")
+    return generated.encode("utf-8")
+
+
+@lru_cache(maxsize=2)
+def _artifact_cipher() -> Fernet:
+    return Fernet(_ensure_key(_ARTIFACT_SECRET_NAME, _ARTIFACT_ENV_VAR))
+
+
+@lru_cache(maxsize=2)
+def _ai_cipher() -> Fernet:
+    return Fernet(_ensure_key(_AI_SECRET_NAME, _AI_ENV_VAR))
+
+
+def encrypt_artifact(data: bytes) -> bytes:
+    """Encrypt *data* for storage on disk."""
+
+    if not isinstance(data, (bytes, bytearray)):
+        raise TypeError("artifact payload must be bytes-like")
+    return _artifact_cipher().encrypt(bytes(data))
+
+
+def decrypt_artifact(blob: bytes) -> bytes:
+    """Decrypt previously stored artifact *blob*."""
+
+    if not isinstance(blob, (bytes, bytearray)):
+        raise TypeError("artifact ciphertext must be bytes-like")
+    try:
+        return _artifact_cipher().decrypt(bytes(blob))
+    except InvalidToken as exc:  # pragma: no cover - defensive guard
+        raise ValueError("Artifact ciphertext could not be decrypted") from exc
+
+
+def encrypt_ai_payload(payload: Mapping[str, Any]) -> Dict[str, Any]:
+    """Return an encrypted wrapper for *payload* suitable for DB storage."""
+
+    serialized = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+    token = _ai_cipher().encrypt(serialized.encode("utf-8"))
+    return {
+        "ciphertext": base64.b64encode(token).decode("ascii"),
+        "algorithm": "fernet",
+    }
+
+
+def decrypt_ai_payload(wrapper: Mapping[str, Any]) -> Dict[str, Any]:
+    """Return the plaintext payload from an encrypted *wrapper*."""
+
+    ciphertext = wrapper.get("ciphertext") if isinstance(wrapper, Mapping) else None
+    if not isinstance(ciphertext, str):
+        raise ValueError("Encrypted payload missing ciphertext")
+    try:
+        token = base64.b64decode(ciphertext.encode("ascii"))
+    except Exception as exc:  # pragma: no cover - invalid base64
+        raise ValueError("Encrypted payload contained invalid base64") from exc
+    try:
+        plaintext = _ai_cipher().decrypt(token)
+    except InvalidToken as exc:
+        raise ValueError("Encrypted payload could not be decrypted") from exc
+    try:
+        return json.loads(plaintext.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError("Encrypted payload was not valid JSON") from exc
+
+
+def rotate_artifact_key() -> None:
+    """Rotate the artifact encryption key."""
+
+    generated = Fernet.generate_key().decode("utf-8")
+    key_manager.store_secret(
+        _ARTIFACT_SECRET_NAME,
+        _ARTIFACT_ENV_VAR,
+        generated,
+        source="rotated",
+    )
+    _artifact_cipher.cache_clear()
+
+
+def rotate_ai_payload_key() -> None:
+    """Rotate the AI payload encryption key."""
+
+    generated = Fernet.generate_key().decode("utf-8")
+    key_manager.store_secret(
+        _AI_SECRET_NAME,
+        _AI_ENV_VAR,
+        generated,
+        source="rotated",
+    )
+    _ai_cipher.cache_clear()
+
+
+__all__ = [
+    "decrypt_ai_payload",
+    "decrypt_artifact",
+    "encrypt_ai_payload",
+    "encrypt_artifact",
+    "rotate_ai_payload_key",
+    "rotate_artifact_key",
+]
+

--- a/backend/guidelines.py
+++ b/backend/guidelines.py
@@ -6,7 +6,8 @@ do not trigger additional network requests.
 """
 from functools import lru_cache
 from typing import Dict, List, Tuple
-import requests
+
+from backend.egress import secure_get
 
 CDC_VACCINES_URL = "https://www.cdc.gov/vaccines/schedules/schedule.json"
 USPSTF_SCREENINGS_URL = "https://api.uspreventiveservicestaskforce.org/v1/recommendations"
@@ -15,8 +16,7 @@ USPSTF_SCREENINGS_URL = "https://api.uspreventiveservicestaskforce.org/v1/recomm
 @lru_cache(maxsize=2)
 def _download(url: str) -> List[dict]:
     """Download JSON data from ``url`` and cache the result."""
-    resp = requests.get(url, timeout=10)
-    resp.raise_for_status()
+    resp = secure_get(url)
     data = resp.json()
     if isinstance(data, dict) and "recommendations" in data:
         return data["recommendations"]  # type: ignore[return-value]

--- a/backend/public_health.py
+++ b/backend/public_health.py
@@ -19,7 +19,7 @@ import os
 import time
 from typing import Dict, List, Optional, Tuple
 
-import requests
+from backend.egress import secure_get
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -55,8 +55,7 @@ def _now() -> float:
 def _download_json(url: str) -> Dict:
     """Best‑effort JSON downloader returning an empty dict on error."""
 
-    resp = requests.get(url, timeout=10)
-    resp.raise_for_status()
+    resp = secure_get(url)
     try:
         return resp.json()
     except Exception:

--- a/backend/security.py
+++ b/backend/security.py
@@ -1,0 +1,148 @@
+"""Security helpers for prompt scrubbing, logging redaction and hashing."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from dataclasses import dataclass
+from typing import Any, Iterable, List, Mapping, Optional
+
+from prometheus_client import Counter
+
+from backend.deid import deidentify
+
+
+PROMPT_REDACTIONS_TOTAL = Counter(
+    "revenuepilot_prompt_redactions_total",
+    "Number of prompts scrubbed before AI dispatch",
+    ("profile", "mode"),
+)
+
+PROMPT_REDACTIONS_SKIPPED = Counter(
+    "revenuepilot_prompt_redactions_skipped_total",
+    "Prompts bypassing the scrubber due to configuration",
+    ("profile",),
+)
+
+
+def hash_identifier(value: Optional[str]) -> Optional[str]:
+    """Return a stable SHA256 hash prefix for identifiers."""
+
+    if not value:
+        return None
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()
+    return digest[:16]
+
+
+def redact_value(value: Any) -> Any:
+    """Redact string values using :func:`deidentify` recursively."""
+
+    if isinstance(value, str):
+        return deidentify(value)
+    if isinstance(value, Mapping):
+        return {key: redact_value(sub_value) for key, sub_value in value.items()}
+    if isinstance(value, Iterable) and not isinstance(value, (bytes, bytearray)):
+        return [redact_value(item) for item in value]
+    return value
+
+
+@dataclass(frozen=True)
+class PromptProfile:
+    include_chart: bool = True
+    include_audio: bool = True
+    include_rules: bool = False
+    allow_demographics: bool = False
+
+
+@dataclass(frozen=True)
+class PromptContext:
+    text: str
+    rules: Optional[List[str]]
+    age: Optional[int]
+    sex: Optional[str]
+    region: Optional[str]
+
+
+class PromptPrivacyGuard:
+    """Utility that enforces per-prompt scrubbing policies."""
+
+    def __init__(self) -> None:
+        mode = os.getenv("PROMPT_SCRUBBING", "minimum").strip().lower()
+        self._mode = "minimum" if mode not in {"off", "disabled"} else "off"
+        self._profiles = {
+            "beautify": PromptProfile(include_chart=False, include_audio=False, include_rules=False, allow_demographics=False),
+            "summary": PromptProfile(include_chart=True, include_audio=True, include_rules=False, allow_demographics=True),
+            "suggest": PromptProfile(include_chart=True, include_audio=True, include_rules=True, allow_demographics=True),
+        }
+
+    @property
+    def enabled(self) -> bool:
+        return self._mode != "off"
+
+    @property
+    def mode(self) -> str:
+        return self._mode
+
+    def profile(self, name: str) -> PromptProfile:
+        return self._profiles.get(name, PromptProfile())
+
+    def prepare(self, name: str, request: Any) -> PromptContext:
+        profile = self.profile(name)
+        mode = self.mode
+        if not self.enabled:
+            PROMPT_REDACTIONS_SKIPPED.labels(profile=name).inc()
+            return self._legacy_prepare(request)
+
+        PROMPT_REDACTIONS_TOTAL.labels(profile=name, mode=mode).inc()
+        parts: List[str] = []
+        if getattr(request, "text", None):
+            parts.append(str(request.text))
+        if profile.include_chart and getattr(request, "chart", None):
+            parts.append(str(request.chart))
+        if profile.include_audio and getattr(request, "audio", None):
+            parts.append(str(request.audio))
+        sanitized = [deidentify(p) for p in parts if p]
+        combined = "\n\n".join(sanitized)
+
+        rules: Optional[List[str]] = None
+        if profile.include_rules and getattr(request, "rules", None):
+            rules = [deidentify(r) for r in request.rules if isinstance(r, str) and r]
+            if not rules:
+                rules = None
+
+        age = request.age if profile.allow_demographics else None
+        sex = request.sex if profile.allow_demographics else None
+        region = request.region if profile.allow_demographics else None
+        return PromptContext(text=combined, rules=rules, age=age, sex=sex, region=region)
+
+    def _legacy_prepare(self, request: Any) -> PromptContext:
+        parts: List[str] = []
+        if getattr(request, "text", None):
+            parts.append(str(request.text))
+        if getattr(request, "chart", None):
+            parts.append(str(request.chart))
+        if getattr(request, "audio", None):
+            parts.append(str(request.audio))
+        combined = "\n\n".join(parts)
+        cleaned = deidentify(combined)
+        rules = [deidentify(r) for r in getattr(request, "rules", []) if isinstance(r, str) and r]
+        if not rules:
+            rules = None
+        return PromptContext(
+            text=cleaned,
+            rules=rules,
+            age=getattr(request, "age", None),
+            sex=getattr(request, "sex", None),
+            region=getattr(request, "region", None),
+        )
+
+
+__all__ = [
+    "PromptContext",
+    "PromptPrivacyGuard",
+    "hash_identifier",
+    "redact_value",
+    "PROMPT_REDACTIONS_TOTAL",
+    "PROMPT_REDACTIONS_SKIPPED",
+]
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -424,6 +424,8 @@ details and enforce the following controls:
 - [SOP.md](SOP.md) – Day-to-day development process and CI expectations.
 - [RDS_OPERATIONS.md](RDS_OPERATIONS.md) – Production database provisioning,
   credential rotation, and migration runbook.
+- [RUNBOOK_KEY_ROTATION.md](RUNBOOK_KEY_ROTATION.md) – Broken-glass steps for
+  encrypting artifacts/AI payloads and rotating managed secrets safely.
 - [`docs/archive/`](archive/README.md) – Historical planning documents kept
   for context.
 

--- a/docs/RUNBOOK_KEY_ROTATION.md
+++ b/docs/RUNBOOK_KEY_ROTATION.md
@@ -1,0 +1,99 @@
+# Broken-Glass Runbook: Encryption Key & Secret Rotation
+
+This runbook captures the steps engineering should follow when a rapid
+rotation of encryption keys or application secrets is required (e.g. after a
+suspected compromise). The procedure assumes production deployments store
+secrets in a managed KMS-backed service (AWS Secrets Manager, Hashicorp Vault,
+etc.) and that fallbacks rely on the encrypted local store for development.
+
+## 1. Preparation
+
+1. **Identify impacted credentials**
+   - Artifact encryption key (`artifact-encryption-key`)
+   - AI payload encryption key (`ai-payload-encryption-key`)
+   - OpenAI / model API keys (`openai`)
+   - JWT signing secret (`jwt`)
+
+2. **Notify stakeholders**
+   - Engineering on-call
+   - Compliance / security officer
+   - Customer success (to coordinate comms if downtime is expected)
+
+3. **Snapshot state**
+   - Capture encrypted backups of the chart artifact directory and database.
+   - Verify monitoring dashboards for error budgets / alerting.
+
+## 2. Rotate the managed secret
+
+1. In the secrets manager create a new version of the affected secret.
+   - For encryption keys generate a new 32-byte key and base64 encode it.
+   - Set the metadata fields (rotatedAt/version) for audit tracking.
+
+2. Update the environment variables or secret references used by the
+   deployment platform (e.g. Kubernetes `Secret`, ECS task definition).
+
+3. For encryption keys run the helper CLI in the maintenance container to
+   re-encrypt persisted data:
+
+   ```bash
+   python -m backend.scripts.reencrypt_artifacts --key-type artifact
+   python -m backend.scripts.reencrypt_ai_payloads
+   ```
+
+   The scripts decrypt using the previously active key then re-encrypt using
+   the new key from the secrets manager. They log progress and emit metrics.
+
+4. Trigger a rolling restart of the backend pods once the new secret versions
+   are available.
+
+## 3. Validation
+
+1. Run smoke tests:
+   - Upload a chart and confirm the stored blob decrypts successfully.
+   - Generate AI suggestions and verify `ai_json_snapshots` rows contain the
+     encrypted envelope (`ciphertext`).
+   - Execute the regression API health check (`pytest tests/test_security_controls.py`).
+
+2. Monitor metrics:
+   - `revenuepilot_prompt_redactions_total` should continue incrementing.
+   - `revenuepilot_egress_failures_total` should remain stable (no spikes).
+   - Verify `SECRET_MAX_AGE` dashboard cards reflect the new rotation date.
+
+3. Confirm log scrubbing:
+   - Inspect recent `chart_upload.saved` entries for `patient_hash` fields.
+   - Ensure no raw patient identifiers appear.
+
+## 4. Post-Rotation Cleanup
+
+1. Revoke the previous secret version in the KMS / secrets manager once the
+   deployment is stable for at least one monitoring interval.
+
+2. Update incident tracking with:
+   - Start / completion time
+   - Secrets rotated
+   - Validation results and any follow-up actions.
+
+3. Schedule the next routine rotation by updating the `rotatedAt` metadata
+   (default 90 days) and confirm the automation tickets are regenerated.
+
+## 5. Contingency Plan
+
+If encryption fails during re-encryption:
+
+1. Halt the scripts immediately.
+2. Restore encrypted backups taken in the preparation step.
+3. Re-run the scripts in dry-run mode to identify corrupt artifacts.
+4. Escalate to security + platform team before re-attempting rotation.
+
+If application pods fail to start due to missing secrets:
+
+1. Revert to the previous secret version.
+2. Rollback the deployment to the last known good revision.
+3. Diagnose missing permissions or configuration before retrying rotation.
+
+---
+
+**Remember:** document every action during a broken-glass event. Post-mortems
+rely on precise timelines to confirm all PHI remained protected throughout the
+rotation.
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,14 @@ models_module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(models_module)  # type: ignore[union-attr]
 sys.modules['backend.db.models'] = models_module
 db_module.models = models_module
+config_path = Path(ROOT) / 'backend' / 'db' / 'config.py'
+config_spec = importlib.util.spec_from_file_location('backend.db.config', config_path)
+if config_spec and config_spec.loader:
+    config_module = importlib.util.module_from_spec(config_spec)
+    sys.modules['backend.db.config'] = config_module
+    config_spec.loader.exec_module(config_module)  # type: ignore[union-attr]
+    db_module.config = config_module
+    db_module.get_database_settings = config_module.get_database_settings
 sys.modules['backend.db'] = db_module
 
 

--- a/tests/test_ai_gating.py
+++ b/tests/test_ai_gating.py
@@ -16,6 +16,7 @@ from backend.ai_gating import (
     EMBED_SENTINEL_OLD,
 )
 from backend.migrations import create_all_tables
+from backend.encryption import decrypt_ai_payload
 
 
 
@@ -318,7 +319,8 @@ def test_reconcile_json_merges_small_divergence(gating_service_state):
         assert state.last_accepted_json_hash == meta["currentHash"]
         snapshot = session.get(AIJsonSnapshot, state.last_accepted_json_hash)
         assert snapshot is not None
-        assert snapshot.payload["reimbursementSummary"] == baseline["reimbursementSummary"]
+        payload = decrypt_ai_payload(snapshot.payload)
+        assert payload["reimbursementSummary"] == baseline["reimbursementSummary"]
 
 
 def test_reconcile_json_skips_merge_for_large_divergence(gating_service_state):
@@ -349,7 +351,8 @@ def test_reconcile_json_skips_merge_for_large_divergence(gating_service_state):
         assert state.last_accepted_json_hash == meta["currentHash"]
         snapshot = session.get(AIJsonSnapshot, state.last_accepted_json_hash)
         assert snapshot is not None
-        assert snapshot.payload == merged
+        payload = decrypt_ai_payload(snapshot.payload)
+        assert payload == merged
 
 def _make_service(db, embed_client):
     create_all_tables(db)

--- a/tests/test_security_controls.py
+++ b/tests/test_security_controls.py
@@ -1,0 +1,67 @@
+import base64
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from backend import main
+from backend.encryption import encrypt_artifact, decrypt_artifact
+from backend.security import hash_identifier
+
+
+async def test_inline_chart_upload_logs_hash(monkeypatch, tmp_path: Path, caplog):
+    caplog.set_level(logging.INFO)
+    monkeypatch.setattr(main, "UPLOAD_DIR", tmp_path)
+
+    class DummyPipeline:
+        async def handle_upload(self, **_: object) -> dict:
+            return {"files": [], "correlation_id": "ctx_dummy", "patient_id": "patient-123"}
+
+    monkeypatch.setattr(main, "context_pipeline", DummyPipeline())
+
+    payload = main.ChartUploadPayload(
+        filename="note.txt",
+        data=base64.b64encode(b"payload").decode(),
+        contentType="text/plain",
+    )
+
+    correlation = await main._process_inline_chart_upload("patient-123", payload)
+    assert correlation
+
+    hashed_expected = hash_identifier("patient-123")
+
+    matched_records = []
+    for record in caplog.records:
+        event = getattr(record, "event", None)
+        patient_hash = getattr(record, "patient_hash", None)
+        parsed_payload = None
+
+        if event != "chart_upload.saved":
+            try:
+                parsed_payload = json.loads(record.getMessage())
+            except json.JSONDecodeError:
+                parsed_payload = None
+            if isinstance(parsed_payload, dict):
+                event = event or parsed_payload.get("event")
+                patient_hash = patient_hash or parsed_payload.get("patient_hash")
+
+        if event == "chart_upload.saved":
+            matched_records.append((record, patient_hash, parsed_payload))
+
+    assert matched_records
+
+    for record, patient_hash, payload in matched_records:
+        assert patient_hash == hashed_expected
+        message = record.getMessage()
+        assert "patient-123" not in message
+        if isinstance(payload, dict):
+            assert payload.get("patient_hash") == hashed_expected
+            assert "patient-123" not in json.dumps(payload)
+
+
+def test_encrypt_artifact_roundtrip():
+    plaintext = b"secret"
+    ciphertext = encrypt_artifact(plaintext)
+    assert ciphertext != plaintext
+    assert decrypt_artifact(ciphertext) == plaintext


### PR DESCRIPTION
## Summary
- add encryption helpers, secure egress clients, and prompt privacy utilities to guard PHI
- integrate hashing/redaction in the FastAPI surface, encrypt chart uploads and AI payloads, and tighten outbound HTTP usage
- document key rotation steps and extend regression tests for encryption, hashed logging, and encrypted snapshots

## Testing
- `pytest tests/test_security_controls.py::test_inline_chart_upload_logs_hash -q`
- `pytest tests/test_patient_endpoints.py::test_patient_encounter_flow -q`
- `pytest tests/test_db_config.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68d33e9625f48324a958941ac34afbfe