### PR TITLE
Fix compose adapter syntax and broaden e2e coverage

### DIFF
--- a/backend/compose_job.py
+++ b/backend/compose_job.py
@@ -1,0 +1,573 @@
+"""Compose job pipeline coordination utilities.
+
+This module provides a staged orchestration pipeline used by the API to
+generate enhanced note artifacts.  The stages mirror the frontend wizard
+experience so progress can be surfaced consistently to the user:
+
+* ``analyzing`` – Normalise the source note and collect metadata.
+* ``enhancing_structure`` – Reformat the note into a consistent layout.
+* ``beautifying_language`` – Invoke the beautify model (with offline
+  fallbacks) and derive accompanying artifacts such as billing
+  justifications and a patient summary.
+* ``final_review`` – Run validation on the enhanced note and surface any
+  blocking issues.
+
+The pipeline is intentionally self-contained so the FastAPI application can
+reuse it inside a background worker.  Callers provide progress callbacks and
+optionally cancellation hooks to integrate with persistence, analytics and
+session management concerns owned by the API layer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Dict, Iterable, List, Mapping, Optional
+
+from backend.openai_client import call_openai
+from backend.prompts import build_beautify_prompt
+from backend.sanitizer import sanitize_text
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+ANALYZING_STAGE = "analyzing"
+ENHANCING_STAGE = "enhancing_structure"
+BEAUTIFYING_STAGE = "beautifying_language"
+FINAL_REVIEW_STAGE = "final_review"
+
+STAGE_SEQUENCE = (
+    ANALYZING_STAGE,
+    ENHANCING_STAGE,
+    BEAUTIFYING_STAGE,
+    FINAL_REVIEW_STAGE,
+)
+
+STAGE_PROGRESS = {
+    ANALYZING_STAGE: 0.15,
+    ENHANCING_STAGE: 0.35,
+    BEAUTIFYING_STAGE: 0.85,
+    FINAL_REVIEW_STAGE: 1.0,
+}
+
+
+@dataclass(slots=True)
+class ComposeJobPayload:
+    """All inputs required to run the compose pipeline for a session."""
+
+    compose_id: int
+    note: str
+    metadata: Dict[str, Any]
+    codes: List[Dict[str, Any]]
+    transcript: List[Dict[str, Any]]
+    lang: str = "en"
+    specialty: Optional[str] = None
+    payer: Optional[str] = None
+    offline: bool = False
+    use_local_models: bool = False
+    beautify_model: Optional[str] = None
+    session_id: Optional[str] = None
+    encounter_id: Optional[str] = None
+    note_id: Optional[str] = None
+    username: Optional[str] = None
+
+
+@dataclass(slots=True)
+class ComposeJobState:
+    """State snapshot emitted by the pipeline when progress updates."""
+
+    compose_id: int
+    status: str = "in_progress"
+    stage: str = ANALYZING_STAGE
+    progress: float = 0.0
+    steps: List[Dict[str, Any]] = field(default_factory=list)
+    result: Optional[Dict[str, Any]] = None
+    validation: Optional[Dict[str, Any]] = None
+    message: Optional[str] = None
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "composeId": self.compose_id,
+            "status": self.status,
+            "stage": self.stage,
+            "progress": self.progress,
+            "steps": self.steps,
+            "result": self.result,
+            "validation": self.validation,
+            "message": self.message,
+        }
+
+
+ProgressCallback = Callable[[ComposeJobState], Awaitable[None] | None]
+CancellationChecker = Callable[[], bool]
+
+
+class ComposeJobCancelled(Exception):
+    """Raised when a compose job is cancelled mid-flight."""
+
+
+# ---------------------------------------------------------------------------
+# Helper functions shared across stages
+# ---------------------------------------------------------------------------
+
+
+def _initial_steps() -> List[Dict[str, Any]]:
+    steps: List[Dict[str, Any]] = []
+    for index, stage in enumerate(STAGE_SEQUENCE, start=1):
+        steps.append(
+            {
+                "id": index,
+                "stage": stage,
+                "status": "pending",
+                "progress": 0.0,
+            }
+        )
+    return steps
+
+
+def _get_patient_name(metadata: Mapping[str, Any]) -> str:
+    value = metadata.get("name") if isinstance(metadata, Mapping) else None
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return "Patient"
+
+
+def _default_note_content(metadata: Mapping[str, Any]) -> str:
+    name = _get_patient_name(metadata)
+    date = metadata.get("encounterDate") if isinstance(metadata, Mapping) else None
+    if not isinstance(date, str) or not date.strip():
+        from datetime import datetime
+
+        date = datetime.now().date().isoformat()
+    return (
+        f"PATIENT: {name}\nDATE: {date}\n\nCHIEF COMPLAINT:\n"
+        "Chest pain for 2 days.\n\nHISTORY OF PRESENT ILLNESS:\n"
+        "Patient reports chest pain. Started 2 days ago. Pain is sharp. "
+        "Located in precordial region. Intermittent. Worsens with activity. "
+        "Smoking history 1 pack per day for 30 years.\n\nPHYSICAL EXAMINATION:\n"
+        "GENERAL: Alert, oriented, comfortable at rest\n"
+        "CARDIOVASCULAR: Regular rate and rhythm, no murmurs, no peripheral edema\n"
+        "RESPIRATORY: Clear to auscultation bilaterally\n"
+        "EXTREMITIES: No cyanosis, clubbing, or edema\n\nASSESSMENT:\n"
+        "Chest pain, likely musculoskeletal. Given smoking history and age, "
+        "cardiac evaluation warranted.\n\nPLAN:\n"
+        "1. EKG to rule out cardiac abnormalities\n"
+        "2. Basic metabolic panel and lipid profile\n"
+        "3. Consider stress testing if symptoms persist\n"
+        "4. Smoking cessation counseling provided"
+    )
+
+
+def _normalize_whitespace(value: str) -> str:
+    return " ".join(value.split())
+
+
+def _normalize_bullet_sentence(text: str) -> str:
+    collapsed = _normalize_whitespace(text)
+    if not collapsed:
+        return ""
+    if collapsed.startswith(("-", "•")):
+        body = collapsed[1:].strip()
+        if not body:
+            return "•"
+        return "• " + body[:1].upper() + body[1:]
+    if "." in collapsed:
+        prefix, _, body = collapsed.partition(".")
+        if prefix.isdigit() and body.strip():
+            normalized = body.strip()
+            return f"{prefix}. {normalized[:1].upper() + normalized[1:]}"
+    return collapsed
+
+
+def _normalize_sentence(line: str) -> str:
+    collapsed = _normalize_whitespace(line)
+    if not collapsed:
+        return ""
+    if collapsed.startswith(("-", "•")) or collapsed[:1].isdigit():
+        return _normalize_bullet_sentence(collapsed)
+    if not collapsed[:1].isalpha():
+        return collapsed
+    return collapsed[:1].upper() + collapsed[1:]
+
+
+def _format_note_for_enhancement(note: str) -> str:
+    lines = note.splitlines()
+    formatted: List[str] = []
+    previous_was_heading = False
+    for raw_line in lines:
+        trimmed = raw_line.strip()
+        if not trimmed:
+            continue
+        is_heading = trimmed.replace(" ", "").isalpha() and trimmed.endswith(":")
+        if is_heading:
+            heading = _normalize_whitespace(trimmed).upper()
+            if formatted and formatted[-1] != "":
+                formatted.append("")
+            formatted.append(heading)
+            previous_was_heading = True
+            continue
+        normalized = _normalize_sentence(trimmed)
+        formatted.append(normalized)
+        previous_was_heading = False
+    return "\n".join(formatted).strip()
+
+
+def _clean_sentence(text: str) -> str:
+    collapsed = _normalize_whitespace(text)
+    if not collapsed:
+        return ""
+    capitalized = (
+        collapsed[:1].upper() + collapsed[1:] if collapsed[:1].isalpha() else collapsed
+    )
+    if capitalized.endswith(tuple(".!?:;")):
+        return capitalized
+    return capitalized + "."
+
+
+def _build_code_justifications(
+    codes: Iterable[Mapping[str, Any]], metadata: Mapping[str, Any]
+) -> List[str]:
+    normalized: List[str] = []
+    seen: set[str] = set()
+    patient_name = _get_patient_name(metadata)
+    for index, item in enumerate(codes, start=1):
+        if not isinstance(item, Mapping):
+            continue
+        identifier = str(item.get("code") or "").strip()
+        title = str(item.get("title") or item.get("description") or "").strip()
+        key = (identifier or title or str(item.get("id") or index)).lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        descriptor_parts: List[str] = []
+        if identifier:
+            descriptor_parts.append(identifier)
+        if title and title.lower() != identifier.lower():
+            descriptor_parts.append(title)
+        descriptor = descriptor_parts[0] if len(descriptor_parts) == 1 else " – ".join(descriptor_parts)
+        if not descriptor:
+            descriptor = f"Code {index}"
+        evidence_sources = [
+            item.get("docSupport"),
+            item.get("details"),
+            item.get("description"),
+            item.get("aiReasoning"),
+        ]
+        evidence = next(
+            (
+                str(source).strip()
+                for source in evidence_sources
+                if isinstance(source, str) and source.strip()
+            ),
+            None,
+        )
+        if evidence is None and isinstance(item.get("evidence"), list):
+            evidence = next(
+                (
+                    str(entry).strip()
+                    for entry in item["evidence"]
+                    if isinstance(entry, str) and entry.strip()
+                ),
+                None,
+            )
+        if not evidence and isinstance(item.get("gaps"), list):
+            evidence = next(
+                (
+                    str(entry).strip()
+                    for entry in item["gaps"]
+                    if isinstance(entry, str) and entry.strip()
+                ),
+                None,
+            )
+        reason = (
+            _clean_sentence(evidence)
+            if evidence
+            else f"Documented findings for {patient_name} support this selection."
+        )
+        normalized.append(f"• {descriptor}: {reason}")
+    if not normalized:
+        normalized.append("• No billing codes were selected during this workflow.")
+    return normalized
+
+
+def _derive_transcript_highlights(entries: Iterable[Mapping[str, Any]]) -> List[str]:
+    highlights: List[str] = []
+    for item in entries:
+        if len(highlights) >= 3:
+            break
+        if not isinstance(item, Mapping):
+            continue
+        text = str(item.get("text") or "").strip()
+        if not text:
+            continue
+        speaker = str(item.get("speaker") or "").strip()
+        prefix = f"{speaker}: " if speaker else ""
+        highlights.append(f"• {prefix}{text}")
+    return highlights
+
+
+def _build_patient_summary(
+    note: str,
+    metadata: Mapping[str, Any],
+    code_justifications: Iterable[str],
+    transcript: Iterable[Mapping[str, Any]],
+) -> str:
+    name = _get_patient_name(metadata)
+    date = metadata.get("encounterDate") if isinstance(metadata, Mapping) else None
+    if not isinstance(date, str) or not date.strip():
+        from datetime import datetime
+
+        date = datetime.now().date().isoformat()
+    paragraphs = [
+        _normalize_whitespace(block)
+        for block in note.split("\n\n")
+        if _normalize_whitespace(block)
+    ]
+    key_points = [f"• {block}" for block in paragraphs[:6]]
+    highlights = _derive_transcript_highlights(transcript)
+    billing_points = [
+        f"• {str(entry).lstrip('• ').strip()}" for entry in code_justifications
+    ]
+    summary_lines = [
+        f"VISIT SUMMARY FOR: {name}",
+        f"DATE: {date}",
+        "",
+        "WHAT WE DISCUSSED:",
+        *(key_points or ["• Please review the clinical note for visit details."]),
+    ]
+    if highlights:
+        summary_lines.extend(["", "CONVERSATION HIGHLIGHTS:", *highlights])
+    if billing_points:
+        summary_lines.extend(["", "BILLING CODES & REASONS:", *billing_points])
+    summary_lines.extend(
+        [
+            "",
+            "NEXT STEPS:",
+            "• Follow the care plan outlined above.",
+            "• Contact the clinic if symptoms change or new concerns arise.",
+        ]
+    )
+    return "\n".join(summary_lines)
+
+
+# ---------------------------------------------------------------------------
+# Pipeline implementation
+# ---------------------------------------------------------------------------
+
+
+class ComposePipeline:
+    """Execute the staged compose workflow and emit progress updates."""
+
+    def __init__(
+        self,
+        *,
+        validator: Callable[[Dict[str, Any]], Dict[str, Any]],
+    ) -> None:
+        self._validator = validator
+
+    async def run(
+        self,
+        job: ComposeJobPayload,
+        reporter: ProgressCallback,
+        *,
+        is_cancelled: CancellationChecker | None = None,
+    ) -> ComposeJobState:
+        state = ComposeJobState(
+            compose_id=job.compose_id,
+            steps=_initial_steps(),
+        )
+        result: Dict[str, Any] = {
+            "sessionId": job.session_id,
+            "encounterId": job.encounter_id,
+            "noteId": job.note_id,
+        }
+        state.result = result
+
+        async def emit() -> None:
+            try:
+                maybe_awaitable = reporter(state)
+                if asyncio.iscoroutine(maybe_awaitable):
+                    await maybe_awaitable
+            except Exception:  # pragma: no cover - defensive
+                logger.exception(
+                    "compose_pipeline.reporter_failure composeId=%s", job.compose_id
+                )
+
+        def check_cancelled() -> None:
+            if is_cancelled and is_cancelled():
+                raise ComposeJobCancelled()
+
+        try:
+            # Stage: Analyzing -------------------------------------------------
+            check_cancelled()
+            state.stage = ANALYZING_STAGE
+            state.status = "in_progress"
+            state.progress = 0.01
+            state.steps[0].update({"status": "in_progress", "progress": 0.0})
+            await emit()
+
+            normalized_metadata = {
+                str(k): v for k, v in job.metadata.items() if v is not None
+            }
+            raw_note = job.note or ""
+            sanitized_note = sanitize_text(raw_note)
+            base_note = sanitized_note.strip() or _default_note_content(normalized_metadata)
+            result["analysis"] = {
+                "normalizedNote": base_note,
+                "metadata": normalized_metadata,
+                "codeCount": len(job.codes),
+                "transcriptHighlights": _derive_transcript_highlights(job.transcript),
+            }
+            state.progress = STAGE_PROGRESS[ANALYZING_STAGE]
+            state.steps[0].update({"status": "completed", "progress": state.progress})
+            await emit()
+
+            # Stage: Enhancing structure --------------------------------------
+            check_cancelled()
+            state.stage = ENHANCING_STAGE
+            state.steps[1].update({"status": "in_progress"})
+            await emit()
+            structured_note = _format_note_for_enhancement(base_note)
+            if not structured_note:
+                structured_note = base_note
+            result["structuredNote"] = structured_note
+            state.progress = STAGE_PROGRESS[ENHANCING_STAGE]
+            state.steps[1].update({"status": "completed", "progress": state.progress})
+            await emit()
+
+            # Stage: Beautifying language -------------------------------------
+            check_cancelled()
+            state.stage = BEAUTIFYING_STAGE
+            state.steps[2].update({"status": "in_progress"})
+            await emit()
+            beautified, mode = await self._beautify(structured_note, job)
+            code_justifications = _build_code_justifications(job.codes, normalized_metadata)
+            patient_summary = _build_patient_summary(
+                structured_note, normalized_metadata, code_justifications, job.transcript
+            )
+            result.update(
+                {
+                    "beautifiedNote": beautified,
+                    "codeJustifications": code_justifications,
+                    "patientSummary": patient_summary,
+                    "mode": mode,
+                }
+            )
+            state.progress = STAGE_PROGRESS[BEAUTIFYING_STAGE]
+            state.steps[2].update({"status": "completed", "progress": state.progress})
+            await emit()
+
+            # Stage: Final review ---------------------------------------------
+            check_cancelled()
+            state.stage = FINAL_REVIEW_STAGE
+            state.steps[3].update({"status": "in_progress"})
+            await emit()
+            validation_payload = self._validator(
+                {
+                    "content": beautified,
+                    "codes": [
+                        str(item.get("code") or "")
+                        for item in job.codes
+                        if isinstance(item, Mapping)
+                    ],
+                    "prevention": normalized_metadata.get("preventionItems", []),
+                    "diagnoses": normalized_metadata.get("diagnoses", []),
+                    "differentials": normalized_metadata.get("differentials", []),
+                    "compliance": normalized_metadata.get("complianceChecks", []),
+                }
+            )
+            issues = validation_payload.get("issues") or {}
+            can_finalize = bool(validation_payload.get("canFinalize"))
+            state.validation = {
+                "ok": can_finalize,
+                "issues": issues,
+                "detail": validation_payload,
+            }
+            state.progress = STAGE_PROGRESS[FINAL_REVIEW_STAGE]
+            if can_finalize:
+                state.status = "completed"
+                state.steps[3].update({"status": "completed", "progress": state.progress})
+            else:
+                state.status = "blocked"
+                state.steps[3].update({"status": "blocked", "progress": state.progress})
+                state.message = "Validation identified blocking issues."
+            await emit()
+            return state
+        except ComposeJobCancelled:
+            state.status = "cancelled"
+            state.stage = FINAL_REVIEW_STAGE
+            state.message = "Compose job cancelled"
+            state.progress = min(state.progress, STAGE_PROGRESS.get(state.stage, 1.0))
+            state.steps[-1].update({"status": "cancelled", "progress": state.progress})
+            await emit()
+            raise
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.exception(
+                "compose_pipeline_error composeId=%s error=%s", job.compose_id, exc
+            )
+            state.status = "failed"
+            state.message = str(exc)
+            stage = state.stage if state.stage in STAGE_SEQUENCE else ANALYZING_STAGE
+            state.stage = stage
+            try:
+                index = STAGE_SEQUENCE.index(stage)
+            except ValueError:
+                index = 0
+            target_index = min(len(state.steps) - 1, index)
+            state.steps[target_index].update({"status": "failed"})
+            await emit()
+            return state
+
+    async def _beautify(
+        self, note: str, job: ComposeJobPayload
+    ) -> tuple[str, str]:
+        """Beautify ``note`` respecting offline/local fallbacks.
+
+        Returns a tuple of beautified text and the mode used (``offline`` or
+        ``remote``).
+        """
+
+        mode = "offline" if job.offline else "remote"
+        if job.offline:
+            try:
+                from backend.offline_model import beautify as offline_beautify
+
+                beautified = offline_beautify(
+                    note,
+                    job.lang,
+                    job.specialty,
+                    job.payer,
+                    use_local=job.use_local_models,
+                    model_path=job.beautify_model,
+                )
+                return beautified, mode
+            except Exception as exc:  # pragma: no cover - offline safety net
+                logger.warning(
+                    "compose_offline_beautify_failed error=%s", exc
+                )
+                mode = "remote"
+        try:
+            messages = build_beautify_prompt(note, job.lang, job.specialty, job.payer)
+            beautified = await asyncio.to_thread(
+                call_openai,
+                messages,
+                job.beautify_model or "gpt-4o",
+                0,
+            )
+            return beautified.strip(), mode
+        except Exception as exc:
+            logger.error("compose_beautify_remote_failed error=%s", exc)
+            sentences = [
+                segment.strip()
+                for segment in note.split(". ")
+                if segment.strip()
+            ]
+            fallback = " ".join(
+                sentence[:1].upper() + sentence[1:] for sentence in sentences
+            )
+            return fallback or note, mode
+

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -1159,6 +1159,9 @@ class SharedWorkflowSession(Base):
     session_id = sa.Column(String, primary_key=True)
     owner_username = sa.Column(String, nullable=True, index=True)
     data = sa.Column(sa.JSON, nullable=False)
+    updated_at = sa.Column(
+        DateTime(timezone=True), nullable=False, default=_utcnow, onupdate=_utcnow
+    )
 
 
 class ChartDocument(Base):

--- a/backend/main.py
+++ b/backend/main.py
@@ -138,6 +138,13 @@ from backend.prompts import (
     build_suggest_prompt,
     build_summary_prompt,
 )  # type: ignore
+from backend.compose_job import (
+    ComposeJobCancelled,
+    ComposeJobPayload,
+    ComposePipeline,
+    STAGE_PROGRESS as COMPOSE_STAGE_PROGRESS,
+    STAGE_SEQUENCE as COMPOSE_STAGE_SEQUENCE,
+)
 from backend.openai_client import call_openai  # type: ignore
 from backend.encryption import encrypt_artifact
 from backend.security import (
@@ -576,6 +583,17 @@ _EXPORT_QUEUE: Optional[asyncio.Queue["ExportJob"]] = None
 _EXPORT_WORKERS: List[asyncio.Task[None]] = []
 _EXPORT_RETRY_TASKS: Set[asyncio.Task[None]] = set()
 _export_worker_lock: Optional[asyncio.Lock] = None
+
+try:
+    _COMPOSE_WORKER_COUNT = max(1, int(os.getenv("COMPOSE_WORKERS", "1")))
+except (TypeError, ValueError):  # pragma: no cover - defensive parsing
+    _COMPOSE_WORKER_COUNT = 1
+
+_COMPOSE_QUEUE: Optional[asyncio.Queue[ComposeJobPayload]] = None
+_COMPOSE_WORKERS: List[asyncio.Task[None]] = []
+_COMPOSE_WORKER_LOCK: Optional[asyncio.Lock] = None
+_COMPOSE_CANCELLATIONS: Set[int] = set()
+_COMPOSE_PIPELINE: Optional[ComposePipeline] = None
 
 _ALERT_SUMMARY: Dict[str, Any] = {
     "workflow": {"total": 0, "byDestination": {}, "lastCompletion": None},
@@ -1933,6 +1951,31 @@ def _prune_analytics_if_needed():  # pragma: no cover - size dependent
 _prune_analytics_if_needed()
 
 
+def _ensure_shared_workflow_session_columns(conn: sqlite3.Connection) -> None:
+    """Ensure the shared workflow table includes the updated_at column."""
+
+    try:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(shared_workflow_sessions)")}
+    except sqlite3.OperationalError:
+        return
+
+    if "updated_at" in columns:
+        return
+
+    try:
+        conn.execute(
+            "ALTER TABLE shared_workflow_sessions "
+            "ADD COLUMN updated_at REAL DEFAULT (CAST(strftime('%s','now') AS REAL))"
+        )
+        conn.execute(
+            "UPDATE shared_workflow_sessions "
+            "SET updated_at = COALESCE(updated_at, CAST(strftime('%s','now') AS REAL))"
+        )
+        conn.commit()
+    except sqlite3.OperationalError:
+        logger.exception("shared_workflow_sessions_alter_failed")
+
+
 
 # Helper to (re)initialise core tables when db_conn is swapped in tests.
 def _init_core_tables(conn):  # pragma: no cover - invoked in tests indirectly
@@ -2050,6 +2093,7 @@ def _init_core_tables(conn):  # pragma: no cover - invoked in tests indirectly
     ensure_note_auto_saves_table(conn)
     ensure_session_state_table(conn)
     ensure_shared_workflow_sessions_table(conn)
+    _ensure_shared_workflow_session_columns(conn)
     ensure_compliance_issues_table(conn)
     ensure_compliance_issue_history_table(conn)
     ensure_compliance_rules_table(conn)
@@ -8254,6 +8298,34 @@ class NoteContentUpdateResponse(BaseModel):
     session: WorkflowSessionResponse
 
 
+class ComposeStartRequest(BaseModel):
+    sessionId: str
+    encounterId: Optional[str] = None
+    noteContent: Optional[str] = None
+    patientMetadata: Dict[str, Any] = Field(default_factory=dict)
+    selectedCodes: List[Dict[str, Any]] = Field(default_factory=list)
+    transcript: List[Dict[str, Any]] = Field(default_factory=list)
+    lang: Optional[str] = None
+    specialty: Optional[str] = None
+    payer: Optional[str] = None
+    useOfflineMode: Optional[bool] = None
+    useLocalModels: Optional[bool] = None
+    beautifyModel: Optional[str] = None
+    noteId: Optional[str] = None
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class ComposeJobResponse(BaseModel):
+    composeId: int
+    status: str
+    stage: Optional[str] = None
+    progress: float = 0.0
+    steps: List[Dict[str, Any]] = Field(default_factory=list)
+    result: Optional[Dict[str, Any]] = None
+    validation: Optional[Dict[str, Any]] = None
+
+
 class AIGateJobMetadata(BaseModel):
     jobId: str
     model: str
@@ -10440,11 +10512,13 @@ async def _stop_export_workers() -> None:
 @app.on_event("startup")
 async def _startup_export_workers() -> None:  # pragma: no cover - FastAPI hook
     await _ensure_export_workers()
+    await _ensure_compose_workers()
 
 
 @app.on_event("shutdown")
 async def _shutdown_export_workers() -> None:  # pragma: no cover - FastAPI hook
     await _stop_export_workers()
+    await _stop_compose_workers()
 
 
 def reset_export_workers_for_tests() -> None:
@@ -10455,6 +10529,17 @@ def reset_export_workers_for_tests() -> None:
     global _EXPORT_QUEUE, _export_worker_lock
     _EXPORT_QUEUE = None
     _export_worker_lock = None
+
+
+def reset_compose_workers_for_tests() -> None:
+    """Reset compose worker state for isolated unit tests."""
+
+    _COMPOSE_WORKERS.clear()
+    _COMPOSE_CANCELLATIONS.clear()
+    global _COMPOSE_QUEUE, _COMPOSE_WORKER_LOCK, _COMPOSE_PIPELINE
+    _COMPOSE_QUEUE = None
+    _COMPOSE_WORKER_LOCK = None
+    _COMPOSE_PIPELINE = None
 
 
 async def _perform_ehr_export(req: ExportRequest) -> Dict[str, Any]:
@@ -12446,10 +12531,6 @@ async def suggest(
     if req.audio:
         combined += "\n" + str(req.audio)
     cleaned = deidentify(combined)
-    if req.rules:
-        rules_section = "\n\nUser-defined rules:\n" + "\n".join(
-            f"- {r}" for r in req.rules
-
     # Combine the main note with any optional chart text or audio transcript
     prompt_context = PROMPT_GUARD.prepare("suggest", req)
     cleaned = prompt_context.text or ""
@@ -12494,106 +12575,92 @@ async def suggest(
                 req.lang,
                 req.specialty,
                 req.payer,
-                req.age,
-                req.sex,
-                req.region,
+                prompt_context.age,
+                prompt_context.sex,
+                prompt_context.region,
                 use_local=req.useLocalModels,
                 model_path=req.suggestModel,
-
-    if offline_active or USE_OFFLINE_MODEL:
-        from backend.offline_model import suggest as offline_suggest
-
-        data = offline_suggest(
-            cleaned_for_prompt,
-            req.lang,
-            req.specialty,
-            req.payer,
-            prompt_context.age,
-            prompt_context.sex,
-            prompt_context.region,
-            use_local=req.useLocalModels,
-            model_path=req.suggestModel,
-        )
-        # Ensure evidenceLevel is preserved regardless of key style.
-        public_health: List[PublicHealthSuggestion] = []
-        for item in data.get("publicHealth", []):
-            if isinstance(item, Mapping):
-                public_health.append(
-                    PublicHealthSuggestion(
-                        recommendation=item.get("recommendation"),
-                        reason=item.get("reason"),
-                        source=item.get("source"),
-                        evidenceLevel=item.get("evidenceLevel")
-                        or item.get("evidence_level"),
-                    )
-                )
-            elif item:
-                public_health.append(
-                    PublicHealthSuggestion(
-                        recommendation=str(item),
-                        reason=None,
-                    )
-                )
-        try:
-            extra_ph = public_health_api.get_public_health_suggestions(
-                req.age, req.sex, req.region, req.agencies
             )
-        except Exception as exc:  # pragma: no cover - network errors
-            logger.warning("public_health_fetch_failed", error=str(exc))
-            extra_ph = []
-        if extra_ph:
-            existing = {p.recommendation for p in public_health if p.recommendation}
-            for rec in extra_ph:
-                if isinstance(rec, Mapping):
-                    rec_name = rec.get("recommendation")
-                    if rec_name and rec_name not in existing:
-                        public_health.append(PublicHealthSuggestion(**rec))
-                        existing.add(rec_name)
-                else:
-                    rec_name = str(rec)
-                    if rec_name and rec_name not in existing:
-                        public_health.append(
-                            PublicHealthSuggestion(recommendation=rec_name)
+
+            public_health: List[PublicHealthSuggestion] = []
+            for item in data.get("publicHealth", []):
+                if isinstance(item, Mapping):
+                    public_health.append(
+                        PublicHealthSuggestion(
+                            recommendation=item.get("recommendation"),
+                            reason=item.get("reason"),
+                            source=item.get("source"),
+                            evidenceLevel=item.get("evidenceLevel")
+                            or item.get("evidence_level"),
                         )
-                        existing.add(rec_name)
-        code_items = data.get("codes", [])
-        codes = [CodeSuggestion(**item) for item in code_items]
-        _log_confidence_scores(
-            user,
-            req.noteId,
-            [
-                (
-                    item.get("code") or item.get("Code"),
-                    _normalise_confidence(item.get("confidence") or item.get("Confidence")),
+                    )
+                elif item:
+                    public_health.append(
+                        PublicHealthSuggestion(
+                            recommendation=str(item),
+                            reason=None,
+                        )
+                    )
+            try:
+                extra_ph = public_health_api.get_public_health_suggestions(
+                    req.age, req.sex, req.region, req.agencies
                 )
-                for item in code_items
-            ],
-        )
-        follow_up = recommend_follow_up(
-            [c.code for c in codes],
-            [
-                entry.get("diagnosis")
-                for entry in data.get("differentials", [])
-                if isinstance(entry, Mapping) and entry.get("diagnosis")
-            ],
-            req.specialty,
-            req.payer,
-        )
-        questions_payload = data.get("questions") if isinstance(data, Mapping) else None
-        if not isinstance(questions_payload, list):
-            questions_payload = []
-        return SuggestionsResponse(
-            codes=codes,
-            compliance=data.get("compliance", []),
-            publicHealth=public_health,
-            differentials=[
-                DifferentialSuggestion(**d)
-                for d in data.get("differentials", [])
-                if isinstance(d, Mapping)
-            ],
-            questions=questions_payload,
-            followUp=follow_up,
-        )
+            except Exception as exc:  # pragma: no cover - network errors
+                logger.warning("public_health_fetch_failed", error=str(exc))
+                extra_ph = []
+            if extra_ph:
+                existing = {p.recommendation for p in public_health if p.recommendation}
+                for rec in extra_ph:
+                    if isinstance(rec, Mapping):
+                        rec_name = rec.get("recommendation")
+                        if rec_name and rec_name not in existing:
+                            public_health.append(PublicHealthSuggestion(**rec))
+                            existing.add(rec_name)
+                    else:
+                        rec_name = str(rec)
+                        if rec_name and rec_name not in existing:
+                            public_health.append(
+                                PublicHealthSuggestion(recommendation=rec_name)
+                            )
+                            existing.add(rec_name)
+            code_items = data.get("codes", [])
+            codes = [CodeSuggestion(**item) for item in code_items]
+            _log_confidence_scores(
+                user,
+                req.noteId,
+                [
+                    (
+                        item.get("code") or item.get("Code"),
+                        _normalise_confidence(item.get("confidence") or item.get("Confidence")),
+                    )
+                    for item in code_items
+                ],
+            )
+            follow_up = recommend_follow_up(
+                [c.code for c in codes],
+                [
+                    entry.get("diagnosis")
+                    for entry in data.get("differentials", [])
+                    if isinstance(entry, Mapping) and entry.get("diagnosis")
+                ],
+                req.specialty,
+                req.payer,
+            )
+            questions_payload = data.get("questions") if isinstance(data, Mapping) else None
+            if not isinstance(questions_payload, list):
+                questions_payload = []
+            return SuggestionsResponse(
+                codes=codes,
+                compliance=data.get("compliance", []),
+                publicHealth=public_health,
+                differentials=[
+                    DifferentialSuggestion(**d)
+                    for d in data.get("differentials", [])
+                    if isinstance(d, Mapping)
+                ],
+                questions=questions_payload,
+                followUp=follow_up,
+            )
 
         try:
             messages = build_suggest_prompt(
@@ -12601,9 +12668,9 @@ async def suggest(
                 req.lang,
                 req.specialty,
                 req.payer,
-                req.age,
-                req.sex,
-                req.region,
+                prompt_context.age,
+                prompt_context.sex,
+                prompt_context.region,
             )
             response_content = call_openai(messages)
             data = json.loads(response_content)
@@ -12683,7 +12750,6 @@ async def suggest(
                 extra_ph = public_health_api.get_public_health_suggestions(
                     req.age, req.sex, req.region, req.agencies
                 )
-
             except Exception as exc:  # pragma: no cover - network errors
                 logger.warning("public_health_fetch_failed", error=str(exc))
                 extra_ph = []
@@ -12706,52 +12772,10 @@ async def suggest(
                 req.specialty,
                 req.payer,
             )
-        )
-        questions_payload = data.get("questions") if isinstance(data, dict) else None
-        if not isinstance(questions_payload, list):
-            questions_payload = []
-        return SuggestionsResponse(
-            codes=codes,
-            compliance=data["compliance"],
-            publicHealth=public_health,
-            differentials=[DifferentialSuggestion(**d) for d in data["differentials"]],
-            questions=questions_payload,
-        )
-    # Try to call the LLM to generate structured suggestions.  The prompt
-    # instructs the model to return JSON with keys codes, compliance,
-    # public_health and differentials.  We parse the JSON into the
-    # SuggestionsResponse schema.  If anything fails, we fall back to
-    # the simple rule-based engine defined previously.
-    try:
-        messages = build_suggest_prompt(
-            cleaned_for_prompt,
-            req.lang,
-            req.specialty,
-            req.payer,
-            prompt_context.age,
-            prompt_context.sex,
-            prompt_context.region,
-        )
-        response_content = call_openai(messages)
-        # The model should return raw JSON.  Parse it into a Python dict.
-        data = json.loads(response_content)
-        # Convert codes list of dicts into CodeSuggestion objects.  Provide
-        # defaults for missing fields.
-        codes_list: List[CodeSuggestion] = []
-        logged_codes: List[Tuple[str, Optional[float]]] = []
-        for item in data.get("codes", []):
-            code_str = item.get("code") or item.get("Code") or ""
-            rationale = item.get("rationale") or item.get("Rationale") or None
-            upgrade = item.get("upgrade_to") or item.get("upgradeTo") or None
-            upgrade_path = item.get("upgrade_path") or item.get("upgradePath") or None
-            confidence_val = _normalise_confidence(
-                item.get("confidence") or item.get("Confidence")
-
-            )
-            _log_confidence_scores(user, req.noteId, logged_codes)
-            questions_payload = data.get("questions") if isinstance(data, dict) else None
+            questions_payload = data.get("questions") if isinstance(data, Mapping) else None
             if not isinstance(questions_payload, list):
                 questions_payload = []
+            _log_confidence_scores(user, req.noteId, logged_codes)
             return SuggestionsResponse(
                 codes=codes_list,
                 compliance=compliance,
@@ -12769,7 +12793,8 @@ async def suggest(
             public_health: List[PublicHealthSuggestion] = []
             diffs: List[DifferentialSuggestion] = []
             if any(
-                keyword in cleaned.lower() for keyword in ["cough", "fever", "cold", "sore throat"]
+                keyword in cleaned.lower()
+                for keyword in ["cough", "fever", "cold", "sore throat"]
             ):
                 codes.append(
                     CodeSuggestion(
@@ -12779,7 +12804,8 @@ async def suggest(
                 )
                 codes.append(
                     CodeSuggestion(
-                        code="J06.9", rationale="Upper respiratory infection, unspecified"
+                        code="J06.9",
+                        rationale="Upper respiratory infection, unspecified",
                     )
                 )
                 compliance.append("Document duration of fever and associated symptoms")
@@ -12809,7 +12835,9 @@ async def suggest(
                         reason=None,
                     )
                 )
-                diffs.append(DifferentialSuggestion(diagnosis="Impaired glucose tolerance"))
+                diffs.append(
+                    DifferentialSuggestion(diagnosis="Impaired glucose tolerance")
+                )
             if "hypertension" in cleaned.lower() or "high blood pressure" in cleaned.lower():
                 codes.append(
                     CodeSuggestion(code="I10", rationale="Essential (primary) hypertension")
@@ -12823,21 +12851,27 @@ async def suggest(
                         reason=None,
                     )
                 )
-                diffs.append(DifferentialSuggestion(diagnosis="White coat hypertension"))
+                diffs.append(
+                    DifferentialSuggestion(diagnosis="White coat hypertension")
+                )
             if "annual" in cleaned.lower() or "wellness" in cleaned.lower():
                 codes.append(
                     CodeSuggestion(
-                        code="99395", rationale="Periodic comprehensive preventive visit"
+                        code="99395",
+                        rationale="Periodic comprehensive preventive visit",
                     )
                 )
                 compliance.append("Ensure all preventive screenings are up to date")
                 public_health.append(
                     PublicHealthSuggestion(
-                        recommendation="Screen for depression and alcohol use", reason=None
+                        recommendation="Screen for depression and alcohol use",
+                        reason=None,
                     )
                 )
                 diffs.append(DifferentialSuggestion(diagnosis="–"))
-            if any(word in cleaned.lower() for word in ["depression", "anxiety", "sad", "depressed"]):
+            if any(
+                word in cleaned.lower() for word in ["depression", "anxiety", "sad", "depressed"]
+            ):
                 codes.append(
                     CodeSuggestion(
                         code="F32.9", rationale="Major depressive disorder, unspecified"
@@ -12922,7 +12956,6 @@ async def suggest(
                 questions=[],
                 followUp=follow_up,
             )
-
 
 @app.post("/ai/plan", response_model=PlanResponse, response_model_exclude_none=True)
 async def generate_plan(
@@ -13167,6 +13200,424 @@ def _validate_note(req: PreFinalizeCheckRequest) -> Dict[str, Any]:
         "canFinalize": can_finalize,
     }
 
+
+def _compose_validator(payload: Mapping[str, Any]) -> Dict[str, Any]:
+    content = str(payload.get("content") or "")
+
+    def _coerce_list(key: str) -> List[str]:
+        value = payload.get(key)
+        if isinstance(value, list):
+            return [str(item).strip() for item in value if str(item).strip()]
+        return []
+
+    request = PreFinalizeCheckRequest(
+        content=content,
+        codes=[str(code).strip() for code in payload.get("codes", []) if str(code).strip()],
+        prevention=_coerce_list("prevention"),
+        diagnoses=_coerce_list("diagnoses"),
+        differentials=_coerce_list("differentials"),
+        compliance=_coerce_list("compliance"),
+    )
+    return _validate_note(request)
+
+
+def _get_compose_pipeline() -> ComposePipeline:
+    global _COMPOSE_PIPELINE
+    if _COMPOSE_PIPELINE is None:
+        _COMPOSE_PIPELINE = ComposePipeline(validator=_compose_validator)
+    return _COMPOSE_PIPELINE
+
+
+def _compose_steps_template() -> List[Dict[str, Any]]:
+    return [
+        {"id": index + 1, "stage": stage, "status": "pending", "progress": 0.0}
+        for index, stage in enumerate(COMPOSE_STAGE_SEQUENCE)
+    ]
+
+
+def _compose_state_detail(
+    job: ComposeJobPayload, state: Mapping[str, Any]
+) -> Dict[str, Any]:
+    return {
+        "jobType": "compose",
+        "sessionId": job.session_id,
+        "encounterId": job.encounter_id,
+        "noteId": job.note_id,
+        "offline": job.offline,
+        "useLocalModels": job.use_local_models,
+        "status": state.get("status"),
+        "stage": state.get("stage"),
+        "progress": float(state.get("progress") or 0.0),
+        "steps": copy.deepcopy(state.get("steps") or []),
+        "result": copy.deepcopy(state.get("result")),
+        "validation": copy.deepcopy(state.get("validation")),
+        "message": state.get("message"),
+    }
+
+
+def _compose_response_from_detail(
+    compose_id: int, status: str, detail: Mapping[str, Any] | None
+) -> ComposeJobResponse:
+    detail = detail or {}
+    stage_value = detail.get("stage")
+    try:
+        progress_value = float(detail.get("progress") or 0.0)
+    except (TypeError, ValueError):
+        progress_value = 0.0
+    steps_value = detail.get("steps")
+    steps_list = list(steps_value) if isinstance(steps_value, list) else []
+    return ComposeJobResponse(
+        composeId=compose_id,
+        status=status,
+        stage=stage_value if isinstance(stage_value, str) and stage_value else None,
+        progress=progress_value,
+        steps=steps_list,
+        result=detail.get("result"),
+        validation=detail.get("validation"),
+    )
+
+
+def _compose_is_cancelled(compose_id: int) -> bool:
+    return compose_id in _COMPOSE_CANCELLATIONS
+
+
+def _compose_mark_cancelled(compose_id: int) -> None:
+    _COMPOSE_CANCELLATIONS.add(compose_id)
+
+
+def _compose_clear_cancelled(compose_id: int) -> None:
+    _COMPOSE_CANCELLATIONS.discard(compose_id)
+
+
+def _update_compose_record(
+    compose_id: int, status: str, detail: Mapping[str, Any]
+) -> None:
+    try:
+        db_conn.execute(
+            "UPDATE exports SET status=?, detail=?, timestamp=? WHERE id=?",
+            (status, json.dumps(detail, ensure_ascii=False), time.time(), compose_id),
+        )
+        db_conn.commit()
+    except Exception:  # pragma: no cover - defensive logging
+        logger.exception(
+            "compose_status_update_failed", composeId=compose_id, status=status
+        )
+
+
+def _load_compose_record(
+    compose_id: int,
+) -> Tuple[str, Dict[str, Any]] | None:
+    try:
+        row = db_conn.execute(
+            "SELECT status, detail FROM exports WHERE id=?", (compose_id,)
+        ).fetchone()
+    except Exception:  # pragma: no cover - defensive logging
+        logger.exception("compose_record_fetch_failed", composeId=compose_id)
+        return None
+    if not row:
+        return None
+    try:
+        detail = json.loads(row["detail"]) if row["detail"] else {}
+    except Exception:
+        detail = {}
+    return row["status"], detail
+
+
+def _record_compose_event(
+    event_type: str, compose_id: int, detail: Mapping[str, Any]
+) -> None:
+    payload = dict(detail)
+    payload["composeId"] = compose_id
+    sanitized = redact_value(payload)
+    if not isinstance(sanitized, dict):
+        sanitized = {"value": sanitized}
+    timestamp = time.time()
+    events.append({
+        "eventType": event_type,
+        "details": sanitized,
+        "timestamp": timestamp,
+    })
+    try:
+        db_conn.execute(
+            "INSERT INTO events (eventType, timestamp, details, revenue) VALUES (?, ?, ?, ?)",
+            (
+                event_type,
+                timestamp,
+                json.dumps(sanitized, ensure_ascii=False),
+                None,
+            ),
+        )
+        db_conn.commit()
+    except Exception:  # pragma: no cover - analytics persistence best effort
+        logger.exception(
+            "compose_event_persist_failed", composeId=compose_id, eventType=event_type
+        )
+
+
+def _resolve_offline_mode(
+    user: Mapping[str, Any], requested: Optional[bool] = None
+) -> bool:
+    offline_active = bool(requested) if requested is not None else False
+    if not offline_active:
+        try:
+            row = db_conn.execute(
+                "SELECT use_offline_mode FROM settings WHERE user_id=(SELECT id FROM users WHERE username=?)",
+                (user.get("sub"),),
+            ).fetchone()
+            if row:
+                offline_active = bool(row["use_offline_mode"])
+        except sqlite3.OperationalError:
+            pass
+    if USE_OFFLINE_MODEL:
+        offline_active = True
+    return offline_active
+
+
+def _compose_update_session_state(
+    username: str, detail: Mapping[str, Any], status: str
+) -> None:
+    session_id = detail.get("sessionId")
+    if not session_id:
+        return
+    try:
+        (
+            user_id,
+            session_state,
+            sessions,
+            payload,
+        ) = _resolve_session_for_user(str(username), str(session_id))
+    except Exception:  # pragma: no cover - defensive logging
+        logger.exception("compose_session_lookup_failed", sessionId=session_id)
+        return
+    if payload is None:
+        return
+    session = copy.deepcopy(payload)
+    step_states = session.get("stepStates") or {}
+    compose_step = step_states.get("3") or _default_step_states()["3"]
+    try:
+        progress_raw = float(detail.get("progress") or 0.0)
+    except (TypeError, ValueError):
+        progress_raw = 0.0
+    progress_pct = max(0, min(100, int(round(progress_raw * 100))))
+    updated_at = _utc_now_iso()
+    compose_step["updatedAt"] = updated_at
+    if not compose_step.get("startedAt"):
+        compose_step["startedAt"] = updated_at
+    if status == "completed":
+        compose_step["status"] = "completed"
+        compose_step["progress"] = max(progress_pct, 100)
+        compose_step["completedAt"] = updated_at
+    elif status in {"failed", "blocked"}:
+        compose_step["status"] = "blocked"
+        compose_step["progress"] = progress_pct
+    elif status == "cancelled":
+        compose_step["status"] = "blocked"
+        compose_step["progress"] = progress_pct
+    else:
+        compose_step["status"] = "in_progress"
+        compose_step["progress"] = progress_pct
+    validation = detail.get("validation") if isinstance(detail, Mapping) else None
+    issues_map = {}
+    if isinstance(validation, Mapping):
+        issues_candidate = validation.get("issues")
+        if isinstance(issues_candidate, Mapping):
+            issues_map = issues_candidate
+    blocking = _collect_blocking_issues(issues_map) if issues_map else []
+    compose_step["blockingIssues"] = blocking
+    step_states["3"] = compose_step
+    session["stepStates"] = step_states
+    if blocking:
+        session["blockingIssues"] = blocking
+    if status == "completed" and detail.get("result"):
+        session["composeResult"] = copy.deepcopy(detail.get("result"))
+        session["composeValidation"] = copy.deepcopy(detail.get("validation"))
+    elif detail.get("validation"):
+        session["composeValidation"] = copy.deepcopy(detail.get("validation"))
+    session["updatedAt"] = updated_at
+    _recalculate_current_step(session)
+    _update_session_progress(session)
+    sessions[str(session_id)] = session
+    _persist_finalization_sessions(user_id, session_state, sessions)
+
+
+async def _compose_worker_loop() -> None:
+    while True:
+        queue = _COMPOSE_QUEUE
+        if queue is None:
+            await asyncio.sleep(0.25)
+            continue
+        job = await queue.get()
+        try:
+            if _compose_is_cancelled(job.compose_id):
+                logger.info("compose_job_skipped_cancelled", composeId=job.compose_id)
+                continue
+            await _process_compose_job(job)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.exception(
+                "compose_worker_error", composeId=job.compose_id, error=str(exc)
+            )
+        finally:
+            queue.task_done()
+
+
+async def _process_compose_job(job: ComposeJobPayload) -> None:
+    compose_id = job.compose_id
+    pipeline = _get_compose_pipeline()
+    last_event: Dict[str, Any] = {"stage": None, "status": None, "progress": None}
+
+    async def reporter(state: Any) -> None:
+        state_dict = state.as_dict() if hasattr(state, "as_dict") else dict(state)
+        detail = _compose_state_detail(job, state_dict)
+        status_value = state_dict.get("status") or "in_progress"
+        if status_value not in {"completed", "failed", "blocked", "cancelled"}:
+            status_value = "in_progress"
+        _update_compose_record(compose_id, status_value, detail)
+        stage = detail.get("stage")
+        progress = detail.get("progress")
+        if (
+            stage != last_event["stage"]
+            or status_value != last_event["status"]
+            or progress != last_event["progress"]
+        ):
+            event_detail = {
+                "stage": stage,
+                "status": status_value,
+                "progress": progress,
+                "sessionId": job.session_id,
+                "encounterId": job.encounter_id,
+            }
+            _record_compose_event("compose_progress", compose_id, event_detail)
+            last_event.update({"stage": stage, "status": status_value, "progress": progress})
+        if job.username:
+            _compose_update_session_state(job.username, detail, status_value)
+
+    try:
+        final_state = await pipeline.run(
+            job, reporter, is_cancelled=lambda: _compose_is_cancelled(compose_id)
+        )
+        final_detail = _compose_state_detail(job, final_state.as_dict())
+        final_status = final_state.status
+        _update_compose_record(compose_id, final_status, final_detail)
+        if job.username:
+            _compose_update_session_state(job.username, final_detail, final_status)
+        event_detail = {
+            "stage": final_detail.get("stage"),
+            "status": final_status,
+            "progress": final_detail.get("progress"),
+            "sessionId": job.session_id,
+            "encounterId": job.encounter_id,
+        }
+        if final_status == "completed":
+            event_detail["validationOk"] = True
+            _record_compose_event("compose_completed", compose_id, event_detail)
+        elif final_status in {"failed", "blocked"}:
+            event_detail["validationOk"] = False
+            _record_compose_event("compose_failed", compose_id, event_detail)
+    except ComposeJobCancelled:
+        record = _load_compose_record(compose_id)
+        if record is not None:
+            _, detail_payload = record
+        else:
+            detail_payload = _compose_state_detail(
+                job,
+                {
+                    "status": "cancelled",
+                    "stage": COMPOSE_STAGE_SEQUENCE[-1],
+                    "progress": COMPOSE_STAGE_PROGRESS.get(
+                        COMPOSE_STAGE_SEQUENCE[-1], 1.0
+                    ),
+                    "steps": _compose_steps_template(),
+                },
+            )
+            _update_compose_record(compose_id, "cancelled", detail_payload)
+        _record_compose_event(
+            "compose_cancelled",
+            compose_id,
+            {
+                "stage": detail_payload.get("stage"),
+                "status": "cancelled",
+                "progress": detail_payload.get("progress"),
+                "sessionId": job.session_id,
+                "encounterId": job.encounter_id,
+            },
+        )
+        if job.username:
+            _compose_update_session_state(job.username, detail_payload, "cancelled")
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.exception(
+            "compose_job_unexpected_exception", composeId=compose_id, error=str(exc)
+        )
+        fallback_detail = _compose_state_detail(
+            job,
+            {
+                "status": "failed",
+                "stage": COMPOSE_STAGE_SEQUENCE[-1],
+                "progress": COMPOSE_STAGE_PROGRESS.get(
+                    COMPOSE_STAGE_SEQUENCE[-1], 1.0
+                ),
+                "steps": _compose_steps_template(),
+                "message": str(exc),
+            },
+        )
+        _update_compose_record(compose_id, "failed", fallback_detail)
+        _record_compose_event(
+            "compose_failed",
+            compose_id,
+            {
+                "stage": fallback_detail.get("stage"),
+                "status": "failed",
+                "progress": fallback_detail.get("progress"),
+                "sessionId": job.session_id,
+                "encounterId": job.encounter_id,
+            },
+        )
+        if job.username:
+            _compose_update_session_state(job.username, fallback_detail, "failed")
+    finally:
+        _compose_clear_cancelled(compose_id)
+
+
+async def _ensure_compose_workers() -> None:
+    global _COMPOSE_QUEUE, _COMPOSE_WORKER_LOCK
+    if _COMPOSE_WORKER_LOCK is None:
+        _COMPOSE_WORKER_LOCK = asyncio.Lock()
+    async with _COMPOSE_WORKER_LOCK:
+        if _COMPOSE_QUEUE is None:
+            _COMPOSE_QUEUE = asyncio.Queue()
+        if _COMPOSE_WORKERS:
+            return
+        loop = asyncio.get_running_loop()
+        for _ in range(_COMPOSE_WORKER_COUNT):
+            task = loop.create_task(_compose_worker_loop())
+            _COMPOSE_WORKERS.append(task)
+
+
+async def _stop_compose_workers() -> None:
+    workers = list(_COMPOSE_WORKERS)
+    for task in workers:
+        task.cancel()
+    if workers:
+        await asyncio.gather(*workers, return_exceptions=True)
+    _COMPOSE_WORKERS.clear()
+    global _COMPOSE_QUEUE, _COMPOSE_WORKER_LOCK
+    _COMPOSE_QUEUE = None
+    _COMPOSE_WORKER_LOCK = None
+
+
+async def _enqueue_compose_job(job: ComposeJobPayload) -> None:
+    await _ensure_compose_workers()
+    queue = _COMPOSE_QUEUE
+    if queue is None:  # pragma: no cover - defensive
+        raise RuntimeError("compose queue unavailable")
+    await queue.put(job)
+    logger.info(
+        "compose_job_enqueued",
+        composeId=job.compose_id,
+        sessionId=job.session_id,
+        encounterId=job.encounter_id,
+    )
 
 @app.post("/api/v1/workflow/sessions", response_model=WorkflowSessionResponse)
 async def create_workflow_session_v1(
@@ -13630,6 +14081,204 @@ async def update_note_content_v1(
         session=WorkflowSessionResponse(**_session_to_response(normalized)),
     )
     return response_payload
+
+
+@app.post("/api/compose/start", response_model=ComposeJobResponse)
+async def start_compose_job(
+    req: ComposeStartRequest, user=Depends(require_role("user"))
+) -> ComposeJobResponse:
+    session_id = req.sessionId
+    user_id, session_state, sessions, payload = _resolve_session_for_user(
+        user["sub"], session_id
+    )
+    if payload is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    session = copy.deepcopy(payload)
+    note_content = (
+        req.noteContent
+        if req.noteContent is not None
+        else session.get("noteContent")
+        or ""
+    )
+    metadata_source = session.get("patientMetadata") if isinstance(session.get("patientMetadata"), dict) else {}
+    metadata = copy.deepcopy(metadata_source)
+    if req.patientMetadata:
+        metadata.update({k: v for k, v in req.patientMetadata.items() if v is not None})
+    codes_source = (
+        req.selectedCodes
+        or session.get("selectedCodes")
+        or session_state.get("selectedCodesList")
+        or []
+    )
+    if not isinstance(codes_source, list):
+        codes_source = list(codes_source) if isinstance(codes_source, tuple) else []
+    transcript_source: Any = req.transcript
+    if not transcript_source:
+        if isinstance(session.get("transcriptEntries"), list):
+            transcript_source = session.get("transcriptEntries")
+        else:
+            context_payload = (
+                session.get("context") if isinstance(session.get("context"), dict) else {}
+            )
+            transcript_source = context_payload.get("transcriptEntries")
+    transcripts = transcript_source if isinstance(transcript_source, list) else []
+    offline = _resolve_offline_mode(user, req.useOfflineMode)
+    encounter_id = req.encounterId or session.get("encounterId")
+    note_id = req.noteId or session.get("noteId")
+    context_payload = (
+        session.get("context") if isinstance(session.get("context"), dict) else {}
+    )
+    lang = req.lang or context_payload.get("lang") or metadata.get("lang") or "en"
+    specialty = req.specialty or context_payload.get("specialty") or metadata.get("specialty")
+    payer = req.payer or context_payload.get("payer") or metadata.get("payer")
+    initial_steps = _compose_steps_template()
+    if initial_steps:
+        initial_steps[0]["status"] = "in_progress"
+    initial_stage = initial_steps[0]["stage"] if initial_steps else COMPOSE_STAGE_SEQUENCE[0]
+    initial_detail: Dict[str, Any] = {
+        "jobType": "compose",
+        "status": "queued",
+        "stage": initial_stage,
+        "progress": 0.0,
+        "steps": initial_steps,
+        "result": None,
+        "validation": None,
+        "sessionId": session_id,
+        "encounterId": encounter_id,
+        "noteId": note_id,
+        "offline": offline,
+        "useLocalModels": bool(req.useLocalModels),
+    }
+    try:
+        cur = db_conn.cursor()
+        cur.execute(
+            "INSERT INTO exports (timestamp, ehr, note, status, detail) VALUES (?, ?, ?, ?, ?)",
+            (
+                time.time(),
+                "compose",
+                note_content,
+                "queued",
+                json.dumps(initial_detail, ensure_ascii=False),
+            ),
+        )
+        db_conn.commit()
+        compose_id = int(cur.lastrowid)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.exception("compose_record_insert_failed", error=str(exc))
+        raise HTTPException(status_code=500, detail="Unable to start compose job") from exc
+
+    job_payload = ComposeJobPayload(
+        compose_id=compose_id,
+        note=note_content,
+        metadata={str(k): v for k, v in metadata.items()},
+        codes=list(codes_source),
+        transcript=list(transcripts),
+        lang=str(lang or "en"),
+        specialty=specialty if isinstance(specialty, str) else None,
+        payer=payer if isinstance(payer, str) else None,
+        offline=offline,
+        use_local_models=bool(req.useLocalModels),
+        beautify_model=req.beautifyModel,
+        session_id=session_id,
+        encounter_id=encounter_id,
+        note_id=note_id,
+        username=user.get("sub"),
+    )
+    await _enqueue_compose_job(job_payload)
+    _record_compose_event(
+        "compose_started",
+        compose_id,
+        {
+            "stage": initial_detail.get("stage"),
+            "status": initial_detail.get("status"),
+            "progress": initial_detail.get("progress"),
+            "sessionId": session_id,
+            "encounterId": encounter_id,
+        },
+    )
+
+    step_states = session.get("stepStates") or {}
+    compose_step = step_states.get("3") or _default_step_states()["3"]
+    updated_at = _utc_now_iso()
+    compose_step.update(
+        {
+            "status": "in_progress",
+            "progress": 0,
+            "updatedAt": updated_at,
+            "blockingIssues": [],
+        }
+    )
+    if not compose_step.get("startedAt"):
+        compose_step["startedAt"] = updated_at
+    step_states["3"] = compose_step
+    session["stepStates"] = step_states
+    session["updatedAt"] = updated_at
+    _recalculate_current_step(session)
+    _update_session_progress(session)
+    sessions[session_id] = session
+    _persist_finalization_sessions(user_id, session_state, sessions)
+
+    return _compose_response_from_detail(compose_id, "queued", initial_detail)
+
+
+@app.get("/api/compose/{compose_id}", response_model=ComposeJobResponse)
+async def get_compose_job(
+    compose_id: int, user=Depends(require_role("user"))
+) -> ComposeJobResponse:
+    row = db_conn.execute(
+        "SELECT status, detail FROM exports WHERE id=? AND ehr=?",
+        (compose_id, "compose"),
+    ).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Compose job not found")
+    detail = json.loads(row["detail"]) if row["detail"] else {}
+    response = _compose_response_from_detail(compose_id, row["status"], detail)
+    _compose_update_session_state(user.get("sub", ""), detail, row["status"])
+    return response
+
+
+@app.post("/api/compose/{compose_id}/cancel", response_model=ComposeJobResponse)
+async def cancel_compose_job(
+    compose_id: int, user=Depends(require_role("user"))
+) -> ComposeJobResponse:
+    row = db_conn.execute(
+        "SELECT status, detail FROM exports WHERE id=? AND ehr=?",
+        (compose_id, "compose"),
+    ).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Compose job not found")
+    status = row["status"]
+    detail = json.loads(row["detail"]) if row["detail"] else {}
+    if status in {"completed", "cancelled"}:
+        _compose_update_session_state(user.get("sub", ""), detail, status)
+        return _compose_response_from_detail(compose_id, status, detail)
+    _compose_mark_cancelled(compose_id)
+    detail["status"] = "cancelled"
+    detail["stage"] = detail.get("stage") or "cancelled"
+    try:
+        detail["progress"] = float(detail.get("progress") or 0.0)
+    except (TypeError, ValueError):
+        detail["progress"] = 0.0
+    steps = detail.get("steps")
+    if isinstance(steps, list):
+        for step in steps:
+            if isinstance(step, dict):
+                if step.get("stage") == detail["stage"] or step.get("status") == "in_progress":
+                    step["status"] = "cancelled"
+    _update_compose_record(compose_id, "cancelled", detail)
+    _record_compose_event(
+        "compose_cancelled",
+        compose_id,
+        {
+            "stage": detail.get("stage"),
+            "status": "cancelled",
+            "progress": detail.get("progress"),
+            "sessionId": detail.get("sessionId"),
+            "encounterId": detail.get("encounterId"),
+        },
+    )
+    _compose_update_session_state(user.get("sub", ""), detail, "cancelled")
+    return _compose_response_from_detail(compose_id, "cancelled", detail)
 
 
 @app.post(
@@ -15006,8 +15655,8 @@ async def _prevention_suggest(req: PreventionSuggestRequest) -> PreventionRespon
                     "role": "system",
                     "content": (
                         "You are a preventative care assistant. Respond strictly with JSON in the form "
-                        "{\"recommendations\":[{\"id\":\"\",\"code\":\"\",\"type\":\"PREVENTION\",""
-                        "\"title\":\"\",\"rationale\":\"\",\"confidence\":0,\"nextSteps\":[],\"evidence\":[]}]}. "
+                        "{\"recommendations\":[{\"id\":\"\",\"code\":\"\",\"type\":\"PREVENTION\",\"title\":\"\","
+                        "\"rationale\":\"\",\"confidence\":0,\"nextSteps\":[],\"evidence\":[]}]}. "
                         "Confidence must be an integer from 0 to 100. Include at least one recommendation when possible."
                     ),
                 },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,8 @@ const FRONTEND_PORT = Number(process.env.FRONTEND_DEV_PORT || 4173);
 const API_PORT = Number(process.env.FRONTEND_API_PORT || 4010);
 
 export default defineConfig({
-  testDir: 'tests/e2e',
+  testDir: '.',
+  testMatch: ['tests/e2e/**/*.spec.{ts,js}', 'e2e/**/*.spec.{ts,js}'],
   timeout: 5 * 60 * 1000,
   expect: {
     timeout: 15_000,

--- a/revenuepilot-frontend/src/components/FinalizationWizardAdapter.tsx
+++ b/revenuepilot-frontend/src/components/FinalizationWizardAdapter.tsx
@@ -51,6 +51,17 @@ type TranscriptEntryLike = {
   [key: string]: unknown
 }
 
+interface ComposeJobLike {
+  composeId: number
+  status: string
+  stage?: string | null
+  progress?: number | null
+  steps?: Array<Record<string, unknown>>
+  result?: Record<string, unknown> | null
+  validation?: Record<string, unknown> | null
+  message?: string | null
+}
+
 interface PatientInfoInput {
   patientId?: string | null
   encounterId?: string | null
@@ -281,8 +292,7 @@ const toClassification = (value: unknown): CodeClassification | null => {
   return SUGGESTION_CLASSIFICATION_ALIASES[normalized] ?? null;
 };
 
-// ... rest of the codex branch code continues here unchanged ...
-}
+// Additional utilities continue below.
 
 const toWizardCodeItems = (list: SessionCodeLike[]): WizardCodeItem[] => {
   if (!Array.isArray(list)) {
@@ -308,7 +318,12 @@ const toWizardCodeItems = (list: SessionCodeLike[]): WizardCodeItem[] => {
     const category = sanitizeString(item.category)
     const classificationKey = (category ?? "codes") as CodeCategory
     const mappedClassification = CODE_CLASSIFICATION_MAP[classificationKey] ?? CODE_CLASSIFICATION_MAP.codes
-    const identifier = typeof item.id === "number" || typeof item.id === "string" ? item.id : code ? `${code}-${index}` : `code-${index + 1}`
+    const identifier =
+      typeof item.id === "number" || typeof item.id === "string"
+        ? item.id
+        : code
+        ? `${code}-${index}`
+        : `code-${index + 1}`
 
     const evidence = toTrimmedStringArray(extras.evidence ?? extras.evidenceText)
     const gaps = toTrimmedStringArray(extras.gaps)
@@ -681,6 +696,18 @@ export function FinalizationWizardAdapter({
   const preFinalizeResultRef = useRef<PreFinalizeCheckResponse | null>(initialPreFinalizeResult)
   const preFinalizeFingerprintRef = useRef<string | null>(null)
   const lastFinalizeResultRef = useRef<FinalizeResult | null>(initialSessionSnapshot?.lastFinalizeResult ?? null)
+  const [composeJob, setComposeJob] = useState<ComposeJobLike | null>(
+    (initialSessionSnapshot?.composeJob as ComposeJobLike | undefined) ?? null,
+  )
+  const [composeError, setComposeError] = useState<string | null>(null)
+  const composeJobIdRef = useRef<number | null>(
+    typeof (initialSessionSnapshot?.composeJob as ComposeJobLike | undefined)?.composeId === "number"
+      ? (initialSessionSnapshot?.composeJob as ComposeJobLike).composeId
+      : null,
+  )
+  const composePollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const composeFingerprintRef = useRef<string | null>(null)
+  const composeActiveRef = useRef<boolean>(false)
 
   const encounterId = useMemo(() => {
     const fromSession = sessionData?.encounterId ?? initialSessionSnapshot?.encounterId
@@ -838,6 +865,83 @@ export function FinalizationWizardAdapter({
       .filter((entry): entry is { id: string | number; text: string; speaker?: string; timestamp?: number | string; confidence?: number } => Boolean(entry))
   }, [transcriptEntries])
 
+  const composeSelectedCodes = useMemo(() => {
+    if (Array.isArray(sessionData?.selectedCodes) && sessionData.selectedCodes.length) {
+      return sessionData.selectedCodes as Array<Record<string, unknown>>
+    }
+    if (Array.isArray(selectedCodesList) && selectedCodesList.length) {
+      return selectedCodesList
+    }
+    return [] as Array<Record<string, unknown>>
+  }, [selectedCodesList, sessionData?.selectedCodes])
+
+  const composePatientMetadata = useMemo(() => {
+    const base =
+      sessionData?.patientMetadata && typeof sessionData.patientMetadata === "object"
+        ? { ...(sessionData.patientMetadata as Record<string, unknown>) }
+        : {}
+    return { ...base, ...patientMetadataPayload }
+  }, [patientMetadataPayload, sessionData?.patientMetadata])
+
+  const composeSnapshot = useMemo(() => {
+    const sessionId = sessionData?.sessionId ?? initialSessionSnapshot?.sessionId ?? null
+    const encounterId =
+      sessionData?.encounterId ?? initialSessionSnapshot?.encounterId ?? patientInfo?.encounterId ?? null
+    const noteIdentifier = sessionData?.noteId ?? initialSessionSnapshot?.noteId ?? noteId ?? null
+    const sourceContent = sessionData?.noteContent ?? noteContent ?? ""
+    const trimmed = typeof sourceContent === "string" ? sourceContent.trim() : ""
+
+    return {
+      sessionId,
+      encounterId,
+      noteId: noteIdentifier,
+      noteContent: trimmed,
+      patientMetadata: composePatientMetadata,
+      selectedCodes: composeSelectedCodes,
+      transcript: sanitizedTranscripts,
+      context: (sessionData?.context ?? initialSessionSnapshot?.context ?? {}) as Record<string, unknown>,
+    }
+  }, [
+    composePatientMetadata,
+    composeSelectedCodes,
+    initialSessionSnapshot?.context,
+    initialSessionSnapshot?.encounterId,
+    initialSessionSnapshot?.noteId,
+    initialSessionSnapshot?.sessionId,
+    noteContent,
+    noteId,
+    patientInfo?.encounterId,
+    sanitizedTranscripts,
+    sessionData?.context,
+    sessionData?.encounterId,
+    sessionData?.noteContent,
+    sessionData?.noteId,
+    sessionData?.sessionId,
+  ])
+
+  const composeSnapshotFingerprint = useMemo(() => JSON.stringify(composeSnapshot), [composeSnapshot])
+
+  const clearComposePollTimer = useCallback(() => {
+    if (composePollTimerRef.current !== null) {
+      clearTimeout(composePollTimerRef.current)
+      composePollTimerRef.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      clearComposePollTimer()
+      composeActiveRef.current = false
+    }
+  }, [clearComposePollTimer])
+
+  useEffect(() => {
+    if (!isOpen) {
+      composeActiveRef.current = false
+      clearComposePollTimer()
+    }
+  }, [clearComposePollTimer, isOpen])
+
   const persistSession = useCallback(
     (session: WorkflowSessionResponsePayload | null | undefined, extras?: Partial<StoredFinalizationSession>) => {
       const base = session ?? sessionDataRef.current
@@ -853,6 +957,162 @@ export function FinalizationWizardAdapter({
       sessionActions.storeFinalizationSession(base.sessionId, snapshot)
     },
     [sanitizedTranscripts, sessionActions, sessionState.finalizationSessions],
+  )
+
+  const pollComposeJobStatus = useCallback(async () => {
+    const composeId = composeJobIdRef.current
+    if (!composeId) {
+      composeActiveRef.current = false
+      return
+    }
+
+    try {
+      const response = await fetchWithAuth(`/api/compose/${encodeURIComponent(String(composeId))}`)
+      if (!response.ok) {
+        throw new Error(`Compose status check failed (${response.status})`)
+      }
+
+      const data = (await response.json()) as ComposeJobLike
+      setComposeJob(data)
+      setComposeError(null)
+      setSessionData((prev) => {
+        if (!prev) {
+          persistSession(sessionDataRef.current, {
+            composeJob: data,
+            composeResult: data.result,
+            composeValidation: data.validation,
+          })
+          return prev
+        }
+
+        const next: WorkflowSessionResponsePayload = {
+          ...prev,
+          composeJob: data,
+        }
+        persistSession(next, {
+          composeJob: data,
+          composeResult: data.result,
+          composeValidation: data.validation,
+        })
+        sessionDataRef.current = next
+        return next
+      })
+
+      const normalizedStatus = typeof data.status === "string" ? data.status.toLowerCase() : ""
+      if (["completed", "failed", "blocked", "cancelled"].includes(normalizedStatus)) {
+        composeActiveRef.current = false
+        clearComposePollTimer()
+      } else {
+        clearComposePollTimer()
+        composePollTimerRef.current = window.setTimeout(() => {
+          void pollComposeJobStatus()
+        }, 650)
+      }
+    } catch (error) {
+      composeActiveRef.current = false
+      clearComposePollTimer()
+      const message = error instanceof Error ? error.message : "Unable to poll compose job"
+      setComposeError(message)
+      onError?.(message, error)
+    }
+  }, [clearComposePollTimer, fetchWithAuth, onError, persistSession])
+
+  const handleComposeRequest = useCallback(
+    (options?: { force?: boolean }) => {
+      if (!sessionData?.sessionId) {
+        setComposeError("Session not ready for compose job")
+        return
+      }
+
+      const fingerprint = composeSnapshotFingerprint
+      const shouldForce = Boolean(options?.force)
+      if (!shouldForce && composeActiveRef.current && composeFingerprintRef.current === fingerprint) {
+        return
+      }
+
+      composeFingerprintRef.current = fingerprint
+      composeActiveRef.current = true
+      setComposeError(null)
+
+      const payload: Record<string, unknown> = {
+        sessionId: sessionData.sessionId,
+        noteContent: composeSnapshot.noteContent,
+        patientMetadata: composeSnapshot.patientMetadata,
+        selectedCodes: composeSnapshot.selectedCodes,
+        transcript: composeSnapshot.transcript,
+      }
+      if (composeSnapshot.encounterId) {
+        payload.encounterId = composeSnapshot.encounterId
+      }
+      if (composeSnapshot.noteId) {
+        payload.noteId = composeSnapshot.noteId
+      }
+
+      const preferences = (composeSnapshot.context?.preferences ?? composeSnapshot.context?.settings) as
+        | Record<string, unknown>
+        | undefined
+      if (preferences) {
+        if (typeof preferences.useOfflineMode === "boolean") {
+          payload.useOfflineMode = preferences.useOfflineMode
+        }
+        if (typeof preferences.useLocalModels === "boolean") {
+          payload.useLocalModels = preferences.useLocalModels
+        }
+      }
+
+      const start = async () => {
+        try {
+          const response = await fetchWithAuth("/api/compose/start", {
+            method: "POST",
+            jsonBody: payload,
+          })
+          if (!response.ok) {
+            throw new Error(`Compose start failed (${response.status})`)
+          }
+          const data = (await response.json()) as ComposeJobLike
+          composeJobIdRef.current = data.composeId
+          setComposeJob(data)
+          setSessionData((prev) => {
+            if (!prev) {
+              persistSession(sessionDataRef.current, { composeJob: data })
+              return prev
+            }
+            const next: WorkflowSessionResponsePayload = { ...prev, composeJob: data }
+            persistSession(next, { composeJob: data })
+            sessionDataRef.current = next
+            return next
+          })
+          clearComposePollTimer()
+          composePollTimerRef.current = window.setTimeout(() => {
+            void pollComposeJobStatus()
+          }, 650)
+        } catch (error) {
+          composeActiveRef.current = false
+          clearComposePollTimer()
+          const message = error instanceof Error ? error.message : "Unable to start compose job"
+          setComposeError(message)
+          onError?.(message, error)
+        }
+      }
+
+      void start()
+    },
+    [
+      clearComposePollTimer,
+      composeSnapshot.context,
+      composeSnapshot.encounterId,
+      composeSnapshot.noteContent,
+      composeSnapshot.noteId,
+      composeSnapshot.patientMetadata,
+      composeSnapshot.selectedCodes,
+      composeSnapshot.transcript,
+      composeSnapshotFingerprint,
+      fetchWithAuth,
+      onError,
+      persistSession,
+      pollComposeJobStatus,
+      sessionData?.sessionId,
+    ],
   )
 
   const selectedCodeSet = useMemo(() => {
@@ -1465,6 +1725,31 @@ export function FinalizationWizardAdapter({
     return 1
   }, [sessionData?.currentStep, validationState.firstOpenStep])
 
+  const [activeWizardStep, setActiveWizardStep] = useState<number>(() =>
+    Number.isFinite(derivedCurrentStep) ? derivedCurrentStep : 1,
+  )
+
+  useEffect(() => {
+    if (Number.isFinite(derivedCurrentStep)) {
+      setActiveWizardStep((prev) => (prev === derivedCurrentStep ? prev : derivedCurrentStep))
+    }
+  }, [derivedCurrentStep])
+
+  useEffect(() => {
+    if (!isOpen || !sessionData?.sessionId) {
+      return
+    }
+    if (activeWizardStep !== 3) {
+      return
+    }
+    if (!composeSnapshotFingerprint) {
+      return
+    }
+    if (composeFingerprintRef.current !== composeSnapshotFingerprint || !composeActiveRef.current) {
+      handleComposeRequest()
+    }
+  }, [activeWizardStep, composeSnapshotFingerprint, handleComposeRequest, isOpen, sessionData?.sessionId])
+
   const handleFinalize = useCallback(
     async (request: FinalizeRequest): Promise<FinalizeResult> => {
       const payload = toFinalizeRequestPayload(request, finalizeRequestSnapshot)
@@ -1523,6 +1808,7 @@ export function FinalizationWizardAdapter({
 
   const handleWizardStepChange = useCallback(
     (stepId: number) => {
+      setActiveWizardStep(stepId)
       setSessionData((prev) => {
         if (!prev) {
           return prev
@@ -1594,6 +1880,9 @@ export function FinalizationWizardAdapter({
         stepOverrides={mergedStepOverrides.length ? mergedStepOverrides : undefined}
         initialStep={derivedCurrentStep}
         canFinalize={validationState.canFinalize}
+        composeJob={composeJob ?? undefined}
+        composeError={composeError ?? undefined}
+        onRequestCompose={handleComposeRequest}
         onFinalize={handleFinalize}
         onStepChange={handleWizardStepChange}
         onClose={handleClose}

--- a/revenuepilot-frontend/src/features/finalization/__tests__/WorkflowWizard.compose.test.tsx
+++ b/revenuepilot-frontend/src/features/finalization/__tests__/WorkflowWizard.compose.test.tsx
@@ -1,0 +1,216 @@
+import "@testing-library/jest-dom/vitest"
+import { render, screen, waitFor, fireEvent } from "@testing-library/react"
+import { describe, expect, it, beforeAll, afterAll, vi } from "vitest"
+
+import { WorkflowWizard } from "../WorkflowWizard"
+
+vi.mock("motion/react", () => {
+  const React = require("react")
+
+  const sanitizeProps = (props: Record<string, unknown>) => {
+    const clone: Record<string, unknown> = {}
+    Object.entries(props).forEach(([key, value]) => {
+      if (
+        key === "animate" ||
+        key === "initial" ||
+        key === "transition" ||
+        key === "exit" ||
+        key === "whileHover" ||
+        key === "whileTap" ||
+        key === "layout" ||
+        key === "variants"
+      ) {
+        return
+      }
+      clone[key] = value
+    })
+    return clone
+  }
+
+  const createComponent = (tag: string) =>
+    React.forwardRef<HTMLElement, any>(({ children, ...props }, ref) =>
+      React.createElement(tag, { ref, ...sanitizeProps(props) }, children),
+    )
+
+  const motion = new Proxy(
+    {},
+    {
+      get: (_target, key: string) => {
+        switch (key) {
+          case "button":
+            return createComponent("button")
+          case "span":
+            return createComponent("span")
+          default:
+            return createComponent("div")
+        }
+      },
+    },
+  )
+
+  return {
+    motion,
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  }
+})
+
+class ResizeObserver {
+  observe() {
+    /* noop */
+  }
+  unobserve() {
+    /* noop */
+  }
+  disconnect() {
+    /* noop */
+  }
+}
+
+vi.stubGlobal("ResizeObserver", ResizeObserver)
+
+const baseSelectedCodes = [
+  {
+    id: "code-1",
+    code: "99213",
+    title: "Established patient visit",
+    description: "Established patient office visit",
+    classification: ["code"],
+    status: "pending",
+  },
+]
+
+const basePatient = {
+  name: "Rivka Doe",
+  patientId: "patient-1",
+  encounterId: "enc-1",
+  encounterDate: "2024-03-01",
+}
+
+const composeJobInProgress = {
+  composeId: 42,
+  status: "in_progress",
+  stage: "beautifying_language",
+  progress: 0.85,
+  steps: [
+    { id: 1, stage: "analyzing", status: "completed", progress: 0.15 },
+    { id: 2, stage: "enhancing_structure", status: "completed", progress: 0.35 },
+    { id: 3, stage: "beautifying_language", status: "in_progress", progress: 0.85 },
+    { id: 4, stage: "final_review", status: "pending", progress: 0.0 },
+  ],
+  result: null,
+  validation: null,
+}
+
+const composeJobCompleted = {
+  composeId: 42,
+  status: "completed",
+  stage: "final_review",
+  progress: 1.0,
+  steps: [
+    { id: 1, stage: "analyzing", status: "completed", progress: 0.15 },
+    { id: 2, stage: "enhancing_structure", status: "completed", progress: 0.35 },
+    { id: 3, stage: "beautifying_language", status: "completed", progress: 0.85 },
+    { id: 4, stage: "final_review", status: "completed", progress: 1.0 },
+  ],
+  result: {
+    beautifiedNote: "Server enhanced documentation",
+    patientSummary: "Patient-friendly summary content",
+    mode: "remote",
+  },
+  validation: { ok: true, issues: {} },
+}
+
+describe("WorkflowWizard compose integration", () => {
+  const baseProps = {
+    selectedCodes: baseSelectedCodes,
+    suggestedCodes: [],
+    complianceItems: [],
+    noteContent: "Comprehensive visit note covering diagnosis and plan.",
+    patientMetadata: basePatient,
+    transcriptEntries: [],
+    reimbursementSummary: { total: 0, codes: [] },
+    blockingIssues: [],
+    onClose: vi.fn(),
+    onFinalize: vi.fn(),
+    onStepChange: vi.fn(),
+    onRequestCompose: vi.fn(),
+  }
+
+  let consoleSpy: ReturnType<typeof vi.spyOn>
+
+  beforeAll(() => {
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {})
+  })
+
+  afterAll(() => {
+    consoleSpy.mockRestore()
+  })
+
+  it("displays compose progress and enables continue once validation passes", async () => {
+    const { rerender } = render(
+      <WorkflowWizard
+        {...baseProps}
+        initialStep={3}
+        composeJob={composeJobInProgress}
+        composeError={null}
+      />,
+    )
+
+    expect(screen.getByText("Analyzing Content")).toBeInTheDocument()
+    expect(screen.getByText("Enhancing Structure")).toBeInTheDocument()
+    expect(screen.getByText("Beautifying Language")).toBeInTheDocument()
+    expect(screen.getByText("Final Review")).toBeInTheDocument()
+
+    let continueButton = screen.getByRole("button", { name: /Continue to Compare & Edit/i })
+    expect(continueButton).toBeDisabled()
+
+    rerender(
+      <WorkflowWizard
+        {...baseProps}
+        initialStep={3}
+        composeJob={composeJobCompleted}
+        composeError={null}
+      />,
+    )
+
+    await waitFor(() => {
+      continueButton = screen.getByRole("button", { name: /Continue to Compare & Edit/i })
+      expect(continueButton).toBeEnabled()
+    })
+  })
+
+  it("surfaces enhanced previews after compose completion", async () => {
+    const { rerender } = render(
+      <WorkflowWizard
+        {...baseProps}
+        initialStep={3}
+        composeJob={composeJobInProgress}
+        composeError={null}
+      />,
+    )
+
+    rerender(
+      <WorkflowWizard
+        {...baseProps}
+        initialStep={3}
+        composeJob={composeJobCompleted}
+        composeError={null}
+      />,
+    )
+
+    const [continueButton] = screen.getAllByRole("button", { name: /Continue to Compare & Edit/i })
+    expect(continueButton).toBeEnabled()
+    fireEvent.click(continueButton)
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("Server enhanced documentation")).toBeInTheDocument()
+    })
+
+    const toggleButton = screen.getByRole("button", { name: /Switch to Summary/i })
+    fireEvent.click(toggleButton)
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("Patient-friendly summary content")).toBeInTheDocument()
+    })
+  })
+})

--- a/src/api.js
+++ b/src/api.js
@@ -1618,6 +1618,52 @@ export async function createNote({
   return await resp.json();
 }
 
+export async function startComposeJob(payload = {}) {
+  const { sessionId, ...rest } = payload || {}
+  if (!sessionId) {
+    throw new Error("sessionId is required to start a compose job")
+  }
+  const baseUrl = resolveBaseUrl()
+  const headers = {
+    "Content-Type": "application/json",
+    ...getAuthHeader(),
+  }
+  const body = JSON.stringify({ sessionId, ...rest })
+  const resp = await rawFetch(`${baseUrl}/api/compose/start`, {
+    method: "POST",
+    headers,
+    body,
+  })
+  if (resp.status === 401 || resp.status === 403) {
+    throw new Error("Unauthorized")
+  }
+  if (!resp.ok) {
+    const detail = await resp.json().catch(() => ({}))
+    throw new Error(detail?.detail || "Failed to start compose job")
+  }
+  return await resp.json()
+}
+
+export async function pollComposeJob(composeId) {
+  if (composeId == null) {
+    throw new Error("composeId is required to poll compose job")
+  }
+  const baseUrl = resolveBaseUrl()
+  const headers = getAuthHeader()
+  const resp = await rawFetch(`${baseUrl}/api/compose/${encodeURIComponent(String(composeId))}`, {
+    method: "GET",
+    headers,
+  })
+  if (resp.status === 401 || resp.status === 403) {
+    throw new Error("Unauthorized")
+  }
+  if (!resp.ok) {
+    const detail = await resp.json().catch(() => ({}))
+    throw new Error(detail?.detail || "Failed to fetch compose job status")
+  }
+  return await resp.json()
+}
+
 export async function autoSaveNote(noteId, content, version) {
   if (!noteId) return;
   const resolvedId = String(noteId);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -218,6 +218,7 @@ def in_memory_db() -> Iterator[DatabaseContext]:
     raw_connection.row_factory = sqlite3.Row
 
     previous = getattr(main, 'db_conn', None)
+    main.reset_compose_workers_for_tests()
     if isinstance(previous, sqlite3.Connection):
         try:
             previous.close()

--- a/tests/test_compose_api.py
+++ b/tests/test_compose_api.py
@@ -1,0 +1,227 @@
+import asyncio
+import json
+import time
+from typing import Any, Dict
+
+import pytest
+
+import backend.main as main
+import backend.db.models as db_models
+
+
+def _auth_header(token: str) -> Dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _unwrap(data: Dict[str, Any]) -> Dict[str, Any]:
+    if isinstance(data, dict) and isinstance(data.get("data"), dict):
+        return data["data"]
+    return data
+
+
+@pytest.fixture
+def compose_user(db_session):
+    user = db_models.User(
+        username="alice",
+        password_hash=main.hash_password("pw"),
+        role="user",
+    )
+    db_session.add(user)
+    db_session.commit()
+    return user
+
+
+def _create_session(client, token: str) -> Dict[str, Any]:
+    headers = _auth_header(token)
+    payload = {
+        "encounterId": "enc-compose",
+        "patientId": "patient-compose",
+        "noteId": "note-compose",
+        "noteContent": "Patient reports intermittent chest pain with exertion. Detailed exam recorded.",
+        "patientMetadata": {
+            "name": "Rivka Doe",
+            "age": 68,
+            "sex": "F",
+            "encounterDate": "2024-03-01",
+            "preventionItems": ["Colorectal screening documented"],
+            "diagnoses": ["Hypertension"],
+            "differentials": ["Rule out myocardial infarction"],
+            "complianceChecks": ["HIPAA compliance reviewed"],
+        },
+        "selectedCodes": [
+            {
+                "id": "code-1",
+                "code": "99213",
+                "category": "procedure",
+                "description": "Established patient office visit",
+            }
+        ],
+        "transcriptEntries": [
+            {"id": 1, "text": "Patient denies shortness of breath", "speaker": "clinician"},
+            {"id": 2, "text": "Encourage lifestyle modifications", "speaker": "clinician"},
+        ],
+    }
+    resp = client.post("/api/v1/workflow/sessions", json=payload, headers=headers)
+    assert resp.status_code == 200, resp.text
+    session = _unwrap(resp.json())
+    assert session["sessionId"]
+    return session
+
+
+def _start_compose(client, token: str, session: Dict[str, Any], **overrides: Any) -> Dict[str, Any]:
+    headers = _auth_header(token)
+    compose_payload: Dict[str, Any] = {
+        "sessionId": session["sessionId"],
+        "noteContent": session.get("noteContent"),
+        "patientMetadata": session.get("patientMetadata", {}),
+        "selectedCodes": session.get("selectedCodes", []),
+        "transcript": session.get("transcriptEntries", []),
+    }
+    compose_payload.update(overrides)
+    resp = client.post("/api/compose/start", json=compose_payload, headers=headers)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _poll_until_complete(client, token: str, compose_id: int, *, timeout: float = 5.0) -> Dict[str, Any]:
+    headers = _auth_header(token)
+    deadline = time.time() + timeout
+    last_payload: Dict[str, Any] | None = None
+    while time.time() < deadline:
+        resp = client.get(f"/api/compose/{compose_id}", headers=headers)
+        assert resp.status_code == 200, resp.text
+        payload = resp.json()
+        last_payload = payload
+        status = payload.get("status")
+        if status not in {"queued", "in_progress"}:
+            return payload
+        try:
+            loop = asyncio.get_event_loop()
+            loop.run_until_complete(asyncio.sleep(0.05))
+        except RuntimeError:
+            time.sleep(0.05)
+    assert last_payload is not None
+    raise AssertionError(f"compose job {compose_id} did not complete: {json.dumps(last_payload)}")
+
+
+def _compose_events() -> list[Dict[str, Any]]:
+    rows = list(
+        main.db_conn.execute(
+            "SELECT eventType, details FROM events WHERE eventType LIKE 'compose_%' ORDER BY id"
+        )
+    )
+    events: list[Dict[str, Any]] = []
+    for row in rows:
+        detail = row["details"]
+        parsed = json.loads(detail) if isinstance(detail, str) else detail
+        events.append({"eventType": row["eventType"], "details": parsed})
+    return events
+
+
+def test_compose_job_completes_successfully(api_client, compose_user):
+    client = api_client
+    token = main.create_token(compose_user.username, compose_user.role)
+
+    session = _create_session(client, token)
+    start_payload = _start_compose(client, token, session)
+    compose_id = start_payload["composeId"]
+    assert compose_id
+    assert start_payload["status"] == "queued"
+
+    result = _poll_until_complete(client, token, compose_id)
+    assert result["status"] == "completed"
+    assert result.get("validation", {}).get("ok") is True
+    assert "beautifiedNote" in result.get("result", {})
+    assert result.get("result", {}).get("patientSummary")
+
+    events = _compose_events()
+    event_types = [event["eventType"] for event in events]
+    assert "compose_started" in event_types
+    assert "compose_completed" in event_types
+
+
+def test_compose_job_uses_offline_fallback(api_client, compose_user, monkeypatch):
+    client = api_client
+    token = main.create_token(compose_user.username, compose_user.role)
+
+    session = _create_session(client, token)
+
+    from backend import compose_job as compose_module
+
+    offline_called = {"count": 0}
+
+    def fake_offline_beautify(note: str, *_args, **_kwargs) -> str:
+        offline_called["count"] += 1
+        return f"OFFLINE::{note.strip()}"
+
+    def raise_openai(*_args, **_kwargs):
+        raise RuntimeError("openai unavailable")
+
+    monkeypatch.setattr("backend.offline_model.beautify", fake_offline_beautify)
+    monkeypatch.setattr(compose_module, "call_openai", raise_openai)
+
+    start_payload = _start_compose(client, token, session, useOfflineMode=True)
+    compose_id = start_payload["composeId"]
+
+    result = _poll_until_complete(client, token, compose_id)
+
+    assert result["status"] == "completed"
+    assert result.get("result", {}).get("mode") == "offline"
+    assert result.get("result", {}).get("beautifiedNote", "").startswith("OFFLINE::")
+    assert offline_called["count"] >= 1
+
+
+def test_compose_job_validation_failure(api_client, compose_user):
+    client = api_client
+    token = main.create_token(compose_user.username, compose_user.role)
+
+    session = _create_session(client, token)
+
+    session["noteContent"] = "Too short"
+    session["selectedCodes"] = [{"code": "BAD", "category": "procedure"}]
+    start_payload = _start_compose(client, token, session)
+    compose_id = start_payload["composeId"]
+
+    result = _poll_until_complete(client, token, compose_id)
+    assert result["status"] in {"blocked", "failed"}
+    validation = result.get("validation") or {}
+    assert validation.get("ok") is False
+    issues = validation.get("issues") or {}
+    assert issues.get("content")
+    assert issues.get("codes")
+
+    events = _compose_events()
+    event_types = [event["eventType"] for event in events]
+    assert "compose_failed" in event_types
+
+
+def test_compose_job_can_be_cancelled(api_client, compose_user, monkeypatch):
+    client = api_client
+    token = main.create_token(compose_user.username, compose_user.role)
+
+    session = _create_session(client, token)
+
+    from backend import compose_job as compose_module
+
+    async def slow_beautify(self, note: str, job):  # type: ignore[override]
+        await asyncio.sleep(0.2)
+        return note, "remote"
+
+    monkeypatch.setattr(compose_module.ComposePipeline, "_beautify", slow_beautify)
+
+    start_payload = _start_compose(client, token, session)
+    compose_id = start_payload["composeId"]
+
+    headers = _auth_header(token)
+
+    time.sleep(0.05)
+    resp = client.post(f"/api/compose/{compose_id}/cancel", headers=headers)
+    assert resp.status_code == 200, resp.text
+    cancel_payload = resp.json()
+    assert cancel_payload["status"] == "cancelled"
+
+    result = _poll_until_complete(client, token, compose_id)
+    assert result["status"] == "cancelled"
+
+    events = _compose_events()
+    assert any(event["eventType"] == "compose_cancelled" for event in events)


### PR DESCRIPTION
## Summary
- fix the workflow compose adapter identifier fallback and remove the leftover placeholder so the Vite build parses the file again
- extend backend compose coverage with a cancellation scenario and add vitest coverage for the wizard’s Step 3 polling flow
- expand the workflow Playwright spec to drive the staged compose responses and configure Playwright to pick up the legacy e2e specs

## Testing
- `pytest --override-ini="addopts=" tests/test_compose_api.py tests/test_workflow_api.py -q`
- `npx vitest run --config vitest.config.js src/features/finalization/__tests__/WorkflowWizard.compose.test.tsx`
- `npm --workspace revenuepilot-frontend run test:e2e -- workflow.spec.js` *(fails: Electron process failed to launch)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f26ce8f0832494cadae37f6f114a