### PR TITLE
Add finalized note PDF downloads with offline fallbacks

### DIFF
--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -874,6 +874,13 @@ class Note(Base):
     status = sa.Column(String, nullable=False, server_default=sa.text("'draft'"))
     created_at = sa.Column(DateTime(timezone=True), nullable=True, default=_utcnow)
     updated_at = sa.Column(DateTime(timezone=True), nullable=True, default=_utcnow, onupdate=_utcnow)
+    finalized_at = sa.Column(DateTime(timezone=True), nullable=True)
+    finalized_note_id = sa.Column(String, nullable=True, unique=True)
+    finalized_content = sa.Column(Text, nullable=True)
+    finalized_summary = sa.Column(sa.JSON, nullable=True)
+    finalized_by = sa.Column(String, nullable=True)
+    finalized_clinic_id = sa.Column(String, nullable=True)
+    finalized_patient_hash = sa.Column(String, nullable=True)
 
 
 class ErrorLog(Base):

--- a/backend/migrations.py
+++ b/backend/migrations.py
@@ -532,6 +532,20 @@ def ensure_notes_table(conn: sqlite3.Connection) -> None:
         conn.execute("ALTER TABLE notes ADD COLUMN created_at REAL")
     if "updated_at" not in columns:
         conn.execute("ALTER TABLE notes ADD COLUMN updated_at REAL")
+    if "finalized_at" not in columns:
+        conn.execute("ALTER TABLE notes ADD COLUMN finalized_at REAL")
+    if "finalized_note_id" not in columns:
+        conn.execute("ALTER TABLE notes ADD COLUMN finalized_note_id TEXT")
+    if "finalized_content" not in columns:
+        conn.execute("ALTER TABLE notes ADD COLUMN finalized_content TEXT")
+    if "finalized_summary" not in columns:
+        conn.execute("ALTER TABLE notes ADD COLUMN finalized_summary TEXT")
+    if "finalized_by" not in columns:
+        conn.execute("ALTER TABLE notes ADD COLUMN finalized_by TEXT")
+    if "finalized_clinic_id" not in columns:
+        conn.execute("ALTER TABLE notes ADD COLUMN finalized_clinic_id TEXT")
+    if "finalized_patient_hash" not in columns:
+        conn.execute("ALTER TABLE notes ADD COLUMN finalized_patient_hash TEXT")
 
 
 def ensure_error_log_table(conn: sqlite3.Connection) -> None:

--- a/backend/pdf_render.py
+++ b/backend/pdf_render.py
@@ -1,0 +1,102 @@
+"""Utilities for rendering finalized notes into PDF byte streams."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Iterable
+
+__all__ = ["render_note_pdf", "render_summary_pdf"]
+
+
+def render_note_pdf(note: str) -> bytes:
+    """Render the supplied note body into a minimal PDF document."""
+
+    if note is None or note.strip() == "":
+        raise ValueError("note content must be a non-empty string")
+
+    return _text_to_pdf(note)
+
+
+def render_summary_pdf(summary: Any) -> bytes:
+    """Render a finalized summary payload into a PDF document."""
+
+    text = _normalise_summary(summary)
+    if text.strip() == "":
+        raise ValueError("summary payload must not be empty")
+
+    return _text_to_pdf(text)
+
+
+def _normalise_summary(summary: Any) -> str:
+    if summary is None:
+        raise ValueError("summary payload must not be empty")
+
+    if isinstance(summary, str):
+        return summary
+
+    if isinstance(summary, (dict, list)):
+        return json.dumps(summary, indent=2, sort_keys=True)
+
+    return str(summary)
+
+
+def _text_to_pdf(text: str) -> bytes:
+    lines = _prepare_lines(text)
+    stream_commands = _build_stream(lines)
+    stream_bytes = "\n".join(stream_commands).encode("utf-8")
+
+    header = b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n"
+    objects = [
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+        b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n",
+        (
+            b"3 0 obj\n"
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+            b"/Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\n"
+            b"endobj\n"
+        ),
+        (f"4 0 obj\n<< /Length {len(stream_bytes)} >>\nstream\n".encode("utf-8")
+         + stream_bytes
+         + b"\nendstream\nendobj\n"),
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n",
+    ]
+
+    buffer = bytearray()
+    buffer.extend(header)
+    offsets = []
+    for obj in objects:
+        offsets.append(len(buffer))
+        buffer.extend(obj)
+
+    xref_offset = len(buffer)
+    buffer.extend(f"xref\n0 {len(offsets) + 1}\n".encode("ascii"))
+    buffer.extend(b"0000000000 65535 f \n")
+    for offset in offsets:
+        buffer.extend(f"{offset:010d} 00000 n \n".encode("ascii"))
+    buffer.extend(b"trailer\n<< /Size ")
+    buffer.extend(f"{len(offsets) + 1}".encode("ascii"))
+    buffer.extend(b" /Root 1 0 R >>\nstartxref\n")
+    buffer.extend(f"{xref_offset}".encode("ascii"))
+    buffer.extend(b"\n%%EOF")
+
+    return bytes(buffer)
+
+
+def _prepare_lines(text: str) -> Iterable[str]:
+    sanitised = text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+    return sanitised.splitlines() or [sanitised]
+
+
+def _build_stream(lines: Iterable[str]) -> list[str]:
+    commands: list[str] = ["BT", "/F1 12 Tf", "72 720 Td"]
+    line_height = 14
+
+    first = True
+    for line in lines:
+        if not first:
+            commands.append(f"0 -{line_height} Td")
+        commands.append(f"({line}) Tj")
+        first = False
+
+    commands.append("ET")
+    return commands

--- a/revenuepilot-frontend/src/components/__tests__/Drafts.finalized.test.tsx
+++ b/revenuepilot-frontend/src/components/__tests__/Drafts.finalized.test.tsx
@@ -1,0 +1,170 @@
+import "../../test/setupDom"
+import "@testing-library/jest-dom/vitest"
+import "../../../../src/i18n.js"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+const { apiFetchMock, apiFetchJsonMock } = vi.hoisted(() => ({
+  apiFetchMock: vi.fn<[
+    RequestInfo | URL,
+    (RequestInit & { jsonBody?: unknown; returnNullOnEmpty?: boolean; fallbackValue?: unknown }) | undefined,
+  ], Promise<Response>>(),
+  apiFetchJsonMock: vi.fn<
+    [RequestInfo | URL, (RequestInit & { returnNullOnEmpty?: boolean; fallbackValue?: unknown }) | undefined],
+    Promise<unknown>
+  >(),
+}))
+
+const downloadPdfWithFallbackMock = vi.hoisted(() => vi.fn<
+  [
+    {
+      finalizedNoteId: string
+      variant: "note" | "summary"
+      patientName?: string | null
+    },
+  ],
+  Promise<void>
+>())
+
+vi.mock("../ui/dropdown-menu", async () => {
+  const actual = await vi.importActual<typeof import("../ui/dropdown-menu")>("../ui/dropdown-menu")
+  const passthrough = ({ children }: { children?: ReactNode }) => <>{children}</>
+  return {
+    ...actual,
+    DropdownMenu: ({ children }: { children?: ReactNode }) => <div data-testid="dropdown-menu">{children}</div>,
+    DropdownMenuTrigger: passthrough,
+    DropdownMenuContent: ({ children }: { children?: ReactNode }) => (
+      <div role="menu" data-testid="dropdown-menu-content">
+        {children}
+      </div>
+    ),
+    DropdownMenuItem: ({ children, ...props }: { children?: ReactNode }) => (
+      <div role="menuitem" {...props}>
+        {children}
+      </div>
+    ),
+  }
+})
+
+vi.mock("../../lib/api", async () => {
+  const actual = await vi.importActual<typeof import("../../lib/api")>("../../lib/api")
+  return {
+    ...actual,
+    apiFetch: apiFetchMock,
+    apiFetchJson: apiFetchJsonMock,
+  }
+})
+
+vi.mock("../../utils/pdfFallback", () => ({
+  downloadPdfWithFallback: downloadPdfWithFallbackMock,
+}))
+
+describe("Drafts finalized items", () => {
+  beforeAll(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    })
+  })
+
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+    apiFetchJsonMock.mockReset()
+    downloadPdfWithFallbackMock.mockReset()
+    downloadPdfWithFallbackMock.mockResolvedValue(undefined)
+    apiFetchMock.mockResolvedValue(new Response(null, { status: 200 }))
+    apiFetchJsonMock.mockImplementation(async (input) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : (input as Request).url
+      if (url === "/api/notes/drafts") {
+        return [
+          {
+            id: 1,
+            content: "Patient ID: PT-001\nEncounter ID: ENC-001\nProvider: Dr. Final\nDraft body",
+            status: "finalized",
+            finalized_note_id: "fn-123",
+            created_at: "2024-01-01T00:00:00Z",
+            updated_at: "2024-01-02T00:00:00Z",
+          },
+        ]
+      }
+      if (url === "/api/analytics/drafts") {
+        return { drafts: 1 }
+      }
+      if (url === "/api/user/session") {
+        return { draftsPreferences: {} }
+      }
+      return []
+    })
+  })
+
+  it("renders a final badge and removes editing affordances for finalized notes", async () => {
+    const { Drafts } = await import("../Drafts")
+
+    render(<Drafts currentUser={{ id: "clin-1", name: "Dr. Final", fullName: "Dr. Final", role: "user", specialty: "IM" }} />)
+
+    const finalBadge = await screen.findByText("Final")
+    expect(finalBadge).toBeInTheDocument()
+
+    const summaryButtons = await screen.findAllByRole("button", {
+      name: /download summary pdf for/i,
+    })
+    expect(summaryButtons[0]).toBeInTheDocument()
+
+    const noteButtons = await screen.findAllByRole("button", {
+      name: /download note pdf for/i,
+    })
+    expect(noteButtons[0]).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: /continue/i })).not.toBeInTheDocument()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText(/preview/i)).toBeInTheDocument()
+    })
+
+    const menuItems = screen.getAllByRole("menuitem")
+    expect(menuItems.every((item) => !/edit/i.test(item.textContent ?? ""))).toBe(true)
+  })
+
+  it("invokes the PDF download helper when finalized download buttons are clicked", async () => {
+    const { Drafts } = await import("../Drafts")
+
+    render(<Drafts currentUser={{ id: "clin-1", name: "Dr. Final", fullName: "Dr. Final", role: "user", specialty: "IM" }} />)
+
+    const summaryButtons = await screen.findAllByRole("button", {
+      name: /download summary pdf for/i,
+    })
+
+    fireEvent.click(summaryButtons[0])
+
+    await waitFor(() => {
+      expect(downloadPdfWithFallbackMock).toHaveBeenCalledWith(
+        expect.objectContaining({ finalizedNoteId: "fn-123", variant: "summary" }),
+      )
+    })
+
+    downloadPdfWithFallbackMock.mockClear()
+
+    const noteButtons = await screen.findAllByRole("button", {
+      name: /download note pdf for/i,
+    })
+
+    fireEvent.click(noteButtons[0])
+
+    await waitFor(() => {
+      expect(downloadPdfWithFallbackMock).toHaveBeenCalledWith(
+        expect.objectContaining({ finalizedNoteId: "fn-123", variant: "note" }),
+      )
+    })
+  })
+})

--- a/revenuepilot-frontend/src/components/__tests__/ProtectedApp.chartUpload.test.tsx
+++ b/revenuepilot-frontend/src/components/__tests__/ProtectedApp.chartUpload.test.tsx
@@ -3,7 +3,15 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 import "@testing-library/jest-dom/vitest"
 import React from "react"
 
-const { mockedApiFetch, mockedApiFetchJson, mockCreateAppointment, sessionActions } = vi.hoisted(() => {
+const {
+  mockedApiFetch,
+  mockedApiFetchJson,
+  mockCreateAppointment,
+  sessionActions,
+  toastInfo,
+  toastSuccess,
+  toastError,
+} = vi.hoisted(() => {
   const actions = {
     addCode: vi.fn(),
     removeCode: vi.fn(),
@@ -19,8 +27,19 @@ const { mockedApiFetch, mockedApiFetchJson, mockCreateAppointment, sessionAction
     mockedApiFetchJson: vi.fn(),
     mockCreateAppointment: vi.fn(),
     sessionActions: actions,
+    toastInfo: vi.fn(),
+    toastSuccess: vi.fn(),
+    toastError: vi.fn(),
   }
 })
+
+vi.mock("sonner", () => ({
+  toast: {
+    info: toastInfo,
+    success: toastSuccess,
+    error: toastError,
+  },
+}))
 
 let resetUploadStatuses: (() => void) | null = null
 
@@ -129,6 +148,9 @@ describe("ProtectedApp chart upload flow", () => {
     mockedApiFetchJson.mockReset()
     mockCreateAppointment.mockReset()
     Object.values(sessionActions).forEach((action) => action.mockReset?.())
+    toastInfo.mockReset()
+    toastSuccess.mockReset()
+    toastError.mockReset()
     resetUploadStatuses?.()
   })
 

--- a/revenuepilot-frontend/src/components/__tests__/ProtectedApp.draftEditing.test.tsx
+++ b/revenuepilot-frontend/src/components/__tests__/ProtectedApp.draftEditing.test.tsx
@@ -4,11 +4,24 @@ import { fireEvent, render, screen, waitFor, cleanup } from "@testing-library/re
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 import type { ReactNode } from "react"
 
-const { noteEditorPropsSpy, sessionResetSpy, apiFetchMock, apiFetchJsonMock } = vi.hoisted(() => ({
+const { noteEditorPropsSpy, sessionResetSpy, apiFetchMock, apiFetchJsonMock, toastInfo, toastSuccess, toastError } = vi.hoisted(
+  () => ({
   noteEditorPropsSpy: vi.fn(),
   sessionResetSpy: vi.fn(),
   apiFetchMock: vi.fn<[RequestInfo | URL, Record<string, any> | undefined], Promise<Response>>(),
   apiFetchJsonMock: vi.fn<[RequestInfo | URL, Record<string, any> | undefined], Promise<any>>(),
+  toastInfo: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+  }),
+)
+
+vi.mock("sonner", () => ({
+  toast: {
+    info: toastInfo,
+    success: toastSuccess,
+    error: toastError,
+  },
 }))
 
 vi.mock("../../contexts/AuthContext", () => ({
@@ -170,6 +183,9 @@ describe("ProtectedApp draft editing", () => {
   beforeEach(() => {
     noteEditorPropsSpy.mockClear()
     sessionResetSpy.mockClear()
+    toastInfo.mockReset()
+    toastSuccess.mockReset()
+    toastError.mockReset()
     apiFetchMock.mockImplementation(async () => new Response(JSON.stringify({}), { status: 200 }))
     apiFetchJsonMock.mockImplementation(async (input: RequestInfo | URL) => {
       const url = resolveUrl(input)

--- a/revenuepilot-frontend/src/utils/__tests__/pdfFallback.test.ts
+++ b/revenuepilot-frontend/src/utils/__tests__/pdfFallback.test.ts
@@ -1,0 +1,96 @@
+import "../../test/setupDom"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const html2pdfMocks = vi.hoisted(() => {
+  const chain: {
+    set: ReturnType<typeof vi.fn>
+    from: ReturnType<typeof vi.fn>
+    save: ReturnType<typeof vi.fn>
+  } & Record<string, unknown> = {} as never
+  chain.set = vi.fn(() => chain)
+  chain.from = vi.fn(() => chain)
+  chain.save = vi.fn(async () => undefined)
+  const factory = vi.fn(() => chain)
+  return { chain, factory }
+})
+
+const toastMocks = vi.hoisted(() => ({
+  error: vi.fn(),
+}))
+
+global.fetch = vi.fn()
+
+vi.mock("html2pdf.js", () => ({
+  default: html2pdfMocks.factory,
+}))
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: toastMocks.error,
+    info: vi.fn(),
+    success: vi.fn(),
+  },
+}))
+
+const { downloadPdfWithFallback } = await import("../pdfFallback")
+
+describe("downloadPdfWithFallback", () => {
+  beforeEach(() => {
+    vi.mocked(global.fetch).mockRejectedValue(new Error("network"))
+    html2pdfMocks.factory.mockClear()
+    html2pdfMocks.chain.set.mockClear()
+    html2pdfMocks.chain.from.mockClear()
+    html2pdfMocks.chain.save.mockClear()
+    toastMocks.error.mockClear()
+    Object.defineProperty(window.navigator, "onLine", { value: true, configurable: true })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(window as any).electronAPI = undefined
+  })
+
+  it("uses html2pdf when server download fails and HTML is available", async () => {
+    await downloadPdfWithFallback({
+      finalizedNoteId: "fn-001",
+      variant: "summary",
+      summaryHtml: "<p>Summary</p>",
+      offlineMessage: "offline",
+    })
+
+    expect(html2pdfMocks.factory).toHaveBeenCalledTimes(1)
+    expect(html2pdfMocks.chain.set).toHaveBeenCalled()
+    expect(html2pdfMocks.chain.from).toHaveBeenCalled()
+    expect(html2pdfMocks.chain.save).toHaveBeenCalled()
+    expect(toastMocks.error).not.toHaveBeenCalled()
+  })
+
+  it("invokes the electron exporter when available", async () => {
+    const invokeMock = vi.fn().mockResolvedValue(undefined)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(window as any).electronAPI = { invoke: invokeMock }
+
+    await downloadPdfWithFallback({
+      finalizedNoteId: "fn-002",
+      variant: "note",
+      noteHtml: "<p>Note</p>",
+      offlineMessage: "offline",
+    })
+
+    expect(invokeMock).toHaveBeenCalledWith(
+      "export-note",
+      expect.objectContaining({ variant: "note" }),
+    )
+    expect(html2pdfMocks.chain.save).not.toHaveBeenCalled()
+    expect(toastMocks.error).not.toHaveBeenCalled()
+  })
+
+  it("shows a toast when no fallback can run", async () => {
+    Object.defineProperty(window.navigator, "onLine", { value: false, configurable: true })
+
+    await downloadPdfWithFallback({
+      finalizedNoteId: "fn-003",
+      variant: "note",
+      offlineMessage: "PDF offline",
+    })
+
+    expect(toastMocks.error).toHaveBeenCalledWith("PDF offline")
+  })
+})

--- a/revenuepilot-frontend/src/utils/pdfFallback.ts
+++ b/revenuepilot-frontend/src/utils/pdfFallback.ts
@@ -1,0 +1,113 @@
+import html2pdf from "html2pdf.js"
+import { toast } from "sonner"
+
+type PdfVariant = "note" | "summary"
+
+export interface PdfFallbackOptions {
+  finalizedNoteId: string
+  variant: PdfVariant
+  patientName?: string | null
+  noteHtml?: string | null
+  summaryHtml?: string | null
+  offlineMessage?: string
+}
+
+const getElectronApi = () =>
+  typeof window !== "undefined"
+    ? (window as { electronAPI?: { invoke?: (...args: unknown[]) => Promise<unknown> } }).electronAPI
+    : undefined
+
+const sanitizeFilename = (input: string) => {
+  const trimmed = input.trim()
+  if (!trimmed) {
+    return "document"
+  }
+  return trimmed
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-zA-Z0-9._-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .toLowerCase()
+}
+
+const buildFilename = (patientName: string | undefined | null, variant: PdfVariant) => {
+  const base = patientName ? sanitizeFilename(patientName) : "note"
+  return `${base || "note"}-${variant}.pdf`
+}
+
+const createDownloadFromBlob = (blob: Blob, filename: string) => {
+  const blobUrl = URL.createObjectURL(blob)
+  const anchor = document.createElement("a")
+  anchor.href = blobUrl
+  anchor.download = filename
+  anchor.rel = "noopener"
+  anchor.style.display = "none"
+  document.body.appendChild(anchor)
+  anchor.click()
+  document.body.removeChild(anchor)
+  URL.revokeObjectURL(blobUrl)
+}
+
+const getHtmlForVariant = (variant: PdfVariant, noteHtml?: string | null, summaryHtml?: string | null) => {
+  if (variant === "note") {
+    return noteHtml ?? null
+  }
+  return summaryHtml ?? null
+}
+
+export async function downloadPdfWithFallback(options: PdfFallbackOptions): Promise<void> {
+  const { finalizedNoteId, variant, patientName, noteHtml, summaryHtml, offlineMessage = "PDF unavailable offline." } = options
+
+  const filename = buildFilename(patientName ?? undefined, variant)
+  const requestUrl = `/api/notes/${encodeURIComponent(finalizedNoteId)}/pdf?variant=${variant}`
+
+  if (typeof window !== "undefined" && window.navigator?.onLine !== false) {
+    try {
+      const response = await fetch(requestUrl, { credentials: "include" })
+      if (!response.ok) {
+        throw new Error(`Unexpected status ${response.status}`)
+      }
+      const blob = await response.blob()
+      if (blob.size <= 0) {
+        throw new Error("Empty PDF response")
+      }
+      createDownloadFromBlob(blob, filename)
+      return
+    } catch (error) {
+      console.error("Primary PDF download failed", error)
+    }
+  }
+
+  const electronAPI = getElectronApi()
+  const htmlForVariant = getHtmlForVariant(variant, noteHtml, summaryHtml)
+
+  if (electronAPI?.invoke && htmlForVariant) {
+    try {
+      await electronAPI.invoke("export-note", {
+        beautified: noteHtml ?? htmlForVariant,
+        summary: summaryHtml ?? htmlForVariant,
+        variant,
+      })
+      return
+    } catch (error) {
+      console.error("Electron PDF fallback failed", error)
+    }
+  }
+
+  if (htmlForVariant) {
+    try {
+      const element = document.createElement("div")
+      element.innerHTML = htmlForVariant
+      await html2pdf()
+        .set({ filename, margin: 12, html2canvas: { scale: 2 } })
+        .from(element)
+        .save()
+      return
+    } catch (error) {
+      console.error("html2pdf fallback failed", error)
+    }
+  }
+
+  toast.error(offlineMessage)
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -130,7 +130,12 @@
   "drafts": {
     "title": "Saved Drafts",
     "none": "No drafts saved.",
-    "delete": "Delete draft"
+    "delete": "Delete draft",
+    "downloadSummaryPdf": "Download Patient Summary (PDF)",
+    "downloadNotePdf": "Download Note (PDF)",
+    "downloadSummaryPdfAria": "Download summary PDF for {{patient}}",
+    "downloadNotePdfAria": "Download note PDF for {{patient}}",
+    "pdfUnavailableOffline": "PDF unavailable offline."
   },
   "notifications": {
     "title": "Notifications",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -130,7 +130,12 @@
   "drafts": {
     "title": "Borradores guardados",
     "none": "No hay borradores guardados.",
-    "delete": "Eliminar borrador"
+    "delete": "Eliminar borrador",
+    "downloadSummaryPdf": "Descargar resumen del paciente (PDF)",
+    "downloadNotePdf": "Descargar nota (PDF)",
+    "downloadSummaryPdfAria": "Descargar PDF del resumen del paciente para {{patient}}",
+    "downloadNotePdfAria": "Descargar PDF de la nota para {{patient}}",
+    "pdfUnavailableOffline": "PDF no disponible sin conexión."
   },
   "notifications": {
     "title": "Notificaciones",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -130,7 +130,12 @@
   "drafts": {
     "title": "Saved Drafts",
     "none": "No drafts saved.",
-    "delete": "Delete draft"
+    "delete": "Delete draft",
+    "downloadSummaryPdf": "Download Patient Summary (PDF)",
+    "downloadNotePdf": "Download Note (PDF)",
+    "downloadSummaryPdfAria": "Download summary PDF for {{patient}}",
+    "downloadNotePdfAria": "Download note PDF for {{patient}}",
+    "pdfUnavailableOffline": "PDF unavailable offline."
   },
   "notifications": {
     "title": "Notifications",

--- a/tests/test_pdf_render.py
+++ b/tests/test_pdf_render.py
@@ -1,0 +1,25 @@
+import pytest
+
+from backend.pdf_render import render_note_pdf, render_summary_pdf
+
+
+def test_render_note_pdf_produces_bytes():
+    payload = "Patient is recovering well after procedure."
+    pdf_bytes = render_note_pdf(payload)
+    assert isinstance(pdf_bytes, bytes)
+    assert pdf_bytes.startswith(b"%PDF")
+    assert len(pdf_bytes) > 0
+
+
+def test_render_summary_pdf_handles_mapping():
+    summary = {"patient": {"name": "Alice"}, "plan": ["Follow up in 2 weeks"]}
+    pdf_bytes = render_summary_pdf(summary)
+    assert pdf_bytes.startswith(b"%PDF")
+    assert len(pdf_bytes) > 0
+
+
+def test_rendering_rejects_empty_input():
+    with pytest.raises(ValueError):
+        render_note_pdf("")
+    with pytest.raises(ValueError):
+        render_summary_pdf("")


### PR DESCRIPTION
## Summary
- add summary and note PDF download actions for finalized drafts and route them through a localized handler that stops card navigation
- introduce a reusable PDF fallback helper that prefers the API, then Electron or html2pdf, and toast-fails when nothing can run
- expand locale strings and component coverage to validate the new buttons and the fallback behaviours

## Testing
- `npm --prefix revenuepilot-frontend test -- src/components/__tests__/Drafts.finalized.test.tsx src/utils/__tests__/pdfFallback.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68d41ca3d8948324a857d37967a5e3e5