### PR TITLE
Add deterministic finalization anchors snapshot flow

### DIFF
--- a/revenuepilot-frontend/src/features/finalization/NoteEditor.tsx
+++ b/revenuepilot-frontend/src/features/finalization/NoteEditor.tsx
@@ -174,6 +174,7 @@ export function NoteEditor({ content, onChange, highlightRanges = [], disabled =
           return (
             <motion.span
               key={partIndex}
+              data-testid="note-highlight"
               initial={{ backgroundColor: "transparent" }}
               animate={{
                 backgroundColor: [colorSet.bg, colorSet.bg.replace("0.2", "0.3"), colorSet.bg.replace("0.2", "0.35"), colorSet.bg.replace("0.2", "0.3"), colorSet.bg],

--- a/revenuepilot-frontend/src/features/finalization/__tests__/WorkflowWizard.evidence.test.tsx
+++ b/revenuepilot-frontend/src/features/finalization/__tests__/WorkflowWizard.evidence.test.tsx
@@ -1,0 +1,149 @@
+import "@testing-library/jest-dom/vitest"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest"
+
+import "../../../../../src/i18n.js"
+
+import * as api from "@/lib/api"
+import { FinalizationWizard } from "../WorkflowWizard"
+
+const MOCK_NOTE = [
+  "Chief Complaint: Hypertension follow-up.",
+  "History: Hypertension noted with elevated blood pressure despite medication.",
+  "Assessment: Hypertension remains uncontrolled; medication management discussed.",
+].join("\n")
+
+describe("FinalizationWizard evidence anchors", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(api, "apiFetchJson").mockResolvedValue(null as never)
+  })
+
+  afterEach(() => {
+    fetchSpy.mockRestore()
+  })
+
+  it("loads anchors and clears highlights when the card is hidden", async () => {
+    const start = MOCK_NOTE.toLowerCase().indexOf("hypertension")
+    fetchSpy.mockImplementation(async (input: RequestInfo | URL) => {
+      if (typeof input === "string" && input.includes("/api/ai/explain/anchors")) {
+        return {
+          anchors: [
+            { start, end: start + "hypertension".length, phrase: "Hypertension", confidence: 0.9 },
+          ],
+        } as any
+      }
+      return null as any
+    })
+
+    render(
+      <FinalizationWizard
+        selectedCodes={[
+          {
+            id: 1,
+            code: "I10",
+            title: "Essential (primary) hypertension",
+            description: "Essential (primary) hypertension",
+            status: "pending",
+            evidence: ["hypertension"],
+            codeType: "ICD-10",
+            confidence: 90,
+          },
+        ]}
+        suggestedCodes={[]}
+        complianceItems={[]}
+        noteContent={MOCK_NOTE}
+        transcriptEntries={[]}
+        initialStep={1}
+      />,
+    )
+
+    const whyTrigger = await screen.findByText(/Why was this suggested/i)
+    fireEvent.mouseEnter(whyTrigger)
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining("/api/ai/explain/anchors"), expect.anything()))
+
+    await waitFor(() => expect(screen.getAllByTestId("note-highlight").length).toBeGreaterThan(0))
+
+    fireEvent.click(screen.getByRole("button", { name: /^Keep$/i }))
+    fireEvent.click(screen.getByRole("button", { name: /Hide Done/i }))
+
+    await waitFor(() => expect(screen.queryAllByTestId("note-highlight")).toHaveLength(0))
+  })
+
+  it("renders suggested codes in stable order", async () => {
+    const suggestions = [
+      {
+        id: 21,
+        code: "I10",
+        title: "Hypertension follow-up",
+        description: "Chronic hypertension with management plan",
+        status: "pending",
+        confidence: 92,
+        codeType: "ICD-10",
+      },
+      {
+        id: 22,
+        code: "99214",
+        title: "Medication management visit",
+        description: "Established patient visit with moderate complexity",
+        status: "pending",
+        confidence: 78,
+        codeType: "CPT",
+      },
+    ]
+
+    const { container } = render(
+      <FinalizationWizard
+        selectedCodes={[]}
+        suggestedCodes={suggestions}
+        complianceItems={[]}
+        noteContent={MOCK_NOTE}
+        transcriptEntries={[]}
+        initialStep={2}
+      />,
+    )
+
+    const cardHeadings = Array.from(container.querySelectorAll(".card-floating-focus h4"))
+    expect(cardHeadings).toHaveLength(2)
+    expect(cardHeadings[0].textContent).toContain("Hypertension follow-up")
+    expect(cardHeadings[1].textContent).toContain("Medication management visit")
+  })
+
+  it("moves kept suggestions into the selected list immediately", async () => {
+    render(
+      <FinalizationWizard
+        selectedCodes={[]}
+        suggestedCodes={[
+          {
+            id: 99,
+            code: "I10",
+            title: "Hypertension suggestion",
+            description: "Suggested hypertension code",
+            status: "pending",
+            confidence: 90,
+            codeType: "ICD-10",
+          },
+        ]}
+        complianceItems={[]}
+        noteContent={MOCK_NOTE}
+        transcriptEntries={[]}
+        initialStep={2}
+      />,
+    )
+
+    const [keepButton] = await screen.findAllByRole("button", { name: /^Keep$/i })
+    fireEvent.click(keepButton)
+
+    await waitFor(() => expect(screen.getAllByText(/All items completed/i).length).toBeGreaterThan(0))
+
+    const previousStepButton = screen
+      .getAllByRole("button", { name: /Previous Step/i })
+      .find((button) => !button.hasAttribute("disabled")) ??
+      screen.getAllByRole("button", { name: /Previous Step/i })[0]
+    fireEvent.click(previousStepButton)
+
+    await waitFor(() => expect(screen.getAllByText(/Hypertension suggestion/i).length).toBeGreaterThan(0))
+  })
+})

--- a/tests/test_finalization_snapshot.py
+++ b/tests/test_finalization_snapshot.py
@@ -1,0 +1,99 @@
+import sqlite3
+from collections import defaultdict, deque
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend import main, migrations
+from backend.main import _init_core_tables
+
+
+@pytest.fixture
+def client(monkeypatch):
+    main.db_conn = sqlite3.connect(":memory:", check_same_thread=False)
+    main.db_conn.row_factory = sqlite3.Row
+    _init_core_tables(main.db_conn)
+    migrations.ensure_settings_table(main.db_conn)
+    pwd = main.hash_password("pw")
+    main.db_conn.execute(
+        "INSERT INTO users (username, password_hash, role) VALUES (?, ?, ?)",
+        ("user", pwd, "user"),
+    )
+    main.db_conn.commit()
+    monkeypatch.setattr(main, "db_conn", main.db_conn)
+    monkeypatch.setattr(main, "events", [])
+    monkeypatch.setattr(
+        main,
+        "transcript_history",
+        defaultdict(lambda: deque(maxlen=main.TRANSCRIPT_HISTORY_LIMIT)),
+    )
+    return TestClient(main.app)
+
+
+def auth_header(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def token(client: TestClient) -> str:
+    resp = client.post("/login", json={"username": "user", "password": "pw"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "access_token" in data
+    return data["access_token"]
+
+
+def test_explain_anchors_returns_valid_offsets(client: TestClient, token: str) -> None:
+    note = (
+        "Chief Complaint: Follow-up visit.\n"
+        "History: Longstanding hypertension with recent medication adjustments.\n"
+        "Assessment: Hypertension remains uncontrolled with blood pressure 150/94."
+    )
+    response = client.post(
+        "/api/ai/explain/anchors",
+        headers=auth_header(token),
+        json={"note": note, "code": "I10"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    anchors = payload.get("anchors") or []
+    assert anchors, "expected at least one anchor"
+    for anchor in anchors:
+        start = anchor["start"]
+        end = anchor["end"]
+        phrase = anchor["phrase"]
+        assert isinstance(start, int) and isinstance(end, int)
+        assert 0 <= start < end <= len(note)
+        assert note[start:end] == phrase
+
+
+def test_snapshot_suggestions_stable_across_calls(client: TestClient, token: str) -> None:
+    base_note = (
+        "Subjective: Patient here for hypertension follow up with medication management.\n"
+        "Objective: Blood pressure 152/96 today, continues lisinopril.\n"
+        "Assessment: Hypertension requires ongoing monitoring; diabetes reviewed." 
+    )
+    payload = {
+        "snapshotId": "snapshot-001",
+        "note": base_note,
+        "selectedCodes": ["E11.9"],
+        "patientContext": {"age": 58, "sex": "female"},
+    }
+    first = client.post(
+        "/api/ai/codes/review-snapshot",
+        headers=auth_header(token),
+        json=payload,
+    )
+    assert first.status_code == 200
+    second = client.post(
+        "/api/ai/codes/review-snapshot",
+        headers=auth_header(token),
+        json={**payload, "note": base_note + " Additional note edits."},
+    )
+    assert second.status_code == 200
+    assert first.json() == second.json()
+    suggestions = first.json().get("newSuggestions") or []
+    assert suggestions, "expected deterministic suggestions"
+    codes = [item.get("code", "").upper() for item in suggestions]
+    assert "E11.9" not in codes
+    assert "I10" in codes


### PR DESCRIPTION
## Summary
- add backend models and routes to expose evidence anchors and snapshot-based suggestions
- update finalization wizard to consume anchor highlights and snapshot-stable recommendations with supporting tests

## Testing
- pytest --no-cov tests/test_finalization_snapshot.py
- npm --workspace revenuepilot-frontend run test -- --run WorkflowWizard.evidence.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d4ab43628083248e1366c60a26a1ab