### PR TITLE
Add finalized note PDF endpoints and renderer

### DIFF
--- a/backend/notes_service.py
+++ b/backend/notes_service.py
@@ -1,0 +1,88 @@
+"""Utilities for loading finalized note artifacts."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from backend.security import hash_identifier
+
+
+@dataclass
+class FinalizedNoteArtifacts:
+    finalized_note_id: str
+    note_html: Optional[str]
+    note_markdown: Optional[str]
+    note_text: Optional[str]
+    summary_html: Optional[str]
+    summary_markdown: Optional[str]
+    summary_json: Optional[Any]
+    summary_text: Optional[str]
+    finalized_by: Optional[str]
+    clinic_id: Optional[str]
+    patient_hash: Optional[str]
+
+
+def load_finalized_note_artifacts(db_conn, finalized_note_id: str) -> FinalizedNoteArtifacts | None:
+    """Load immutable artifacts for a finalized note."""
+
+    row = db_conn.execute(
+        "SELECT * FROM notes WHERE finalized_note_id = ? LIMIT 1",
+        (finalized_note_id,),
+    ).fetchone()
+
+    if row is None:
+        return None
+
+    data = dict(row)
+
+    summary_payload = data.get("finalized_summary")
+    summary_json: Optional[Any]
+    summary_text: Optional[str] = None
+
+    if summary_payload is None:
+        summary_json = None
+    elif isinstance(summary_payload, (dict, list)):
+        summary_json = summary_payload
+    else:
+        try:
+            summary_json = json.loads(summary_payload)
+        except (TypeError, json.JSONDecodeError):
+            summary_json = None
+            if isinstance(summary_payload, str):
+                summary_text = summary_payload
+
+    if summary_json is None and summary_text is None:
+        summary_text = None
+
+    artifacts = FinalizedNoteArtifacts(
+        finalized_note_id=finalized_note_id,
+        note_html=data.get("finalized_note_html"),
+        note_markdown=data.get("finalized_note_md"),
+        note_text=data.get("finalized_content") or data.get("content"),
+        summary_html=data.get("finalized_summary_html"),
+        summary_markdown=data.get("finalized_summary_md"),
+        summary_json=summary_json,
+        summary_text=summary_text,
+        finalized_by=data.get("finalized_by"),
+        clinic_id=data.get("finalized_clinic_id"),
+        patient_hash=data.get("finalized_patient_hash"),
+    )
+
+    return artifacts
+
+
+def verify_patient_access(patient_id: Optional[str], expected_hash: Optional[str], *, role: Optional[str]) -> bool:
+    if expected_hash is None:
+        return True
+
+    if role == "admin":
+        return True
+
+    if not patient_id:
+        return False
+
+    provided_hash = hash_identifier(patient_id.strip())
+    return provided_hash == expected_hash
+

--- a/backend/pdf_render.py
+++ b/backend/pdf_render.py
@@ -1,102 +1,226 @@
-"""Utilities for rendering finalized notes into PDF byte streams."""
+"""Helpers for rendering finalized note artifacts into PDF documents."""
 
 from __future__ import annotations
 
-import json
-from typing import Any, Iterable
+import html
+import re
+import textwrap
+from typing import Iterable, List
 
-__all__ = ["render_note_pdf", "render_summary_pdf"]
-
-
-def render_note_pdf(note: str) -> bytes:
-    """Render the supplied note body into a minimal PDF document."""
-
-    if note is None or note.strip() == "":
-        raise ValueError("note content must be a non-empty string")
-
-    return _text_to_pdf(note)
+__all__ = [
+    "render_pdf_from_html",
+    "render_pdf_from_text",
+]
 
 
-def render_summary_pdf(summary: Any) -> bytes:
-    """Render a finalized summary payload into a PDF document."""
-
-    text = _normalise_summary(summary)
-    if text.strip() == "":
-        raise ValueError("summary payload must not be empty")
-
-    return _text_to_pdf(text)
+# Basic PDF geometry (Letter size, portrait orientation)
+PAGE_WIDTH = 612  # 8.5" * 72pt
+PAGE_HEIGHT = 792  # 11" * 72pt
+MARGIN = 72  # 1" margins
+LINE_HEIGHT = 14
+MAX_CHARS_PER_LINE = 90
 
 
-def _normalise_summary(summary: Any) -> str:
-    if summary is None:
-        raise ValueError("summary payload must not be empty")
-
-    if isinstance(summary, str):
-        return summary
-
-    if isinstance(summary, (dict, list)):
-        return json.dumps(summary, indent=2, sort_keys=True)
-
-    return str(summary)
+LINES_PER_PAGE = max(1, int((PAGE_HEIGHT - 2 * MARGIN) // LINE_HEIGHT))
 
 
-def _text_to_pdf(text: str) -> bytes:
-    lines = _prepare_lines(text)
-    stream_commands = _build_stream(lines)
-    stream_bytes = "\n".join(stream_commands).encode("utf-8")
+class _HTMLNormalizer:
+    """Convert lightweight HTML into newline-delimited plain text."""
+
+    def __init__(self, html_input: str) -> None:
+        self.html_input = html_input
+
+    def to_text(self) -> str:
+        cleaned = self._replace_line_breaks(self.html_input)
+        cleaned = self._strip_tags(cleaned)
+        cleaned = html.unescape(cleaned)
+        cleaned = self._normalise_whitespace(cleaned)
+        return cleaned.strip()
+
+    def _replace_line_breaks(self, value: str) -> str:
+        # Replace <br> and </p> style tags with explicit newlines to preserve structure.
+        value = re.sub(r"<\s*br\s*/?>", "\n", value, flags=re.IGNORECASE)
+        value = re.sub(r"<\s*/\s*p\s*>", "\n\n", value, flags=re.IGNORECASE)
+        value = re.sub(r"<\s*/\s*div\s*>", "\n\n", value, flags=re.IGNORECASE)
+        value = re.sub(r"<\s*/\s*h[1-6]\s*>", "\n\n", value, flags=re.IGNORECASE)
+        value = re.sub(r"<\s*/\s*li\s*>", "\n", value, flags=re.IGNORECASE)
+        value = re.sub(r"<\s*li[^>]*>", "\n• ", value, flags=re.IGNORECASE)
+        value = re.sub(r"<\s*tr[^>]*>", "\n", value, flags=re.IGNORECASE)
+        value = re.sub(r"<\s*td[^>]*>", "\t", value, flags=re.IGNORECASE)
+        return value
+
+    def _strip_tags(self, value: str) -> str:
+        # Remove any remaining HTML tags. This deliberately avoids a full parser to
+        # keep the dependency footprint minimal.
+        return re.sub(r"<[^>]+>", "", value)
+
+    def _normalise_whitespace(self, value: str) -> str:
+        # Collapse runs of spaces while preserving intentional blank lines.
+        value = value.replace("\r", "\n")
+        value = re.sub(r"\n{3,}", "\n\n", value)
+        value = re.sub(r"[ \t]+", " ", value)
+        value = re.sub(r" ?\n", "\n", value)
+        return value
+
+
+def render_pdf_from_html(html_content: str, title: str) -> bytes:
+    """Render HTML content into a PDF byte string."""
+
+    if html_content is None:
+        raise ValueError("html_content must not be None")
+
+    text = _HTMLNormalizer(html_content).to_text()
+    if not text.strip():
+        raise ValueError("HTML content produced an empty document")
+
+    return render_pdf_from_text(text, title)
+
+
+def render_pdf_from_text(text: str, title: str) -> bytes:
+    """Render plain text content into a PDF byte string."""
+
+    if text is None:
+        raise ValueError("text must not be None")
+
+    normalised = text.strip("\n")
+    if not normalised:
+        raise ValueError("text must not be empty")
+
+    wrapped_lines = _wrap_lines(normalised.splitlines())
+    pages = _paginate(wrapped_lines)
+    return _build_pdf(pages, title=title)
+
+
+def _wrap_lines(lines: Iterable[str]) -> List[str]:
+    wrapper = textwrap.TextWrapper(
+        width=MAX_CHARS_PER_LINE,
+        break_long_words=True,
+        drop_whitespace=False,
+        replace_whitespace=False,
+    )
+    wrapped: List[str] = []
+    for line in lines:
+        if line == "":
+            wrapped.append("")
+            continue
+        segments = wrapper.wrap(line)
+        if not segments:
+            wrapped.append("")
+        else:
+            wrapped.extend(segment.rstrip() for segment in segments)
+    return wrapped
+
+
+def _paginate(lines: Iterable[str]) -> List[List[str]]:
+    pages: List[List[str]] = []
+    current: List[str] = []
+    for line in lines:
+        if len(current) >= LINES_PER_PAGE:
+            pages.append(current)
+            current = []
+        current.append(line)
+    if current:
+        pages.append(current)
+    return pages or [[]]
+
+
+def _build_pdf(pages: List[List[str]], *, title: str | None = None) -> bytes:
+    objects: List[bytes | None] = [None]  # object 0 is the free object
+
+    def reserve_object() -> int:
+        objects.append(None)
+        return len(objects) - 1
+
+    def set_object(object_id: int, payload: bytes) -> None:
+        if not payload.endswith(b"\n"):
+            payload += b"\n"
+        objects[object_id] = payload
+
+    catalog_object_id = reserve_object()
+    pages_object_id = reserve_object()
+    page_object_ids = [reserve_object() for _ in pages]
+    content_object_ids = [reserve_object() for _ in pages]
+    font_object_id = reserve_object()
+    info_object_id = reserve_object() if title else None
+
+    for object_id, page_lines in zip(content_object_ids, pages):
+        stream_bytes = _build_page_stream(page_lines)
+        payload = (
+            f"<< /Length {len(stream_bytes)} >>\nstream\n".encode("utf-8")
+            + stream_bytes
+            + b"\nendstream\n"
+        )
+        set_object(object_id, payload)
+
+    set_object(font_object_id, b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>")
+
+    media_box = f"[0 0 {PAGE_WIDTH} {PAGE_HEIGHT}]"
+    for page_id, content_id in zip(page_object_ids, content_object_ids):
+        payload = (
+            b"<< /Type /Page "
+            + f"/Parent {pages_object_id} 0 R /MediaBox {media_box} ".encode("utf-8")
+            + f"/Contents {content_id} 0 R ".encode("utf-8")
+            + f"/Resources << /Font << /F1 {font_object_id} 0 R >> >> >>".encode("utf-8")
+        )
+        set_object(page_id, payload)
+
+    kids = " ".join(f"{obj_id} 0 R" for obj_id in page_object_ids)
+    set_object(
+        pages_object_id,
+        f"<< /Type /Pages /Kids [{kids}] /Count {len(page_object_ids)} >>".encode("utf-8"),
+    )
+
+    set_object(
+        catalog_object_id,
+        f"<< /Type /Catalog /Pages {pages_object_id} 0 R >>".encode("utf-8"),
+    )
+
+    if info_object_id is not None and title:
+        safe_title = _escape_pdf_string(title)
+        set_object(info_object_id, f"<< /Title ({safe_title}) >>".encode("utf-8"))
 
     header = b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n"
-    objects = [
-        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
-        b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n",
-        (
-            b"3 0 obj\n"
-            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
-            b"/Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\n"
-            b"endobj\n"
-        ),
-        (f"4 0 obj\n<< /Length {len(stream_bytes)} >>\nstream\n".encode("utf-8")
-         + stream_bytes
-         + b"\nendstream\nendobj\n"),
-        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n",
-    ]
+    buffer = bytearray(header)
+    offsets: List[int] = []
 
-    buffer = bytearray()
-    buffer.extend(header)
-    offsets = []
-    for obj in objects:
+    for object_id, payload in enumerate(objects[1:], start=1):
+        if payload is None:
+            raise ValueError(f"PDF object {object_id} was not initialised")
         offsets.append(len(buffer))
-        buffer.extend(obj)
+        buffer.extend(f"{object_id} 0 obj\n".encode("utf-8"))
+        buffer.extend(payload)
+        buffer.extend(b"endobj\n")
 
     xref_offset = len(buffer)
-    buffer.extend(f"xref\n0 {len(offsets) + 1}\n".encode("ascii"))
+    total_objects = len(objects)
+    buffer.extend(f"xref\n0 {total_objects}\n".encode("ascii"))
     buffer.extend(b"0000000000 65535 f \n")
     for offset in offsets:
         buffer.extend(f"{offset:010d} 00000 n \n".encode("ascii"))
-    buffer.extend(b"trailer\n<< /Size ")
-    buffer.extend(f"{len(offsets) + 1}".encode("ascii"))
-    buffer.extend(b" /Root 1 0 R >>\nstartxref\n")
+
+    trailer_parts = [f"/Size {total_objects}", f"/Root {catalog_object_id} 0 R"]
+    if info_object_id is not None:
+        trailer_parts.append(f"/Info {info_object_id} 0 R")
+    trailer_body = " ".join(trailer_parts)
+    buffer.extend(f"trailer\n<< {trailer_body} >>\nstartxref\n".encode("ascii"))
     buffer.extend(f"{xref_offset}".encode("ascii"))
     buffer.extend(b"\n%%EOF")
 
     return bytes(buffer)
 
 
-def _prepare_lines(text: str) -> Iterable[str]:
-    sanitised = text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
-    return sanitised.splitlines() or [sanitised]
+def _escape_pdf_string(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
 
 
-def _build_stream(lines: Iterable[str]) -> list[str]:
-    commands: list[str] = ["BT", "/F1 12 Tf", "72 720 Td"]
-    line_height = 14
-
-    first = True
-    for line in lines:
-        if not first:
-            commands.append(f"0 -{line_height} Td")
-        commands.append(f"({line}) Tj")
-        first = False
-
+def _build_page_stream(lines: List[str]) -> bytes:
+    start_y = PAGE_HEIGHT - MARGIN
+    commands: List[str] = ["BT", "/F1 12 Tf", f"{MARGIN} {start_y} Td"]
+    for index, line in enumerate(lines):
+        if index > 0:
+            commands.append(f"0 -{LINE_HEIGHT} Td")
+        safe_line = _escape_pdf_string(line)
+        commands.append(f"({safe_line}) Tj")
     commands.append("ET")
-    return commands
+    return "\n".join(commands).encode("utf-8")
+

--- a/tests/test_notes_pdf.py
+++ b/tests/test_notes_pdf.py
@@ -1,0 +1,108 @@
+import hashlib
+import sqlite3
+import sys
+import types
+from collections import defaultdict, deque
+
+import pytest
+from fastapi.testclient import TestClient
+
+stub = types.ModuleType("presidio_analyzer")
+sys.modules.setdefault("presidio_analyzer", stub)
+
+from backend import main, migrations
+from backend.main import _init_core_tables
+
+
+def auth_header(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def client(monkeypatch):
+    main.reset_export_workers_for_tests()
+    main.db_conn = sqlite3.connect(":memory:", check_same_thread=False)
+    main.db_conn.row_factory = sqlite3.Row
+    _init_core_tables(main.db_conn)
+    migrations.ensure_settings_table(main.db_conn)
+    pwd = main.hash_password("pw")
+    main.db_conn.execute(
+        "INSERT INTO users (username, password_hash, role) VALUES (?, ?, ?)",
+        ("user", pwd, "user"),
+    )
+    main.db_conn.commit()
+    monkeypatch.setattr(main, "db_conn", main.db_conn)
+    monkeypatch.setattr(main, "events", [])
+    monkeypatch.setattr(
+        main,
+        "transcript_history",
+        defaultdict(lambda: deque(maxlen=main.TRANSCRIPT_HISTORY_LIMIT)),
+    )
+    return TestClient(main.app)
+
+
+def test_finalized_note_pdf_is_deterministic(client):
+    token = main.create_token("det-user", "user")
+    payload = {
+        "content": "Subjective findings and plan.",
+        "codes": ["99213", "93000"],
+        "prevention": ["Vaccination"],
+        "diagnoses": ["I10"],
+        "differentials": ["E11.9"],
+        "compliance": ["HIPAA"],
+        "patientId": "hash-patient",
+    }
+
+    finalize_resp = client.post(
+        "/api/notes/finalize",
+        json=payload,
+        headers=auth_header(token),
+    )
+    assert finalize_resp.status_code == 200
+    finalized_note_id = finalize_resp.json()["finalizedNoteId"]
+
+    pdf_resp = client.get(
+        f"/api/notes/{finalized_note_id}/pdf",
+        params={"variant": "note", "patientId": "hash-patient"},
+        headers=auth_header(token),
+    )
+
+    assert pdf_resp.status_code == 200
+    assert pdf_resp.headers["content-type"] == "application/pdf"
+    digest = hashlib.sha256(pdf_resp.content[:1024]).hexdigest()
+    assert digest == "ebcb02e89fe696eb49e7c4ae0ca3984008f1e06ee7a62645be37068f627e589b"
+
+
+def test_missing_summary_returns_placeholder(client):
+    token = main.create_token("summary-user", "user")
+    payload = {
+        "content": "Assessment and plan go here.",
+        "codes": [],
+        "prevention": [],
+        "diagnoses": [],
+        "differentials": [],
+        "compliance": [],
+    }
+
+    finalize_resp = client.post(
+        "/api/notes/finalize",
+        json=payload,
+        headers=auth_header(token),
+    )
+    finalized_note_id = finalize_resp.json()["finalizedNoteId"]
+
+    main.db_conn.execute(
+        "UPDATE notes SET finalized_summary = NULL WHERE finalized_note_id = ?",
+        (finalized_note_id,),
+    )
+    main.db_conn.commit()
+
+    summary_resp = client.get(
+        f"/api/notes/{finalized_note_id}/pdf",
+        params={"variant": "summary"},
+        headers=auth_header(token),
+    )
+
+    assert summary_resp.status_code == 200
+    assert summary_resp.headers["content-type"] == "application/pdf"
+    assert b"Summary not available" in summary_resp.content

--- a/tests/test_pdf_render.py
+++ b/tests/test_pdf_render.py
@@ -1,25 +1,25 @@
 import pytest
 
-from backend.pdf_render import render_note_pdf, render_summary_pdf
+from backend.pdf_render import render_pdf_from_html, render_pdf_from_text
 
 
-def test_render_note_pdf_produces_bytes():
+def test_render_pdf_from_text_produces_bytes():
     payload = "Patient is recovering well after procedure."
-    pdf_bytes = render_note_pdf(payload)
+    pdf_bytes = render_pdf_from_text(payload, title="Note")
     assert isinstance(pdf_bytes, bytes)
     assert pdf_bytes.startswith(b"%PDF")
     assert len(pdf_bytes) > 0
 
 
-def test_render_summary_pdf_handles_mapping():
-    summary = {"patient": {"name": "Alice"}, "plan": ["Follow up in 2 weeks"]}
-    pdf_bytes = render_summary_pdf(summary)
+def test_render_pdf_from_html_handles_markup():
+    html = "<h1>Heading</h1><p>Paragraph with <strong>content</strong>.</p>"
+    pdf_bytes = render_pdf_from_html(html, title="Doc")
     assert pdf_bytes.startswith(b"%PDF")
     assert len(pdf_bytes) > 0
 
 
 def test_rendering_rejects_empty_input():
     with pytest.raises(ValueError):
-        render_note_pdf("")
+        render_pdf_from_text("", title="Empty")
     with pytest.raises(ValueError):
-        render_summary_pdf("")
+        render_pdf_from_html("", title="Empty")


### PR DESCRIPTION
## Summary
- load finalized note artifacts for PDF downloads and enforce patient access checks
- replace the PDF renderer with a multi-page text/HTML implementation and integrate it into the finalized note endpoint
- add deterministic PDF endpoint tests alongside renderer unit coverage

## Testing
- pytest -q tests/test_pdf_render.py tests/test_notes_pdf.py -o addopts=


------
https://chatgpt.com/codex/tasks/task_e_68d5fd71c18483249007daef0baeecda